### PR TITLE
Return 404 on non-existing download attempt

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -58,11 +58,12 @@ class DownloadsController < ApplicationController
     @download_documents = DownloadDocuments.new(download: downloads.find(params[:id]))
     @download_documents.fetch_zip_from_s3
 
-    send_file @download_documents.zip_path
+    file_exists = @download_documents.zip_exists_locally?
+    file_exists ? send_file(@download_documents.zip_path) : record_not_found
   end
 
   def record_not_found
-    render "not_found"
+    render text: "not_found", status: 404
   end
 
   private

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -63,7 +63,7 @@ class DownloadsController < ApplicationController
   end
 
   def record_not_found
-    render text: "not_found", status: 404
+    render text: "not found", status: 404
   end
 
   private

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -63,7 +63,7 @@ class DownloadsController < ApplicationController
   end
 
   def record_not_found
-    render text: "not found", status: 404
+    render "not_found", status: 404
   end
 
   private

--- a/app/services/download_documents.rb
+++ b/app/services/download_documents.rb
@@ -87,7 +87,7 @@ class DownloadDocuments
   end
 
   def zip_exists_locally?
-    File.exists?(zip_path)
+    File.exist?(zip_path)
   end
 
   def fetch_zip_from_s3

--- a/app/services/download_documents.rb
+++ b/app/services/download_documents.rb
@@ -86,9 +86,13 @@ class DownloadDocuments
     @s3.fetch_file(document.s3_filename, document.filepath)
   end
 
+  def zip_exists_locally?
+    File.exists?(zip_path)
+  end
+
   def fetch_zip_from_s3
     # if the file exists on the filesystem, skip
-    return if File.exist?(zip_path)
+    return if zip_exists_locally?
 
     @s3.fetch_file(@download.s3_filename, zip_path)
   end
@@ -101,7 +105,7 @@ class DownloadDocuments
     before_package_contents
     @download.update_attributes(status: :packaging_contents)
 
-    File.delete(zip_path) if File.exist?(zip_path)
+    File.delete(zip_path) if zip_exists_locally?
 
     Zip::File.open(zip_path, Zip::File::CREATE) do |zipfile|
       @download.documents.success.each_with_index do |document, index|

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -308,7 +308,7 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Download non-existing zip" do
-    fake_id = 'non_existing_download_id'
+    fake_id = "non_existing_download_id"
     expect(Download.where(id: fake_id)).to be_empty
 
     visit download_download_path(fake_id)

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -307,6 +307,14 @@ RSpec.feature "Downloads" do
     expect(GetDownloadFilesJob).to have_received(:perform_later)
   end
 
+  scenario "Download non-existing zip" do
+    fake_id = 'non_existing_download_id'
+    expect(Download.where(id: fake_id)).to be_empty
+
+    visit download_download_path(fake_id)
+    expect(page.status_code).to be(404)
+  end
+
   scenario "Completed download" do
     Fakes::BGSService.veteran_info = {
       "12" => {


### PR DESCRIPTION
Testing:
- All tests pass
- Added tests that specifically test a non-existing download 
- Manually testing in the browser works as expected:
<img width="768" alt="screen shot 2016-10-13 at 5 54 15 pm" src="https://cloud.githubusercontent.com/assets/2256237/19371584/57755028-9182-11e6-82e4-e6207a53b536.png">
