### PR TITLE
Updated the text on the download eFolder page.

### DIFF
--- a/app/views/downloads/_progress.html.erb
+++ b/app/views/downloads/_progress.html.erb
@@ -24,8 +24,8 @@
           <p class="usa-alert-text">
             All of the documents in the VBMS eFolder for #<%= @download.file_number %> are ready to download.
             Click the "Download eFolder" button below.
-            <br/>
-            <br/>
+          </p>
+          <p>
             (Remember that Virtual VA documents are not included in this download)
           </p>
           <br/>

--- a/app/views/downloads/_progress.html.erb
+++ b/app/views/downloads/_progress.html.erb
@@ -24,6 +24,9 @@
           <p class="usa-alert-text">
             All of the documents in the VBMS eFolder for #<%= @download.file_number %> are ready to download.
             Click the "Download eFolder" button below.
+            <br/>
+            <br/>
+            (Remember that Virtual VA documents are not included in this download)
           </p>
           <br/>
           <%= link_to "Download eFolder", download_download_path(@download), {class: "usa-button"} %>


### PR DESCRIPTION
Added: "(Remember that Virtual VA documents are not included in this download)" on the download eFolder page.

Fixes #267 

**Test Plan**
-Ran test suite locally.
-Verify the new text is correct: ![screen shot 2016-10-24 at 4 44 20 pm](https://cloud.githubusercontent.com/assets/3885236/19663251/32f0c478-9a09-11e6-8f97-63eb4359b324.png)
