### PR TITLE
Allow Gem source to be overridden by env

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,4 @@
-if ENV['GEM_SERVER_URL'] == nil
-  source 'https://rubygems.org'
-else
-  source ENV['GEM_SERVER_URL']
-end
+source ENV['GEM_SERVER_URL'] || 'https://rubygems.org'
 
 gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "3b13049"
 gem "moment_timezone-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,8 @@
-source 'https://rubygems.org'
+if ENV['GEM_SERVER_URL'] == nil
+  source 'https://rubygems.org'
+else
+  source ENV['GEM_SERVER_URL']
+end
 
 gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "3b13049"
 gem "moment_timezone-rails"


### PR DESCRIPTION
Allow gem source to be overridden by `GEM_SERVER_URL`. This URL will port to an internal gem server in deployment scripts.

See also https://github.com/department-of-veterans-affairs/appeals-deployment/pull/198