### PR TITLE
only log sentry user if there's a current_user

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_raven_user
-    if ENV["SENTRY_DSN"]
+    if current_user && ENV["SENTRY_DSN"]
       # Raven sends error info to Sentry.
       Raven.user_context(
         id: current_user.id,


### PR DESCRIPTION
Otherwise causes 

```
NoMethodError (undefined method `id' for nil:NilClass):
  app/controllers/application_controller.rb:22:in `set_raven_user'
```

See https://github.com/department-of-veterans-affairs/caseflow-certification/blob/master/app/controllers/application_controller.rb#L39-L47 for similar implementation of this functionality. 