### PR TITLE
Adds link to Caseflow Feedback

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -53,4 +53,15 @@ class ApplicationController < ActionController::Base
   def configure_bgs
     BGSService.user = current_user
   end
+
+  def feedback_url
+    unless ENV["CASEFLOW_FEEDBACK_URL"]
+      return "https://vaww.vaco.portal.va.gov/sites/BVA/olkm/DigitalService/Lists/Feedback/NewForm.aspx"
+    end
+
+    param_object = { redirect: request.original_url, subject: "eFolder Express" }
+
+    ENV["CASEFLOW_FEEDBACK_URL"] + "?" + param_object.to_param
+  end
+  helper_method :feedback_url
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -81,6 +81,7 @@
 
             <ul id="menu" class="cf-dropdown-menu" aria-labelledby="menu-trigger">
               <li><a href="<%= url_for controller: 'help', action: 'show'%>">Help</a></li>
+              <li><a href="<%= feedback_url %>" target="_blank">Send Feedback</a></li>
               <li>
                 <a href="<%= url_for controller: 'sessions', action: 'destroy'%>">Sign out</a>
               </li>
@@ -106,7 +107,7 @@
       <a href="http://www.va.gov/ds/">Digital Service at the <abbr title="Department of Veterans Affairs">VA</abbr></a>.
     </div>
     <div class="cf-push-right">
-      <a target="_blank" href="https://vaww.vaco.portal.va.gov/sites/BVA/olkm/DigitalService/Lists/Feedback/NewForm.aspx">
+      <a target="_blank" href="<%= feedback_url %>">
         Send feedback
       </a>
     </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,4 +42,8 @@ Rails.application.configure do
   config.s3_bucket_name = "efolder-express-staging"
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # URL for feedback app. If not present, link points to Sharepoint.
+  # This can also be in Jenkins.
+  ENV["CASEFLOW_FEEDBACK_URL"] = "https://dsva-appeals-feedback-demo-1748368704.us-gov-west-1.elb.amazonaws.com/"
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,4 +41,8 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # URL for feedback app. If not present, the feedback link defaults
+  # to Sharepoint. This can also be in Jenkins.
+  ENV["CASEFLOW_FEEDBACK_URL"] = "test.feedback.url"
 end

--- a/spec/features/send_feedback_spec.rb
+++ b/spec/features/send_feedback_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.feature "Send feedback" do
+  before do
+    User.authenticate!
+  end
+
+  scenario "Sending feedback about eFolder Express" do
+    visit "/"
+
+    expect(page).to have_link("Send feedback")
+
+    href = find_link("Send feedback")["href"]
+    expect(href.include?(ENV["CASEFLOW_FEEDBACK_URL"])).to be true
+    expect(href.include?("subject=eFolder+Express")).to be true
+    expect(href.include?("redirect=")).to be true
+  end
+end


### PR DESCRIPTION
Links point to Caseflow Feedback in the dropdown and on bottom right if an env variable is set.

To enable this in prod and uat, we'll need to set `ENV["CASEFLOW_FEEDBACK_URL"]`

Testing:
Link works locally, points to demo.
![image](https://cloud.githubusercontent.com/assets/3781835/20841648/93f69b48-b882-11e6-80d9-0c180e40b96b.png)
