### PR TITLE
Match VBMS ordering of documents

### DIFF
--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -14,7 +14,7 @@ class Download < ActiveRecord::Base
 
   # sort by receipt date; documents with same date ordered as sent by vbms; see
   # https://github.com/department-of-veterans-affairs/caseflow-efolder/issues/213
-  has_many :documents, -> { order(received_at: :desc, id: :desc) }
+  has_many :documents, -> { order(received_at: :desc, id: :asc) }
 
   after_initialize do |download|
     if download.file_number


### PR DESCRIPTION
fixes #213, apparently we're displaying docs with same receipt date backwards from VBMS.