### PR TITLE
Allow APP_ENV to be overridden through ENV

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,9 +21,17 @@ def notify(message, color='good') {
 }
 
 node {
+  // Default to UAT environment, but allow Jenkins to override this in
+  // environment variables.
+  def APP_ENV;
+  if(env.APP_ENV) {
+    APP_ENV = env.APP_ENV
+  } else {
+    APP_ENV = 'uat'
+    print "APP_ENV is not defined, defaulting to ${APP_ENV}"
+  }
 
   def APP_NAME = 'efolder';
-  def APP_ENV = 'uat';
   def APP_VERSION = 'HEAD'
 
   // withCredentials allows us to expose the secrets in Credential Binding
@@ -88,7 +96,7 @@ node {
       // awhile to complete.
       stage ('deploy') {
         dir ('./appeals-deployment') {
-          sh "echo \"${env.VAULT_PASS}\"| \
+          sh "echo \"${env.VAULT_PASS}\" | \
             ansible-playbook deploy-to-aws.yml \
               --verbose \
               -i localhost \


### PR DESCRIPTION
By allowing APP_ENV to be overridden through environment variables, Jenkins can inject custom properties in the pipeline. This way, we can use the same Jenkinsfile for different AWS environment.

![jenkins-prop](https://cloud.githubusercontent.com/assets/3258724/19535308/18e80c14-9615-11e6-8531-aaf1bef3dabe.png)
