### PR TITLE
Use a different log_path for worker closes #68

### DIFF
--- a/config/initializers/logger.rb
+++ b/config/initializers/logger.rb
@@ -13,8 +13,16 @@ log_tags << lambda { |req|
 config = Rails.application.config
 config.log_tags = log_tags
 
+# don't mix worker and RAILS http logs
+if !ENV["IS_WORKER"].blank?
+  config.paths["log"] = "log/efolder-express-worker.log"
+end
+
 # roll logger over every 1MB, retain 10
 logger_path = config.paths["log"].first
 rollover_logger = Logger.new(logger_path, 10, 1.megabyte)
 Rails.logger = ActiveSupport::TaggedLogging.new(rollover_logger) unless Rails.env.development?
+
+# log sidekiq to application logger (defaults to stdout)
+Sidekiq::Logging.logger = Rails.logger
 # :nocov:


### PR DESCRIPTION
Also redirects sidekiq log to application log