### PR TITLE
Secondary sort by id for docs with same date

### DIFF
--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -12,7 +12,7 @@ class Download < ActiveRecord::Base
   TIMEOUT = 10.minutes
   HOURS_UNTIL_EXPIRY = 24
 
-  has_many :documents, -> { order(received_at: :desc) }
+  has_many :documents, -> { order(received_at: :desc, id: :desc) }
 
   after_initialize do |download|
     if download.file_number

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -12,6 +12,8 @@ class Download < ActiveRecord::Base
   TIMEOUT = 10.minutes
   HOURS_UNTIL_EXPIRY = 24
 
+  # sort by receipt date; documents with same date ordered as sent by vbms; see
+  # https://github.com/department-of-veterans-affairs/caseflow-efolder/issues/213
   has_many :documents, -> { order(received_at: :desc, id: :desc) }
 
   after_initialize do |download|


### PR DESCRIPTION
closes #213 ...I hope. If not, there's no reliable way to reproduce the order of documents in VBMS.