### PR TITLE
Added a download to search history as soon as the search is started. …

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -86,7 +86,7 @@ class DownloadsController < ApplicationController
   end
 
   def recent_downloads
-    @recent_downloads ||= downloads.where(status: [3, 4, 5, 6])
+    @recent_downloads ||= downloads.where(status: [0, 1, 2, 3, 4, 5, 6])
   end
   helper_method :recent_downloads
 

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -415,7 +415,7 @@ RSpec.feature "Downloads" do
 
     visit "/"
 
-    expect(page).to_not have_content(pending_confirmation.file_number)
+    expect(page).to have_content(pending_confirmation.file_number)
     expect(page).to_not have_content(another_user.file_number)
 
     complete_with_errors_row = "#download-#{complete_with_errors.id}"


### PR DESCRIPTION
…Fixed test for recent downloads.
To test: Do a search and before it finishes click on eFolder Express to get back to the Search page. The search should be present in History section.
fixes #298