### PR TITLE
Add support for filtering vbms doctypes

### DIFF
--- a/app/services/download_documents.rb
+++ b/app/services/download_documents.rb
@@ -130,12 +130,10 @@ class DownloadDocuments
   end
 
   def self.ignored_doc_types
-    ignored_types = []
-
-    # C&P Exam (DBQ) sent back as both XML and PDF, ignore the XML 999981
-    ignored_types << "999981"
-
-    ignored_types
+    [
+      # C&P Exam (DBQ) sent back as both XML and PDF, ignore the XML 999981
+      "999981"
+    ]
   end
 
   def self.filter_vbms_documents(vbms_documents)

--- a/app/services/download_documents.rb
+++ b/app/services/download_documents.rb
@@ -4,7 +4,7 @@ require "zip"
 class DownloadDocuments
   def initialize(opts = {})
     @download = opts[:download]
-    @vbms_documents = opts[:vbms_documents] || []
+    @vbms_documents = DownloadDocuments.filter_vbms_documents(opts[:vbms_documents] || [])
     @vbms_service = opts[:vbms_service] || VBMSService
     @s3 = opts[:s3] || (Rails.application.config.s3_enabled ? S3Service : Fakes::S3Service)
   end
@@ -127,5 +127,21 @@ class DownloadDocuments
 
   def before_package_contents
     # Test hook for testing race conditions
+  end
+
+  def self.ignored_doc_types
+    ignored_types = []
+
+    # C&P Exam (DBQ) sent back as both XML and PDF, ignore the XML 999981
+    ignored_types << "999981"
+
+    ignored_types
+  end
+
+  def self.filter_vbms_documents(vbms_documents)
+    ignored = DownloadDocuments.ignored_doc_types
+    vbms_documents.select do |vbms_document|
+      !ignored.include?(vbms_document.doc_type)
+    end
   end
 end

--- a/spec/services/download_documents_spec.rb
+++ b/spec/services/download_documents_spec.rb
@@ -1,5 +1,6 @@
 require "fileutils"
 require "zip"
+require "rails_helper"
 
 describe DownloadDocuments do
   before do
@@ -236,6 +237,21 @@ describe DownloadDocuments do
         Zip::File.open(Rails.root + "tmp/files/#{download.id}/#{download.package_filename}") do |zip_file|
           expect(zip_file.glob("00000-keep-stamping.pdf").first).to_not be_nil
         end
+      end
+    end
+
+    context "when some vbms files aren't supported" do
+      let(:vbms_documents) do
+        [
+          VBMS::Responses::Document.new(document_id: "1", doc_type: "352"),
+          VBMS::Responses::Document.new(document_id: "2", doc_type: "999981")
+        ]
+      end
+
+      it "filters unsupported types" do
+        download_documents.create_documents
+        expect(download.documents.count).to eq(1)
+        expect(download.documents[0].document_id).to eq("1")
       end
     end
   end


### PR DESCRIPTION
And filter out the XML versions of `999981 - C&P Exam` docs that are also sent as PDFs.

Closes #211 