### PR TITLE
Show document ID for errored downloads

### DIFF
--- a/app/assets/stylesheets/_download.scss
+++ b/app/assets/stylesheets/_download.scss
@@ -15,6 +15,10 @@
   width: 80%;
 }
 
+.ee-doc-id-row {
+  white-space: nowrap;
+}
+
 .ee-right-button {
   float: right;
   margin-right: 0;

--- a/app/jobs/demo_get_download_manifest_job.rb
+++ b/app/jobs/demo_get_download_manifest_job.rb
@@ -72,7 +72,7 @@ class DemoGetDownloadManifestJob < ActiveJob::Base
       download.documents.create(
         vbms_filename: "happy-thursday-#{SecureRandom.hex}.txt",
         doc_type: Document::TYPES.keys.sample,
-        document_id: SecureRandom.hex.to_s,
+        document_id: "{#{SecureRandom.hex(4).upcase}-#{SecureRandom.hex(2).upcase}-#{SecureRandom.hex(2).upcase}-#{SecureRandom.hex(2).upcase}-#{SecureRandom.hex(6).upcase}}",
         mime_type: "text/plain",
         received_at: (i * 2).days.ago
       )

--- a/app/views/downloads/_progress.html.erb
+++ b/app/views/downloads/_progress.html.erb
@@ -86,6 +86,9 @@
         <tr>
           <th scope="col"><span class="usa-sr-only">Status</span></th>
           <th scope="col">Filename</th>
+          <% if current_tab == "errored" %>
+            <th scope="col">Document ID</th>
+          <% end %>
           <th scope="col">Receipt Date</th>
         </tr>
       </thead>
@@ -97,6 +100,9 @@
               <%= svg_icon(document.download_status_icon) %>
             </td>
             <td class="ee-filename-row"><%= document.type_name %></td>
+            <% if current_tab == "errored" %>
+              <td class="ee-doc-id-row"><%= document.filename_doc_id %></td>
+            <% end %>
             <td><%= document.received_at && document.received_at.to_formatted_s(:short_date) %></td>
           </tr>
         <% end %>

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -253,8 +253,13 @@ RSpec.feature "Downloads" do
   scenario "Download progress shows documents in tabs based on their status" do
     @download = @user_download.create(status: :pending_documents)
     @download.documents.create(vbms_filename: "yawn.pdf", mime_type: "application/pdf", download_status: :pending)
-    @download.documents.create(vbms_filename: "poo.pdf", mime_type: "application/pdf", download_status: :failed)
     @download.documents.create(vbms_filename: "smiley.pdf", mime_type: "application/pdf", download_status: :success)
+    @download.documents.create(
+      doc_type: "129",
+      document_id: "{1234-1234-1234-5555}",
+      mime_type: "application/pdf",
+      download_status: :failed
+    )
 
     visit download_path(@download)
     expect(page).to have_css ".cf-tab.cf-active", text: "Progress (1)"
@@ -270,7 +275,7 @@ RSpec.feature "Downloads" do
 
     click_on "Errors"
     expect(page).to have_css ".cf-tab.cf-active", text: "Errors (1)"
-    expect(page).to have_css ".document-failed", text: "poo.pdf"
+    expect(page).to have_css ".document-failed", text: "VA 21-509 Statement of Dependency of Parents 1234-1234-1234-5555"
     expect(page).to_not have_css ".document-success", text: "smiley.pdf"
     expect(page).to_not have_css ".document-pending", text: "yawn.pdf"
   end


### PR DESCRIPTION
<img width="1543" alt="screen shot 2016-10-14 at 2 51 33 pm" src="https://cloud.githubusercontent.com/assets/1596259/19399255/a7883b7e-921e-11e6-8da7-f57ef869d1b8.png">

fixes #169