### PR TITLE
Update cta button text for retrying download

### DIFF
--- a/app/views/downloads/_progress.html.erb
+++ b/app/views/downloads/_progress.html.erb
@@ -3,16 +3,16 @@
     <% if @download.documents.failed.any? %>
       <div class="usa-alert usa-alert-error" role="alert">
         <div class="usa-alert-body">
-          <h3 class="usa-alert-heading">Some files couldn't be added</h3>
+          <h3 class="usa-alert-heading">Some files couldn't be added to eFolder</h3>
           <p class="usa-alert-text">
-            eFolder Express couldn't fetch some files. Click on the "Errors" tab below.
+            eFolder Express wasn't able to retrieve some files. Click on the 'Errors' tab below to view them
           </p>
           <p>
-            You can still download the rest of the files by clicking the "Download" button below.
+            You can still download the rest of the files by clicking the 'Download Anyway' button below.
           </p>
           <ul class="ee-button-list">
             <li><%= link_to "Download Anyway", download_download_path(@download), {class: "usa-button"} %></li>
-            <li><%= link_to "Retry Download", retry_download_path(@download), {method: :post, class: "usa-button usa-button-gray"} %></li>
+            <li><%= link_to "Try Retrieving eFolder Again", retry_download_path(@download), {method: :post, class: "usa-button usa-button-gray"} %></li>
           </ul>
         </div>
       </div>

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -299,7 +299,7 @@ RSpec.feature "Downloads" do
     @download.documents.create(vbms_filename: "tide.pdf", mime_type: "application/pdf", download_status: :success)
 
     visit download_path(@download)
-    click_on "Retry Download"
+    click_on "Try Retrieving eFolder Again"
 
     expect(page).to have_css ".cf-tab.cf-active", text: "Progress (2)"
     expect(page).to have_content "Completed (0)"


### PR DESCRIPTION
If any of the files have failed to download, the user can retry by
clicking a CTA button. Updating the text from "Retry Download" to "Try
Retrieving eFolder Again"

Testing:
- Tests all pass
- Manual searched for "DEMO3", error message & CTA button rendered as expected:
<img width="1171" alt="screen shot 2016-10-13 at 4 37 26 pm" src="https://cloud.githubusercontent.com/assets/2256237/19366115/d9416a5c-9163-11e6-93d9-a4c7bbad9deb.png">


CC @lakohl took some small liberty in capitalizing all the words in the button to match the "Download Anyway", let me know if this was incorrect!