### PR TITLE
Make database connection pool size configurable

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -7,7 +7,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  pool: 5
+  pool: <%= ENV["DB_CONN_POOL_MAX_SIZE"] || 5 %>
   timeout: 5000
 
 development:


### PR DESCRIPTION
Closes #107 

5 is most definitely too low for production and possibly too low for lower environments too. 