### PR TITLE
Add ruby-gemset to repo

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+efolder


### PR DESCRIPTION
Sounds like everyone is using rbenv, which is cool. I just happened to already have RVM installed on my machine so would prefer to add a .ruby-gemset file. Shouldn't affect anyone else, I believe. Does this seem reasonable? Otherwise I can just keep it uncommitted locally. 