### PR TITLE
Git submodule commands should run from root dir

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ node {
     // since the deployment scripts are separated from the source code.
     stage ('checkout-deploy-repo') {
       sh "git clone https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/appeals-deployment"
-      dir ('./ansible/appeals-deployment') {
+      dir ('./appeals-deployment') {
         sh 'git submodule init'
         sh 'git submodule update'
 


### PR DESCRIPTION
1. The `dir` command was wrong, the correct home for ansible playbooks is now `/ansible` so for Jenkins it's `appeals-deployment/ansible`
1. There's actually no need to change directory, the git submodule commands can be run from the root.