### PR TITLE
Add note to download history

### DIFF
--- a/app/assets/stylesheets/_download.scss
+++ b/app/assets/stylesheets/_download.scss
@@ -32,6 +32,11 @@
 .ee-recent-searches {
   border-top: 1px solid $color-gray-lighter;
   padding-top: 45px;
+  margin-bottom: 0;
+}
+
+.ee-recent-searches-note {
+  margin-top: 5px;
 }
 
 .ee-actions-cell {

--- a/app/views/downloads/new.html.erb
+++ b/app/views/downloads/new.html.erb
@@ -55,6 +55,7 @@
 
   <% if recent_downloads.exists? %>
     <h2 class="ee-recent-searches">History</h2>
+    <p class="ee-recent-searches-note">Note: eFolders remain in your history for <b>72 hours</b></p>
     <table class="usa-table-borderless" summary="List of recent downloads and links to download their contents">
     <thead>
       <tr class="usa-sr-only">


### PR DESCRIPTION
- Add note to download history explaining how long downloads persist

Fixes #261 

Testing:
Manually loaded in browser, now looks like
<img width="1187" alt="screen shot 2016-10-19 at 11 44 50 am" src="https://cloud.githubusercontent.com/assets/2256237/19526152/7a22c5ec-95f1-11e6-8392-ca29233957b3.png">
