### PR TITLE
Clarify Files Complete Progress

### DIFF
--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -133,6 +133,14 @@ class Download < ActiveRecord::Base
     "#{user_id} (Station #{user_station_id})"
   end
 
+  def calculate_remaining_documents
+    documents.where(completed_at: nil).count
+  end
+
+  def number_of_documents
+    documents.count
+  end
+
   def self.downloads_by_user(downloads:)
     downloads.each_with_object({}) do |download, result|
       result[download.user_id_string] ||= 0

--- a/app/views/downloads/_progress.html.erb
+++ b/app/views/downloads/_progress.html.erb
@@ -50,7 +50,7 @@
     <p class="ee-fetching-files">
       <% if @download.estimated_to_complete_at %>
         Estimated time left: <%= distance_of_time_in_words(@download.estimated_to_complete_at, Time.zone.now, include_seconds: true) %>
-        (<%=@download.calculate_remaining_documents%> of <%=@download.number_of_documents%> files remaining)
+        (<%= @download.calculate_remaining_documents %> of <%= @download.number_of_documents %> files remaining)
       <% end %>
     </p>
 

--- a/app/views/downloads/_progress.html.erb
+++ b/app/views/downloads/_progress.html.erb
@@ -32,19 +32,6 @@
 
     <% end %>
   <% else %>
-    <h1 class="cf-txt-c">Retrieving Files ...</h1>
-    <p class="ee-fetching-files">
-      <% if @download.estimated_to_complete_at %>
-        Estimated time left: <%= distance_of_time_in_words(@download.estimated_to_complete_at, Time.zone.now, include_seconds: true) %>
-      <% end %>
-    </p>
-
-    <div class="progress-bar">
-      <span style="width: <%= @download.progress_percentage %>%;">
-        Progress: <%= @download.progress_percentage %>%
-      </span>
-    </div>
-
     <p>
       <div class="usa-alert usa-alert-info" role="alert">
         <div class="usa-alert-body">
@@ -58,6 +45,20 @@
         </div>
       </div>
     </p>
+
+    <h1 class="cf-txt-c">Retrieving Files ...</h1>
+    <p class="ee-fetching-files">
+      <% if @download.estimated_to_complete_at %>
+        Estimated time left: <%= distance_of_time_in_words(@download.estimated_to_complete_at, Time.zone.now, include_seconds: true) %>
+        (<%=@download.calculate_remaining_documents%> of <%=@download.number_of_documents%> files remaining)
+      <% end %>
+    </p>
+
+    <div class="progress-bar">
+      <span style="width: <%= @download.progress_percentage %>%;">
+        Progress: <%= @download.progress_percentage %>%
+      </span>
+    </div>
   <% end %>
 
   <div class="cf-tab-navigation">


### PR DESCRIPTION
Update the download progress bar to show the number of files remaining, and move the notice that you can close that page at any time above the progress bar.

Fixes #259 

**Test Plan**
- Run test suite
- Verify the new text is there
![screen shot 2016-10-24 at 5 56 55 pm](https://cloud.githubusercontent.com/assets/3885236/19665755/a3ef31fe-9a14-11e6-8883-7fa79bfae457.png)
