### PR TITLE
Add Google Analytics support

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -158,4 +158,19 @@ module ApplicationHelper
     return "#{format('%.2f', seconds)} <span class=\"ee-stat-unit\">sec</span>".html_safe if seconds < 60
     "#{format('%.2f', seconds / 60)} <span class=\"ee-stat-unit\">min</span>".html_safe
   end
+
+  def current_ga_path
+    full_path = request.env["PATH_INFO"]
+
+    begin
+      route = Rails.application.routes.recognize_path(full_path)
+      return full_path unless route
+      ["", route[:controller], route[:action]].join("/")
+
+    # no match in recognize_path
+    rescue ActionController::RoutingError
+      full_path
+    end
+
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -171,6 +171,5 @@ module ApplicationHelper
     rescue ActionController::RoutingError
       full_path
     end
-
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -47,6 +47,17 @@
 
 -->
 
+  <% if !Rails.configuration.analytics_account.nil? %>
+      <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+        ga('create', '<%= Rails.configuration.analytics_account %>', 'auto');
+        ga('send', 'pageview', '<%= current_ga_path %>');
+      </script>
+  <% end %>
+
   <link rel="icon" type="image/png" sizes="32x32"   href="/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="96x96"   href="/favicon-96x96.png">
   <link rel="icon" type="image/png" sizes="16x16"   href="/favicon-16x16.png">

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,8 @@ module CaseflowEfolder
     config.autoload_paths << Rails.root.join('lib')
 
     config.active_job.queue_adapter = :sidekiq
+
+    # default to no analytics (production only)
+    config.analytics_account = nil
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,4 +78,6 @@ Rails.application.configure do
 
   config.s3_enabled = true
   config.s3_bucket_name = ENV["AWS_BUCKET_NAME"]
+
+  config.google_analytics_account = "UA-74789258-2"
 end

--- a/spec/features/application_helper_spec.rb
+++ b/spec/features/application_helper_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe "#current_ga_path" do
+    it "returns route's path without resource ids" do
+      helper.request.env["PATH_INFO"] = "/downloads/5/download"
+      expect(helper.current_ga_path).to eq "/downloads/download"
+    end
+  end
+end


### PR DESCRIPTION
* Configure account # via `Rails.configuration.analytics_account`
* Emit download events for `start` and `create` download 
* Due to redirects on `download#show`, pass analytics events via `ga_event` querystring parameter. 