### PR TITLE
Handle VBMS connection errors

### DIFF
--- a/app/jobs/demo_get_download_manifest_job.rb
+++ b/app/jobs/demo_get_download_manifest_job.rb
@@ -25,13 +25,15 @@ class DemoGetDownloadManifestJob < ActiveJob::Base
     },
     "DEMO_VBMS_ERROR" => {
       manifest_load: 1,
+      num_docs: 5,
       error: true,
-      error_type: 'VBMS'
+      error_type: "VBMS"
     },
     "DEMO_NO_DOCUMENTS" => {
       manifest_load: 1,
+      num_docs: 0,
       error: true,
-      error_type: 'NO_DOCUMENTS'
+      error_type: "NO_DOCUMENTS"
     },
     "DEMODEFAULT" => {
       manifest_load: 4,
@@ -42,25 +44,31 @@ class DemoGetDownloadManifestJob < ActiveJob::Base
 
   def perform(download)
     demo = DEMOS[download.file_number] || DEMOS["DEMODEFAULT"]
-    sleep(demo[:manifest_load] || 0)
-    create_documents(download, demo[:num_docs] || 0)
+    sleep_manifest_load(demo[:manifest_load])
+    create_documents(download, demo[:num_docs])
 
-    raise VBMS::ClientError if demo[:error] && demo[:error_type] == 'VBMS'
-    raise 'no documents' if demo[:error] && demo[:error_type] == 'NO_DOCUMENTS'
-
-
+    check_and_raise_errors(demo)
 
     download.update_attributes!(status: :pending_confirmation)
   rescue VBMS::ClientError => e
     Rails.logger.info "#{e.message}\n#{e.backtrace.join("\n")}"
     Raven.capture_exception(e)
     download.update_attributes!(status: :vbms_connection_error)
-  rescue => e
+  rescue
     download.update_attributes!(status: :no_documents)
   end
 
+  def check_and_raise_errors(demo)
+    fail VBMS::ClientError if demo[:error] && demo[:error_type] == "VBMS"
+    fail "no documents" if demo[:error] && demo[:error_type] == "NO_DOCUMENTS"
+  end
+
+  def sleep_manifest_load(wait)
+    sleep(wait || 0)
+  end
+
   def create_documents(download, number)
-    number.times do |i|
+    (number || 0).times do |i|
       download.documents.create(
         vbms_filename: "happy-thursday-#{SecureRandom.hex}.txt",
         mime_type: "text/plain",

--- a/app/jobs/demo_get_download_manifest_job.rb
+++ b/app/jobs/demo_get_download_manifest_job.rb
@@ -52,6 +52,8 @@ class DemoGetDownloadManifestJob < ActiveJob::Base
 
     download.update_attributes!(status: :pending_confirmation)
   rescue VBMS::ClientError => e
+    Rails.logger.info "#{e.message}\n#{e.backtrace.join("\n")}"
+    Raven.capture_exception(e)
     download.update_attributes!(status: :vbms_connection_error)
   rescue => e
     download.update_attributes!(status: :no_documents)

--- a/app/jobs/get_download_manifest_job.rb
+++ b/app/jobs/get_download_manifest_job.rb
@@ -11,7 +11,9 @@ class GetDownloadManifestJob < ActiveJob::Base
       download_documents.create_documents
       download.update_attributes!(status: :pending_confirmation)
     end
-  rescue
+  rescue VBMS::ClientError => e
+    download.update_attributes!(status: :vbms_connection_error)
+  rescue => e
     download.update_attributes!(status: :no_documents)
   end
 

--- a/app/jobs/get_download_manifest_job.rb
+++ b/app/jobs/get_download_manifest_job.rb
@@ -15,7 +15,7 @@ class GetDownloadManifestJob < ActiveJob::Base
     Rails.logger.error "#{e.message}\n#{e.backtrace.join("\n")}"
     Raven.capture_exception(e)
     download.update_attributes!(status: :vbms_connection_error)
-  rescue => e
+  rescue
     download.update_attributes!(status: :no_documents)
   end
 

--- a/app/jobs/get_download_manifest_job.rb
+++ b/app/jobs/get_download_manifest_job.rb
@@ -12,6 +12,8 @@ class GetDownloadManifestJob < ActiveJob::Base
       download.update_attributes!(status: :pending_confirmation)
     end
   rescue VBMS::ClientError => e
+    Rails.logger.error "#{e.message}\n#{e.backtrace.join("\n")}"
+    Raven.capture_exception(e)
     download.update_attributes!(status: :vbms_connection_error)
   rescue => e
     download.update_attributes!(status: :no_documents)

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -6,7 +6,8 @@ class Download < ActiveRecord::Base
     pending_documents: 3,
     packaging_contents: 4,
     complete_success: 5,
-    complete_with_errors: 6
+    complete_with_errors: 6,
+    vbms_connection_error: 7
   }
 
   TIMEOUT = 10.minutes

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -44,7 +44,7 @@ class Search < ActiveRecord::Base
       file_number: sanitized_file_number,
       user_id: user_id,
       user_station_id: user_station_id
-    ).where.not(status: 1)
+    ).where.not(status: [1, 7])
   end
 
   def match_existing_download

--- a/app/views/downloads/_confirm.html.erb
+++ b/app/views/downloads/_confirm.html.erb
@@ -22,6 +22,17 @@
       </div>
     </div>
 
+  <% elsif @download.vbms_connection_error? %>
+    <div class="usa-alert usa-alert-error" role="alert">
+      <div class="usa-alert-body">
+        <h3 class="usa-alert-heading">Can't connect to VBMS</h3>
+        <p class="usa-alert-text">
+          Please give VBMS a few moments to come back online, then try searching for the eFolder again.
+        </p>
+        <p class="usa-alert-text"><%= link_to "Try Again", root_path %></p>
+      </div>
+    </div>
+
   <% elsif @download.pending_confirmation? %>
     <p>
       eFolder Express found <%= @download.documents.count %> files in eFolder #<%= @download.file_number %>

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -170,6 +170,15 @@ RSpec.feature "Downloads" do
     expect(page).to have_current_path(root_path)
   end
 
+  scenario "Download with VBMS connection error" do
+    @download = @user_download.create(status: :vbms_connection_error)
+    visit download_path(@download)
+
+    expect(page).to have_css ".usa-alert-heading", text: "Can't connect to VBMS"
+    click_on "Try Again"
+    expect(page).to have_current_path(root_path)
+  end
+
   scenario "Confirming download" do
     Fakes::BGSService.veteran_names = { "3456" => "Steph Curry" }
     @download = @user_download.create(file_number: "3456", status: :fetching_manifest)

--- a/spec/jobs/get_download_manifest_job_spec.rb
+++ b/spec/jobs/get_download_manifest_job_spec.rb
@@ -19,8 +19,8 @@ describe GetDownloadManifestJob do
         GetDownloadManifestJob.perform_now(download)
       end
 
-      it "saves download status as :no_documents" do
-        expect(download.reload).to be_no_documents
+      it "saves download status as :vbms_connection_error" do
+        expect(download.reload).to be_vbms_connection_error
       end
     end
 

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -89,6 +89,24 @@ describe Search do
       end
     end
 
+    context "when the download has vbms connection error" do
+      before do
+        @existing_download = Download.create!(
+          user_id: "NICKSABAN",
+          user_station_id: "200",
+          file_number: "22223333",
+          status: :vbms_connection_error
+        )
+      end
+
+      it "creates a new download" do
+        expect(@existing_download).to be_truthy
+        expect(subject).to be_truthy
+        expect(search.reload).to be_download_created
+        expect(search.download.id).to_not eq(@existing_download.id)
+      end
+    end
+
     context "when user cannot access file with that file_number" do
       before do
         Fakes::BGSService.sensitive_files = { "22223333" => true }


### PR DESCRIPTION
This PR:
- Adds support for "DEMO_VBMS_ERROR" and "DEMO_NO_DOCUMENTS" file_number for triggering desired error
- Logging VBMS connection errors and sending them to sentry 
- Updated error messaging on VBMS connection error during search


New UI:
![demo_vbms_error](https://cloud.githubusercontent.com/assets/2256237/19286814/2aec95ea-8fcd-11e6-9a7d-c9c6aef2209a.gif)



Testing:
- Running `rake`, all current tests pass
- New unit and feature tests have been added and pass
- VBMS error properly displays in Sentry:
<img width="1614" alt="screen shot 2016-10-11 at 1 32 58 pm" src="https://cloud.githubusercontent.com/assets/2256237/19286746/e0976236-8fcc-11e6-9ab8-bfcdfa67d72f.png">
- VBMS error properly shows up in logs:
<img width="1670" alt="screen shot 2016-10-11 at 2 12 17 pm" src="https://cloud.githubusercontent.com/assets/2256237/19286760/ea88f7aa-8fcc-11e6-9f27-51cef717c8bb.png">


