### PR TITLE
Updates .zip filename to match format  "LastName, Firstname - Last4SSN"

### DIFF
--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -18,7 +18,10 @@ class Download < ActiveRecord::Base
 
   after_initialize do |download|
     if download.file_number
-      download.veteran_name ||= download.demo? ? "TEST" : Download.bgs_service.fetch_veteran_name(download.file_number)
+      demo_info = veteran_info = { "first_name": "Test", "last_name": "User", "last_4_ssn": "1224" }
+      veteran_info = download.demo? ? demo_info : Download.bgs_service.fetch_veteran_info(download.file_number)
+      veteran_info ||= {}
+      download.veteran_name ||= "#{veteran_info[:first_name]} #{veteran_info[:last_name]}"
     end
   end
 
@@ -57,7 +60,7 @@ class Download < ActiveRecord::Base
   end
 
   def case_exists?
-    !Download.bgs_service.fetch_veteran_name(file_number).nil?
+    !Download.bgs_service.fetch_veteran_info(file_number).nil?
   rescue
     false
   end

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -20,7 +20,7 @@ class Download < ActiveRecord::Base
     if download.file_number
       veteran_info = Download.bgs_service.fetch_veteran_info(download.file_number)
       if veteran_info
-        download.veteran_name ||= "#{veteran_info[:veteran_first_name]} #{veteran_info[:veteran_last_name]}"
+        download.veteran_name ||= "#{veteran_info['veteran_first_name']} #{veteran_info['veteran_last_name']}"
       end
     end
   end

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -19,7 +19,9 @@ class Download < ActiveRecord::Base
   after_initialize do |download|
     if download.file_number
       veteran_info = Download.bgs_service.fetch_veteran_info(download.file_number)
-      download.veteran_name ||= "#{veteran_info[:first_name]} #{veteran_info[:last_name]}"
+      if veteran_info
+        download.veteran_name ||= "#{veteran_info[:veteran_first_name]} #{veteran_info[:veteran_last_name]}"
+      end
     end
   end
 

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -30,7 +30,7 @@ class Download < ActiveRecord::Base
   end
 
   def demo?
-    file_number =~ /DEMO/
+    Download.bgs_service.demo?(file_number)
   end
 
   def time_to_fetch_manifest

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -18,9 +18,7 @@ class Download < ActiveRecord::Base
 
   after_initialize do |download|
     if download.file_number
-      demo_info = veteran_info = { "first_name": "Test", "last_name": "User", "last_4_ssn": "1224" }
-      veteran_info = download.demo? ? demo_info : Download.bgs_service.fetch_veteran_info(download.file_number)
-      veteran_info ||= {}
+      veteran_info = Download.bgs_service.fetch_veteran_info(download.file_number)
       download.veteran_name ||= "#{veteran_info[:first_name]} #{veteran_info[:last_name]}"
     end
   end

--- a/app/services/bgs_service.rb
+++ b/app/services/bgs_service.rb
@@ -10,13 +10,16 @@ class BGSService
 
   def self.fetch_veteran_info(file_number)
     if demo?(file_number)
-      return { "veteran_first_name" => "Test",
-               "veteran_last_name" => "User",
-               "veteran_last_four_ssn" => "1224" }
+      return {
+        "veteran_first_name" => "Test",
+        "veteran_last_name" => "User",
+        "veteran_last_four_ssn" => "1224"
+      }
     end
     @client ||= init_client
     veteran_data = @client.people.find_by_file_number(file_number)
-    { "veteran_first_name" => veteran_data[:first_nm],
+    {
+      "veteran_first_name" => veteran_data[:first_nm],
       "veteran_last_name" => veteran_data[:last_nm],
       "veteran_last_four_ssn" => veteran_data[:ssn_nbr]
     } if veteran_data

--- a/app/services/bgs_service.rb
+++ b/app/services/bgs_service.rb
@@ -4,10 +4,6 @@ require "bgs"
 class BGSService
   cattr_accessor :user
 
-  def demo?(file_number)
-    file_number =~ /DEMO/
-  end
-
   def self.fetch_veteran_name(file_number)
     @client ||= init_client
     veteran_data = @client.people.find_by_file_number(file_number)
@@ -16,13 +12,15 @@ class BGSService
 
   def self.fetch_veteran_info(file_number)
     if file_number =~ /DEMO/
-      return { veteran_first_name: "Test", veteran_last_name: "User", veteran_last_four_ssn: "1224" }
+      return { "veteran_first_name" => "Test",
+                "veteran_last_name" => "User",
+                "veteran_last_four_ssn" => "1224" }
     end
     @client ||= init_client
     veteran_data = @client.people.find_by_file_number(file_number)
-    { veteran_first_name: veteran_data[:first_nm],
-      veteran_last_name: veteran_data[:last_nm],
-      veteran_last_four_ssn: veteran_data[:ssn_nbr]
+    { "veteran_first_name" => veteran_data[:first_nm],
+      "veteran_last_name" => veteran_data[:last_nm],
+      "veteran_last_four_ssn" => veteran_data[:ssn_nbr]
     } if veteran_data
   end
 

--- a/app/services/bgs_service.rb
+++ b/app/services/bgs_service.rb
@@ -6,7 +6,7 @@ class BGSService
 
   def self.parse_veteran_info(veteran_data)
     ssn = veteran_data[:ssn_nbr]
-    last_four_ssn = ssn[ssn.length - 4..ssn.length]
+    last_four_ssn = ssn ? ssn[ssn.length - 4..ssn.length] : nil
     {
       "veteran_first_name" => veteran_data[:first_nm],
       "veteran_last_name" => veteran_data[:last_nm],

--- a/app/services/bgs_service.rb
+++ b/app/services/bgs_service.rb
@@ -4,6 +4,10 @@ require "bgs"
 class BGSService
   cattr_accessor :user
 
+  def self.demo?(file_number)
+    file_number =~ /DEMO/
+  end
+
   def self.fetch_veteran_name(file_number)
     @client ||= init_client
     veteran_data = @client.people.find_by_file_number(file_number)
@@ -11,10 +15,10 @@ class BGSService
   end
 
   def self.fetch_veteran_info(file_number)
-    if file_number =~ /DEMO/
+    if demo?(file_number)
       return { "veteran_first_name" => "Test",
-                "veteran_last_name" => "User",
-                "veteran_last_four_ssn" => "1224" }
+               "veteran_last_name" => "User",
+               "veteran_last_four_ssn" => "1224" }
     end
     @client ||= init_client
     veteran_data = @client.people.find_by_file_number(file_number)

--- a/app/services/bgs_service.rb
+++ b/app/services/bgs_service.rb
@@ -4,10 +4,26 @@ require "bgs"
 class BGSService
   cattr_accessor :user
 
+  def demo?(file_number)
+    file_number =~ /DEMO/
+  end
+
   def self.fetch_veteran_name(file_number)
     @client ||= init_client
     veteran_data = @client.people.find_by_file_number(file_number)
     "#{veteran_data[:first_nm]} #{veteran_data[:last_nm]}" if veteran_data
+  end
+
+  def self.fetch_veteran_info(file_number)
+    if file_number =~ /DEMO/
+      return { veteran_first_name: "Test", veteran_last_name: "User", veteran_last_four_ssn: "1224" }
+    end
+    @client ||= init_client
+    veteran_data = @client.people.find_by_file_number(file_number)
+    { veteran_first_name: veteran_data[:first_nm],
+      veteran_last_name: veteran_data[:last_nm],
+      veteran_last_four_ssn: veteran_data[:ssn_nbr]
+    } if veteran_data
   end
 
   def self.check_sensitivity(file_number)

--- a/app/services/bgs_service.rb
+++ b/app/services/bgs_service.rb
@@ -4,25 +4,21 @@ require "bgs"
 class BGSService
   cattr_accessor :user
 
-  def self.demo?(file_number)
-    file_number =~ /DEMO/
-  end
-
-  def self.fetch_veteran_info(file_number)
-    if demo?(file_number)
-      return {
-        "veteran_first_name" => "Test",
-        "veteran_last_name" => "User",
-        "veteran_last_four_ssn" => "1224"
-      }
-    end
-    @client ||= init_client
-    veteran_data = @client.people.find_by_file_number(file_number)
+  def self.parse_veteran_info(veteran_data)
+    ssn = veteran_data[:ssn_nbr]
+    last_four_ssn = ssn[ssn.length - 4..ssn.length]
     {
       "veteran_first_name" => veteran_data[:first_nm],
       "veteran_last_name" => veteran_data[:last_nm],
-      "veteran_last_four_ssn" => veteran_data[:ssn_nbr]
-    } if veteran_data
+      "veteran_last_four_ssn" => last_four_ssn
+    }
+  end
+
+  def self.fetch_veteran_info(file_number)
+    @client ||= init_client
+    veteran_data = @client.people.find_by_file_number(file_number)
+
+    parse_veteran_info(veteran_data) if veteran_data
   end
 
   def self.check_sensitivity(file_number)

--- a/app/services/bgs_service.rb
+++ b/app/services/bgs_service.rb
@@ -8,12 +8,6 @@ class BGSService
     file_number =~ /DEMO/
   end
 
-  def self.fetch_veteran_name(file_number)
-    @client ||= init_client
-    veteran_data = @client.people.find_by_file_number(file_number)
-    "#{veteran_data[:first_nm]} #{veteran_data[:last_nm]}" if veteran_data
-  end
-
   def self.fetch_veteran_info(file_number)
     if demo?(file_number)
       return { "veteran_first_name" => "Test",

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,9 +15,6 @@ development:
   username: <%= `whoami` %>
   database: caseflow_efolder_development
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
   username: <%= `whoami` %>

--- a/db/migrate/20161011020910_add_first_name_last_name_ssn_to_downloads.rb
+++ b/db/migrate/20161011020910_add_first_name_last_name_ssn_to_downloads.rb
@@ -6,9 +6,16 @@ class AddFirstNameLastNameSsnToDownloads < ActiveRecord::Migration
     add_column :downloads, :veteran_first_name, :string
     add_column :downloads, :veteran_last_four_ssn, :string
 
-    Download.all.each do |download|
-      first, last = download.veteran_name.split(' ', 2)
-      download.update(veteran_first_name: first, veteran_last_name: last)
+    Download.find_each do |download|
+      if download.veteran_name
+        # This isn't going to be exactly right in all cases--
+        # if one's first name were "Carly Rae" and last name
+        # "Jepsen", for instance, we would split on the wrong
+        # space. However, historical Download rows are kept
+        # for record-keeping, so it's probably acceptable.
+        first, last = download.veteran_name.split(' ', 2)
+        download.update(veteran_first_name: first, veteran_last_name: last)
+      end
     end
 
     remove_column :downloads, :veteran_name
@@ -16,7 +23,7 @@ class AddFirstNameLastNameSsnToDownloads < ActiveRecord::Migration
   def down
     add_column :downloads, :veteran_name, :string
 
-    Download.all.each do |download|
+    Download.find_each do |download|
       full_name = "#{download.veteran_first_name} #{download.veteran_last_name}"
       download.update(veteran_name: full_name)
     end

--- a/db/migrate/20161011020910_add_first_name_last_name_ssn_to_downloads.rb
+++ b/db/migrate/20161011020910_add_first_name_last_name_ssn_to_downloads.rb
@@ -1,0 +1,28 @@
+class AddFirstNameLastNameSsnToDownloads < ActiveRecord::Migration
+  def up
+    # we could be more clever here by renaming a name column
+    # instead of adding two columns, but this seems fine.
+    add_column :downloads, :veteran_last_name, :string
+    add_column :downloads, :veteran_first_name, :string
+    add_column :downloads, :veteran_last_four_ssn, :string
+
+    Download.all.each do |download|
+      first, last = download.veteran_name.split(' ', 2)
+      download.update(veteran_first_name: first, veteran_last_name: last)
+    end
+
+    remove_column :downloads, :veteran_name
+  end
+  def down
+    add_column :downloads, :veteran_name, :string
+
+    Download.all.each do |download|
+      full_name = "#{download.veteran_first_name} #{download.veteran_last_name}"
+      download.update(veteran_name: full_name)
+    end
+
+    remove_column :downloads, :veteran_last_four_ssn
+    remove_column :downloads, :veteran_first_name
+    remove_column :downloads, :veteran_last_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160801203957) do
+ActiveRecord::Schema.define(version: 20161011020910) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,16 +55,18 @@ ActiveRecord::Schema.define(version: 20160801203957) do
   create_table "downloads", force: :cascade do |t|
     t.string   "request_id"
     t.string   "file_number"
-    t.integer  "status",              default: 0
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
+    t.integer  "status",                default: 0
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
     t.string   "user_station_id"
     t.string   "user_id"
     t.integer  "lock_version"
-    t.string   "veteran_name"
     t.datetime "manifest_fetched_at"
     t.datetime "started_at"
     t.datetime "completed_at"
+    t.string   "veteran_last_name"
+    t.string   "veteran_first_name"
+    t.string   "veteran_last_four_ssn"
   end
 
   add_index "downloads", ["completed_at"], name: "downloads_completed_at", using: :btree

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -2,8 +2,12 @@ class Fakes::BGSService
   cattr_accessor :veteran_info
   cattr_accessor :sensitive_files
 
+  def self.demo?(file_number)
+    file_number =~ /DEMO/
+  end
+
   def self.fetch_veteran_info(file_number)
-    if file_number =~ /DEMO/
+    if demo?(file_number)
       return { "veteran_first_name" => "Test",
                "veteran_last_name" => "User",
                "veteran_last_four_ssn" => "1224" }

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -8,9 +8,11 @@ class Fakes::BGSService
 
   def self.fetch_veteran_info(file_number)
     if demo?(file_number)
-      return { "veteran_first_name" => "Test",
-               "veteran_last_name" => "User",
-               "veteran_last_four_ssn" => "1224" }
+      return {
+        "veteran_first_name" => "Test",
+        "veteran_last_name" => "User",
+        "veteran_last_four_ssn" => "1224"
+      }
     end
     (veteran_info || {})[file_number]
   end

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -6,14 +6,16 @@ class Fakes::BGSService
     file_number =~ /DEMO/
   end
 
+  def self.demo_veteran_info
+    {
+      "veteran_first_name" => "Test",
+      "veteran_last_name" => "User",
+      "veteran_last_four_ssn" => "1224"
+    }
+  end
+
   def self.fetch_veteran_info(file_number)
-    if demo?(file_number)
-      return {
-        "veteran_first_name" => "Test",
-        "veteran_last_name" => "User",
-        "veteran_last_four_ssn" => "1224"
-      }
-    end
+    return demo_veteran_info if demo?(file_number)
     (veteran_info || {})[file_number]
   end
 

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -1,9 +1,9 @@
 class Fakes::BGSService
-  cattr_accessor :veteran_names
+  cattr_accessor :veteran_info
   cattr_accessor :sensitive_files
 
-  def self.fetch_veteran_name(file_number)
-    (veteran_names || {})[file_number]
+  def self.fetch_veteran_info(file_number)
+    (veteran_info || {})[file_number]
   end
 
   def self.check_sensitivity(file_number)

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -3,6 +3,9 @@ class Fakes::BGSService
   cattr_accessor :sensitive_files
 
   def self.fetch_veteran_info(file_number)
+    if file_number =~ /DEMO/
+      return { "first_name": "Test", "last_name": "User", "last_4_ssn": "1224" }
+    end
     (veteran_info || {})[file_number]
   end
 

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -4,9 +4,9 @@ class Fakes::BGSService
 
   def self.fetch_veteran_info(file_number)
     if file_number =~ /DEMO/
-      return { veteran_first_name: "Test",
-        veteran_last_name: "User",
-        veteran_last_four_ssn: "1224" }
+      return { "veteran_first_name" => "Test",
+               "veteran_last_name" => "User",
+               "veteran_last_four_ssn" => "1224" }
     end
     (veteran_info || {})[file_number]
   end

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -4,7 +4,9 @@ class Fakes::BGSService
 
   def self.fetch_veteran_info(file_number)
     if file_number =~ /DEMO/
-      return { "first_name": "Test", "last_name": "User", "last_4_ssn": "1224" }
+      return { veteran_first_name: "Test",
+        veteran_last_name: "User",
+        veteran_last_four_ssn: "1224" }
     end
     (veteran_info || {})[file_number]
   end

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -145,6 +145,8 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Using demo mode" do
+    expect(DemoGetDownloadManifestJob).to receive(:perform_later)
+
     visit "/"
 
     fill_in "Search for a Veteran ID number below to get started.", with: "DEMO123"

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -41,7 +41,8 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Creating a download" do
-    Fakes::BGSService.veteran_info = { "1234" => { "veteran_first_name" => "Stan", "veteran_last_name" => "Lee", "veteran_last_four_ssn" => "2222" } }
+    Fakes::BGSService.veteran_info =
+      { "1234" => { "veteran_first_name" => "Stan", "veteran_last_name" => "Lee", "veteran_last_four_ssn" => "2222" } }
 
     visit "/"
     expect(page).to_not have_content "Recent Searches"
@@ -54,7 +55,6 @@ RSpec.feature "Downloads" do
 
     @download = @user_download.last
     expect(@download).to_not be_nil
-    puts @download.inspect
     expect(@download.veteran_name).to eq("Stan Lee")
 
     expect(page).to have_content "Stan Lee (1234)"
@@ -67,7 +67,8 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Searching for an errored download tries again" do
-    Fakes::BGSService.veteran_info = { "5555" => { "veteran_first_name" => "Stan", "veteran_last_name" => "Lee", "veteran_last_four_ssn" => "2222" } }
+    Fakes::BGSService.veteran_info =
+      { "5555" => { "veteran_first_name" => "Stan", "veteran_last_name" => "Lee", "veteran_last_four_ssn" => "2222" } }
 
     @user_download.create!(
       file_number: "5555",
@@ -98,7 +99,8 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Extraneous spaces in search input" do
-    Fakes::BGSService.veteran_info = { "1234" => { "veteran_first_name" => "Stan", "veteran_last_name" => "Lee", "veteran_last_four_ssn" => "2222" } }
+    Fakes::BGSService.veteran_info =
+      { "1234" => { "veteran_first_name" => "Stan", "veteran_last_name" => "Lee", "veteran_last_four_ssn" => "2222" } }
 
     visit "/"
     expect(page).to_not have_content "Recent Searches"
@@ -125,7 +127,7 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Sensitive download error" do
-    Fakes::BGSService.veteran_info = { "8888" => { "veteran_first_name" => "Nick", "veteran_last_name" => "Saban"} }
+    Fakes::BGSService.veteran_info = { "8888" => { "veteran_first_name" => "Nick", "veteran_last_name" => "Saban" } }
     Fakes::BGSService.sensitive_files = { "8888" => true }
 
     visit "/"
@@ -172,7 +174,13 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Confirming download" do
-    Fakes::BGSService.veteran_info = { "3456" => {"veteran_first_name" => "Steph", "veteran_last_name" => "Curry", "veteran_last_four_ssn" => "2345"} }
+    Fakes::BGSService.veteran_info =
+      { "3456" => {
+        "veteran_first_name" => "Steph",
+        "veteran_last_name" => "Curry",
+        "veteran_last_four_ssn" => "2345"
+      }
+      }
     @download = @user_download.create(file_number: "3456", status: :fetching_manifest)
 
     visit download_path(@download)
@@ -255,7 +263,8 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Completed download" do
-    Fakes::BGSService.veteran_info = { "12" => { "veteran_first_name" => "Stan", "veteran_last_name" => "Lee", "veteran_last_four_ssn" => "2222" } }
+    Fakes::BGSService.veteran_info =
+      { "12" => { "veteran_first_name" => "Stan", "veteran_last_name" => "Lee", "veteran_last_four_ssn" => "2222" } }
 
     # clean files
     FileUtils.rm_rf(Rails.application.config.download_filepath)

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -56,6 +56,9 @@ RSpec.feature "Downloads" do
     @download = @user_download.last
     expect(@download).to_not be_nil
     expect(@download.veteran_name).to eq("Stan Lee")
+    expect(@download.veteran_first_name).to eq("Stan")
+    expect(@download.veteran_last_name).to eq("Lee")
+    expect(@download.veteran_last_four_ssn).to eq("2222")
 
     expect(page).to have_content "Stan Lee (1234)"
     expect(page).to have_content "We are gathering the list of files in the eFolder now"
@@ -174,13 +177,13 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Confirming download" do
-    Fakes::BGSService.veteran_info =
-      { "3456" => {
+    Fakes::BGSService.veteran_info = {
+      "3456" => {
         "veteran_first_name" => "Steph",
         "veteran_last_name" => "Curry",
         "veteran_last_four_ssn" => "2345"
       }
-      }
+    }
     @download = @user_download.create(file_number: "3456", status: :fetching_manifest)
 
     visit download_path(@download)
@@ -263,9 +266,13 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Completed download" do
-    Fakes::BGSService.veteran_info =
-      { "12" => { "veteran_first_name" => "Stan", "veteran_last_name" => "Lee", "veteran_last_four_ssn" => "2222" } }
-
+    Fakes::BGSService.veteran_info = {
+      "12" => {
+        "veteran_first_name" => "Stan",
+        "veteran_last_name" => "Lee",
+        "veteran_last_four_ssn" => "2222"
+      }
+    }
     # clean files
     FileUtils.rm_rf(Rails.application.config.download_filepath)
 

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -41,8 +41,13 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Creating a download" do
-    Fakes::BGSService.veteran_info =
-      { "1234" => { "veteran_first_name" => "Stan", "veteran_last_name" => "Lee", "veteran_last_four_ssn" => "2222" } }
+    Fakes::BGSService.veteran_info = {
+      "1234" => {
+        "veteran_first_name" => "Stan",
+        "veteran_last_name" => "Lee",
+        "veteran_last_four_ssn" => "2222"
+      }
+    }
 
     visit "/"
     expect(page).to_not have_content "Recent Searches"
@@ -70,8 +75,13 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Searching for an errored download tries again" do
-    Fakes::BGSService.veteran_info =
-      { "5555" => { "veteran_first_name" => "Stan", "veteran_last_name" => "Lee", "veteran_last_four_ssn" => "2222" } }
+    Fakes::BGSService.veteran_info = {
+      "5555" => {
+        "veteran_first_name" => "Stan",
+        "veteran_last_name" => "Lee",
+        "veteran_last_four_ssn" => "2222"
+      }
+    }
 
     @user_download.create!(
       file_number: "5555",
@@ -102,8 +112,13 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Extraneous spaces in search input" do
-    Fakes::BGSService.veteran_info =
-      { "1234" => { "veteran_first_name" => "Stan", "veteran_last_name" => "Lee", "veteran_last_four_ssn" => "2222" } }
+    Fakes::BGSService.veteran_info = {
+      "1234" => {
+        "veteran_first_name" => "Stan",
+        "veteran_last_name" => "Lee",
+        "veteran_last_four_ssn" => "2222"
+      }
+    }
 
     visit "/"
     expect(page).to_not have_content "Recent Searches"
@@ -127,6 +142,22 @@ RSpec.feature "Downloads" do
 
     @search = Search.where(user_id: "123123", file_number: "abcd").first
     expect(@search).to be_veteran_not_found
+  end
+
+  scenario "Using demo mode" do
+    visit "/"
+
+    fill_in "Search for a Veteran ID number below to get started.", with: "DEMO123"
+    click_button "Search"
+
+    @download = @user_download.last
+    expect(@download).to_not be_nil
+    expect(@download.veteran_name).to eq("Test User")
+    expect(@download.veteran_first_name).to eq("Test")
+    expect(@download.veteran_last_name).to eq("User")
+    expect(@download.veteran_last_four_ssn).to eq("1224")
+
+    expect(page).to have_content "Test User (DEMO123)"
   end
 
   scenario "Sensitive download error" do

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Creating a download" do
-    Fakes::BGSService.veteran_info = { "1234" => { "first_name" => "Stan", "last_name" => "Lee", "last_four_ssn" => "2222" } }
+    Fakes::BGSService.veteran_info = { "1234" => { "veteran_first_name" => "Stan", "veteran_last_name" => "Lee", "veteran_last_four_ssn" => "2222" } }
 
     visit "/"
     expect(page).to_not have_content "Recent Searches"
@@ -54,6 +54,7 @@ RSpec.feature "Downloads" do
 
     @download = @user_download.last
     expect(@download).to_not be_nil
+    puts @download.inspect
     expect(@download.veteran_name).to eq("Stan Lee")
 
     expect(page).to have_content "Stan Lee (1234)"
@@ -66,7 +67,7 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Searching for an errored download tries again" do
-    Fakes::BGSService.veteran_info = { "5555" => { "first_name" => "Stan", "last_name" => "Lee", "last_four_ssn" => "2222" } }
+    Fakes::BGSService.veteran_info = { "5555" => { "veteran_first_name" => "Stan", "veteran_last_name" => "Lee", "veteran_last_four_ssn" => "2222" } }
 
     @user_download.create!(
       file_number: "5555",
@@ -97,7 +98,7 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Extraneous spaces in search input" do
-    Fakes::BGSService.veteran_info = { "1234" => { "first_name" => "Stan", "last_name" => "Lee", "last_four_ssn" => "2222" } }
+    Fakes::BGSService.veteran_info = { "1234" => { "veteran_first_name" => "Stan", "veteran_last_name" => "Lee", "veteran_last_four_ssn" => "2222" } }
 
     visit "/"
     expect(page).to_not have_content "Recent Searches"
@@ -124,7 +125,7 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Sensitive download error" do
-    Fakes::BGSService.veteran_info = { "8888" => { "first_name" => "Nick", "last_name" => "Saban"} }
+    Fakes::BGSService.veteran_info = { "8888" => { "veteran_first_name" => "Nick", "veteran_last_name" => "Saban"} }
     Fakes::BGSService.sensitive_files = { "8888" => true }
 
     visit "/"
@@ -171,7 +172,7 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Confirming download" do
-    Fakes::BGSService.veteran_info = { "3456" => {"first_name" => "Steph", "last_name" => "Curry", "last_four_ssn" => "2345"} }
+    Fakes::BGSService.veteran_info = { "3456" => {"veteran_first_name" => "Steph", "veteran_last_name" => "Curry", "veteran_last_four_ssn" => "2345"} }
     @download = @user_download.create(file_number: "3456", status: :fetching_manifest)
 
     visit download_path(@download)
@@ -254,7 +255,7 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Completed download" do
-    Fakes::BGSService.veteran_info = { "12" => { "first_name" => "Stan", "last_name" => "Lee", "last_four_ssn" => "2222" } }
+    Fakes::BGSService.veteran_info = { "12" => { "veteran_first_name" => "Stan", "veteran_last_name" => "Lee", "veteran_last_four_ssn" => "2222" } }
 
     # clean files
     FileUtils.rm_rf(Rails.application.config.download_filepath)

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Creating a download" do
-    Fakes::BGSService.veteran_names = { "1234" => "Stan Lee" }
+    Fakes::BGSService.veteran_info = { "1234" => { "first_name" => "Stan", "last_name" => "Lee", "last_four_ssn" => "2222" } }
 
     visit "/"
     expect(page).to_not have_content "Recent Searches"
@@ -50,11 +50,12 @@ RSpec.feature "Downloads" do
     click_button "Search"
 
     # Test that Caseflow caches veteran name for a download
-    Fakes::BGSService.veteran_names = {}
+    Fakes::BGSService.veteran_info = {}
 
     @download = @user_download.last
     expect(@download).to_not be_nil
-    expect(@download.veteran_name).to eq("Stan Lee")
+    expect(@download.veteran_info.first_name).to eq("Stan")
+    expect(@download.veteran_info.last_name).to eq("Lee")
 
     expect(page).to have_content "Stan Lee (1234)"
     expect(page).to have_content "We are gathering the list of files in the eFolder now"
@@ -66,7 +67,7 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Searching for an errored download tries again" do
-    Fakes::BGSService.veteran_names = { "5555" => "Stan Lee" }
+    Fakes::BGSService.veteran_info = { "5555" => { "first_name" => "Stan", "last_name" => "Lee", "last_four_ssn" => "2222" } }
 
     @user_download.create!(
       file_number: "5555",
@@ -97,7 +98,7 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Extraneous spaces in search input" do
-    Fakes::BGSService.veteran_names = { "1234" => "Stan Lee" }
+    Fakes::BGSService.veteran_info = { "1234" => { "first_name" => "Stan", "last_name" => "Lee", "last_four_ssn" => "2222" } }
 
     visit "/"
     expect(page).to_not have_content "Recent Searches"
@@ -171,7 +172,7 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Confirming download" do
-    Fakes::BGSService.veteran_names = { "3456" => "Steph Curry" }
+    Fakes::BGSService.veteran_info = { "3456" => {"first_name" => "Steph", "last_name" => "Curry", "last_four_ssn" => "2345"} }
     @download = @user_download.create(file_number: "3456", status: :fetching_manifest)
 
     visit download_path(@download)
@@ -254,7 +255,7 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Completed download" do
-    Fakes::BGSService.veteran_names = { "12" => "Tom Thomson" }
+    Fakes::BGSService.veteran_info = { "12" => { "first_name" => "Stan", "last_name" => "Lee", "last_four_ssn" => "2222" } }
 
     # clean files
     FileUtils.rm_rf(Rails.application.config.download_filepath)

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -54,8 +54,7 @@ RSpec.feature "Downloads" do
 
     @download = @user_download.last
     expect(@download).to_not be_nil
-    expect(@download.veteran_info.first_name).to eq("Stan")
-    expect(@download.veteran_info.last_name).to eq("Lee")
+    expect(@download.veteran_name).to eq("Stan Lee")
 
     expect(page).to have_content "Stan Lee (1234)"
     expect(page).to have_content "We are gathering the list of files in the eFolder now"
@@ -125,7 +124,7 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Sensitive download error" do
-    Fakes::BGSService.veteran_names = { "8888" => "Nick Saban" }
+    Fakes::BGSService.veteran_info = { "8888" => { "first_name" => "Nick", "last_name" => "Saban"} }
     Fakes::BGSService.sensitive_files = { "8888" => true }
 
     visit "/"

--- a/spec/models/download_spec.rb
+++ b/spec/models/download_spec.rb
@@ -46,6 +46,11 @@ describe "Download" do
     end
   end
 
+  context "veteran_name" do
+    subject { download.veteran_name }
+    it { is_expected.to eq("Stan Lee") }
+  end
+
   context "#time_to_fetch_manifest" do
     let(:download) do
       Download.create(

--- a/spec/models/download_spec.rb
+++ b/spec/models/download_spec.rb
@@ -3,7 +3,7 @@ describe "Download" do
     Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
 
     Download.bgs_service = Fakes::BGSService
-    Fakes::BGSService.veteran_info = { "1234": { "veteran_first_name": "Stan", "veteran_last_name": "Lee" } }
+    Fakes::BGSService.veteran_info = { "1234" => { "veteran_first_name" => "Stan", "veteran_last_name" => "Lee" } }
   end
   after { Timecop.return }
 
@@ -16,7 +16,7 @@ describe "Download" do
     context "when file number is set" do
       before do
         Download.bgs_service = Fakes::BGSService
-        Fakes::BGSService.veteran_info = { "1234": {"veteran_first_name": "Stan", "veteran_last_name": "Lee" } }
+        Fakes::BGSService.veteran_info = { "1234" => { "veteran_first_name" => "Stan", "veteran_last_name" => "Lee" } }
       end
 
       it "sets veteran name" do

--- a/spec/models/download_spec.rb
+++ b/spec/models/download_spec.rb
@@ -32,6 +32,7 @@ describe "Download" do
       end
 
       it "sets veteran name" do
+        subject.save!
         expect(subject.veteran_name).to eq("Stan Lee")
       end
     end

--- a/spec/models/download_spec.rb
+++ b/spec/models/download_spec.rb
@@ -3,7 +3,7 @@ describe "Download" do
     Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
 
     Download.bgs_service = Fakes::BGSService
-    Fakes::BGSService.veteran_names = { "1234" => "Stan Lee" }
+    Fakes::BGSService.veteran_info = { "1234": { "first_name": "Stan", "last_name": "Lee" } }
   end
   after { Timecop.return }
 
@@ -16,7 +16,7 @@ describe "Download" do
     context "when file number is set" do
       before do
         Download.bgs_service = Fakes::BGSService
-        Fakes::BGSService.veteran_names = { "1234" => {"first_name" => "Stan", "last_name" => "Lee" } }
+        Fakes::BGSService.veteran_info = { "1234": {"first_name": "Stan", "last_name": "Lee" } }
       end
 
       it "sets veteran name" do

--- a/spec/models/download_spec.rb
+++ b/spec/models/download_spec.rb
@@ -31,6 +31,13 @@ describe "Download" do
         }
       end
 
+      it "indicates that veteran info is missing if it is" do
+        # veteran names & ssn are fetched right before persistance
+        # to the db, so before save is called, that info won't be
+        # present
+        expect(subject.missing_veteran_info?).to eq(true)
+      end
+
       it "sets veteran name" do
         subject.save!
         expect(subject.veteran_name).to eq("Stan Lee")

--- a/spec/models/download_spec.rb
+++ b/spec/models/download_spec.rb
@@ -16,7 +16,7 @@ describe "Download" do
     context "when file number is set" do
       before do
         Download.bgs_service = Fakes::BGSService
-        Fakes::BGSService.veteran_names = { "1234" => "Stan Lee" }
+        Fakes::BGSService.veteran_names = { "1234" => {"first_name" => "Stan", "last_name" => "Lee" } }
       end
 
       it "sets veteran name" do

--- a/spec/models/download_spec.rb
+++ b/spec/models/download_spec.rb
@@ -3,7 +3,7 @@ describe "Download" do
     Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
 
     Download.bgs_service = Fakes::BGSService
-    Fakes::BGSService.veteran_info = { "1234": { "first_name": "Stan", "last_name": "Lee" } }
+    Fakes::BGSService.veteran_info = { "1234": { "veteran_first_name": "Stan", "veteran_last_name": "Lee" } }
   end
   after { Timecop.return }
 
@@ -16,7 +16,7 @@ describe "Download" do
     context "when file number is set" do
       before do
         Download.bgs_service = Fakes::BGSService
-        Fakes::BGSService.veteran_info = { "1234": {"first_name": "Stan", "last_name": "Lee" } }
+        Fakes::BGSService.veteran_info = { "1234": {"veteran_first_name": "Stan", "veteran_last_name": "Lee" } }
       end
 
       it "sets veteran name" do

--- a/spec/models/download_spec.rb
+++ b/spec/models/download_spec.rb
@@ -3,7 +3,13 @@ describe "Download" do
     Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
 
     Download.bgs_service = Fakes::BGSService
-    Fakes::BGSService.veteran_info = { "1234" => { "veteran_first_name" => "Stan", "veteran_last_name" => "Lee" } }
+    Fakes::BGSService.veteran_info = {
+      "1234" => {
+        "veteran_first_name" => "Stan",
+        "veteran_last_name" => "Lee",
+        "veteran_last_four_ssn" => "0987"
+      }
+    }
   end
   after { Timecop.return }
 
@@ -16,7 +22,13 @@ describe "Download" do
     context "when file number is set" do
       before do
         Download.bgs_service = Fakes::BGSService
-        Fakes::BGSService.veteran_info = { "1234" => { "veteran_first_name" => "Stan", "veteran_last_name" => "Lee" } }
+        Fakes::BGSService.veteran_info = {
+          "1234" => {
+            "veteran_first_name" => "Stan",
+            "veteran_last_name" => "Lee",
+            "veteran_last_four_ssn" => "0987"
+          }
+        }
       end
 
       it "sets veteran name" do
@@ -68,7 +80,7 @@ describe "Download" do
 
   context "package_filename" do
     subject { download.package_filename }
-    it { is_expected.to eq("stanlee-20150101.zip") }
+    it { is_expected.to eq("Lee, Stan - 0987.zip") }
   end
 
   context "#stalled?" do

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -25,7 +25,7 @@ describe Search do
     subject { search.perform! }
 
     before do
-      Fakes::BGSService.veteran_info = { "22223333" => {"first_name" => "John", "last_name" => "McJohn" } }
+      Fakes::BGSService.veteran_info = { "22223333" => {"veteran_first_name" => "John", "veteran_last_name" => "McJohn" } }
       Fakes::BGSService.sensitive_files = {}
       Download.bgs_service = Fakes::BGSService
       allow(GetDownloadManifestJob).to receive(:perform_later)

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -25,7 +25,11 @@ describe Search do
     subject { search.perform! }
 
     before do
-      Fakes::BGSService.veteran_info = { "22223333" => {"veteran_first_name" => "John", "veteran_last_name" => "McJohn" } }
+      Fakes::BGSService.veteran_info =
+        { "22223333" => {
+          "veteran_first_name" => "John",
+          "veteran_last_name" => "McJohn" }
+        }
       Fakes::BGSService.sensitive_files = {}
       Download.bgs_service = Fakes::BGSService
       allow(GetDownloadManifestJob).to receive(:perform_later)

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -27,8 +27,9 @@ describe Search do
     before do
       Fakes::BGSService.veteran_info =
         { "22223333" => {
-          "veteran_first_name" => "John",
-          "veteran_last_name" => "McJohn" }
+            "veteran_first_name" => "John",
+            "veteran_last_name" => "McJohn"
+          }
         }
       Fakes::BGSService.sensitive_files = {}
       Download.bgs_service = Fakes::BGSService

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -26,7 +26,8 @@ describe Search do
 
     before do
       Fakes::BGSService.veteran_info =
-        { "22223333" => {
+        { "22223333" =>
+          {
             "veteran_first_name" => "John",
             "veteran_last_name" => "McJohn"
           }

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -25,7 +25,7 @@ describe Search do
     subject { search.perform! }
 
     before do
-      Fakes::BGSService.veteran_names = { "22223333" => "John McJohn" }
+      Fakes::BGSService.veteran_info = { "22223333" => {"first_name" => "John", "last_name" => "McJohn" } }
       Fakes::BGSService.sensitive_files = {}
       Download.bgs_service = Fakes::BGSService
       allow(GetDownloadManifestJob).to receive(:perform_later)

--- a/spec/services/bgs_service_spec.rb
+++ b/spec/services/bgs_service_spec.rb
@@ -1,0 +1,34 @@
+describe BGSService do
+  context "#parse_veteran_info" do
+    before do
+      @veteran_info = {
+        ssn_nbr: "123-43-1111",
+        first_nm: "FirstName",
+        last_nm: "LastName"
+      }
+    end
+
+    context "if bgs service returns a string ssn" do
+      subject { BGSService.parse_veteran_info(@veteran_info)["veteran_last_four_ssn"] }
+      it { is_expected.to eq("1111") }
+    end
+
+    context "if bgs service returns no ssn" do
+      veteran_info = {
+        ssn_nbr: nil
+      }
+      subject { BGSService.parse_veteran_info(veteran_info)["veteran_last_four_ssn"] }
+      it { is_expected.to eq(nil) }
+    end
+
+    context "if bgs service returns last name" do
+      subject { BGSService.parse_veteran_info(@veteran_info)["veteran_last_name"] }
+      it { is_expected.to eq("LastName") }
+    end
+
+    context "if bgs service returns first name" do
+      subject { BGSService.parse_veteran_info(@veteran_info)["veteran_first_name"] }
+      it { is_expected.to eq("FirstName") }
+    end
+  end
+end

--- a/spec/services/download_documents_spec.rb
+++ b/spec/services/download_documents_spec.rb
@@ -11,7 +11,13 @@ describe DownloadDocuments do
     Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
   end
 
-  let(:download) { Download.create!(file_number: "21012", veteran_name: "George Washington") }
+  let(:download) do
+    Download.create!(
+      file_number: "21012",
+      veteran_first_name: "George",
+      veteran_last_name: "Washington"
+    )
+  end
 
   let(:vbms_documents) do
     [


### PR DESCRIPTION
Changes download filename to "LastName, Firstname - Last4SSN". This was significantly more difficult than first anticipated! Adds a DB migration to store the last four digits of a veteran's ssn, and the first and last name in separate columns. A bit of tech debt is also cleaned up here and there for good measure.

Fixes #223
Fixes #55 

Reviewer: @shanear 

Test plan:
modified and added unit tests
locally tested that the file download now occurs with the expected format
tested the migration and rollback several times
![image](https://cloud.githubusercontent.com/assets/3781835/19258215/1ba6ddea-8f44-11e6-85b7-4ff036bc9c87.png)
TODO: currently blocked on testing this with the live DB. @shanear, can you help me figure out how to proceed?
