### PR TITLE
Added the date a downloaded eFolder will be deleted.

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -68,6 +68,10 @@ table td {
   width: 1em;
 }
 
+.cf-file-info {
+  color: $color-gray-light;
+}
+
 .ee-fetching-files {
   text-align: center;
   color: $color-gray;

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -68,10 +68,6 @@ table td {
   width: 1em;
 }
 
-.cf-file-info {
-  color: $color-gray-light;
-}
-
 .ee-fetching-files {
   text-align: center;
   color: $color-gray;

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -134,7 +134,7 @@ class Download < ActiveRecord::Base
   end
 
   def expriation_day
-    (completed_at + HOURS_UNTIL_EXPIRY.hours).strftime("%m/%d")
+    started_at ? (started_at + HOURS_UNTIL_EXPIRY.hours).strftime("%m/%d") : nil
   end
 
 

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -133,7 +133,7 @@ class Download < ActiveRecord::Base
     "#{user_id} (Station #{user_station_id})"
   end
 
-  def expriation_day
+  def expiration_day
     started_at ? (started_at + HOURS_UNTIL_EXPIRY.hours).strftime("%m/%d") : nil
   end
 

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -133,6 +133,11 @@ class Download < ActiveRecord::Base
     "#{user_id} (Station #{user_station_id})"
   end
 
+  def expriation_day
+    (completed_at + HOURS_UNTIL_EXPIRY.hours).strftime("%m/%d")
+  end
+
+
   def self.downloads_by_user(downloads:)
     downloads.each_with_object({}) do |download, result|
       result[download.user_id_string] ||= 0

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -137,7 +137,6 @@ class Download < ActiveRecord::Base
     started_at ? (started_at + HOURS_UNTIL_EXPIRY.hours).strftime("%m/%d") : nil
   end
 
-
   def self.downloads_by_user(downloads:)
     downloads.each_with_object({}) do |download, result|
       result[download.user_id_string] ||= 0

--- a/app/views/downloads/new.html.erb
+++ b/app/views/downloads/new.html.erb
@@ -67,7 +67,12 @@
         <tr id="download-<%= download.id %>">
           <td>
             <%= download.veteran_name %>
-            <span class="cf-subtext">(<%= download.file_number %>) - (Expries on <%= download.expriation_day %>)</span>
+            <span class="cf-subtext cf-file-info">
+              (<%= download.file_number %>)
+              <% if download.expriation_day %>
+                 - Expries on <%= download.expriation_day %>
+              <% end %>
+             </span>
           </td>
           <td class="ee-actions-cell">
             <% if download.complete_with_errors? %>

--- a/app/views/downloads/new.html.erb
+++ b/app/views/downloads/new.html.erb
@@ -54,7 +54,7 @@
   </div>
 
   <% if recent_downloads.exists? %>
-    <h2 class="ee-recent-searches">Download History</h2>
+    <h2 class="ee-recent-searches">History</h2>
     <table class="usa-table-borderless" summary="List of recent downloads and links to download their contents">
     <thead>
       <tr class="usa-sr-only">

--- a/app/views/downloads/new.html.erb
+++ b/app/views/downloads/new.html.erb
@@ -69,8 +69,8 @@
             <%= download.veteran_name %>
             <span class="cf-subtext">
               (<%= download.file_number %>)
-              <% if download.expriation_day %>
-                 - Expries on <%= download.expriation_day %>
+              <% if download.expiration_day %>
+                 - Expries on <%= download.expiration_day %>
               <% end %>
              </span>
           </td>

--- a/app/views/downloads/new.html.erb
+++ b/app/views/downloads/new.html.erb
@@ -54,8 +54,7 @@
   </div>
 
   <% if recent_downloads.exists? %>
-    <h2 class="ee-recent-searches">History</h2>
-    <p class="ee-recent-searches-note">Note: eFolders remain in your history for <b>72 hours</b></p>
+    <h2 class="ee-recent-searches">Download History</h2>
     <table class="usa-table-borderless" summary="List of recent downloads and links to download their contents">
     <thead>
       <tr class="usa-sr-only">
@@ -68,7 +67,7 @@
         <tr id="download-<%= download.id %>">
           <td>
             <%= download.veteran_name %>
-            <span class="cf-subtext">(<%= download.file_number %>)</span>
+            <span class="cf-subtext">(<%= download.file_number %>) - (Expries on <%= download.expriation_day %>)</span>
           </td>
           <td class="ee-actions-cell">
             <% if download.complete_with_errors? %>

--- a/app/views/downloads/new.html.erb
+++ b/app/views/downloads/new.html.erb
@@ -67,7 +67,7 @@
         <tr id="download-<%= download.id %>">
           <td>
             <%= download.veteran_name %>
-            <span class="cf-subtext cf-file-info">
+            <span class="cf-subtext">
               (<%= download.file_number %>)
               <% if download.expriation_day %>
                  - Expries on <%= download.expriation_day %>


### PR DESCRIPTION
Removed the text saying that downloads are deleted in 72 hours and added specific delete dates to each download.

Fixes https://github.com/department-of-veterans-affairs/appeals-pm/issues/781

**Test Plan**
-Run the test suite
-Check the text on the page:
![screen shot 2016-10-25 at 11 37 45 am](https://cloud.githubusercontent.com/assets/3885236/19693219/bf379912-9aa8-11e6-953f-7909617882ce.png)
