### PR TITLE
Only poll for download status when fetching manifest

### DIFF
--- a/app/assets/javascripts/application/download_status.js
+++ b/app/assets/javascripts/application/download_status.js
@@ -3,6 +3,7 @@ window.DownloadStatus = (function($) {
 
   // public
   return {
+    intervalID: null,
     recheck: function() {
       if (id) {
         $.getJSON("/downloads/" + id).then(function(download) {
@@ -15,7 +16,7 @@ window.DownloadStatus = (function($) {
       id = downloadId;
       currentStatus = downloadStatus;
 
-      window.setInterval(this.recheck, 1000);
+      this.intervalID = window.setInterval(this.recheck, 1000);
     }
   };
 })($);

--- a/app/views/downloads/_confirm.html.erb
+++ b/app/views/downloads/_confirm.html.erb
@@ -1,7 +1,9 @@
-<script>
-  // Set up automatic download status updates
-  window.DownloadStatus.init(<%= @download.id %>, "<%= @download.status %>");
-</script>
+<% if @download.fetching_manifest? %>
+  <script>
+    // Set up automatic download status updates
+    window.DownloadStatus.init(<%= @download.id %>, "<%= @download.status %>");
+  </script>
+<% end %>
 
 <% fetch_button_text = "Start retrieving eFolder" %>
 

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -68,10 +68,12 @@ RSpec.feature "Downloads" do
     expect(page).to have_content "Stan Lee (1234)"
     expect(page).to have_content "We are gathering the list of files in the eFolder now"
     expect(page).to have_current_path(download_path(@download))
+    expect(page.evaluate_script("window.DownloadStatus.interalID")).to be_truthy
     expect(GetDownloadManifestJob).to have_received(:perform_later)
 
     @search = Search.where(user_id: "123123", file_number: "1234").first
     expect(@search).to be_download_created
+
   end
 
   scenario "Searching for an errored download tries again" do
@@ -242,6 +244,7 @@ RSpec.feature "Downloads" do
     expect(page).to have_content "Steph Curry (3456)"
     expect(page).to have_content "yawn.pdf 09/06/2015"
     expect(page).to have_content "smiley.pdf 01/19/2015"
+    expect(page.evaluate_script("window.DownloadStatus.intervalID")).to be_falsey
     first(:button, "Start retrieving eFolder").click
 
     expect(@download.reload).to be_pending_documents

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -68,12 +68,11 @@ RSpec.feature "Downloads" do
     expect(page).to have_content "Stan Lee (1234)"
     expect(page).to have_content "We are gathering the list of files in the eFolder now"
     expect(page).to have_current_path(download_path(@download))
-    expect(page.evaluate_script("window.DownloadStatus.interalID")).to be_truthy
+    expect(page.evaluate_script("window.DownloadStatus.intervalID")).to be_truthy
     expect(GetDownloadManifestJob).to have_received(:perform_later)
 
     @search = Search.where(user_id: "123123", file_number: "1234").first
     expect(@search).to be_download_created
-
   end
 
   scenario "Searching for an errored download tries again" do


### PR DESCRIPTION
Fixes #33 

Testing:
- Added feature tests to verify it does and does not call  `window.DownloadStatus.init()` as expected
- All current tests pass
- Manual browser testing, everything worked as expected