### PR TITLE
Add 'users' table, rename user_id to css_id in downloads and searches

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -34,6 +34,7 @@ class Search < ActiveRecord::Base
 
   def user=(user)
     self.user_id = user.id
+    self.css_id = user.id
     self.user_station_id = user.station_id
     self.email = user.email
   end
@@ -44,6 +45,7 @@ class Search < ActiveRecord::Base
     Download.active.where(
       file_number: sanitized_file_number,
       user_id: user_id,
+      css_id: css_id,
       user_station_id: user_station_id
     ).where.not(status: [1, 7])
   end

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -17,6 +17,8 @@ class Search < ActiveRecord::Base
     return true if match_existing_download
 
     self.download = download_scope.new
+    # set css_id if it is a new download
+    download.css_id = css_id
 
     return false unless validate!
 
@@ -45,7 +47,6 @@ class Search < ActiveRecord::Base
     Download.active.where(
       file_number: sanitized_file_number,
       user_id: user_id,
-      css_id: css_id,
       user_station_id: user_station_id
     ).where.not(status: [1, 7])
   end

--- a/db/migrate/20161220180421_add_css_id_to_downloads_and_searches.rb
+++ b/db/migrate/20161220180421_add_css_id_to_downloads_and_searches.rb
@@ -1,0 +1,10 @@
+class AddCssIdToDownloadsAndSearches < ActiveRecord::Migration
+  def change
+    add_column :searches, :css_id, :string
+    add_column :downloads, :css_id, :string
+
+    (Search.all + Download.all).each do |record|
+      record.update(css_id: record.user_id)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161214165833) do
+ActiveRecord::Schema.define(version: 20161220180421) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,9 +55,9 @@ ActiveRecord::Schema.define(version: 20161214165833) do
   create_table "downloads", force: :cascade do |t|
     t.string   "request_id"
     t.string   "file_number"
-    t.integer  "status",                            default: 0
-    t.datetime "created_at",                                     null: false
-    t.datetime "updated_at",                                     null: false
+    t.integer  "status",                default: 0
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
     t.string   "user_station_id"
     t.string   "user_id"
     t.integer  "lock_version"
@@ -67,6 +67,7 @@ ActiveRecord::Schema.define(version: 20161214165833) do
     t.string   "veteran_last_name"
     t.string   "veteran_first_name"
     t.string   "veteran_last_four_ssn"
+    t.string   "css_id"
   end
 
   add_index "downloads", ["completed_at"], name: "downloads_completed_at", using: :btree
@@ -75,11 +76,12 @@ ActiveRecord::Schema.define(version: 20161214165833) do
   create_table "searches", force: :cascade do |t|
     t.integer  "download_id"
     t.string   "file_number"
-    t.integer  "status",          default: 0
+    t.integer  "status",                      default: 0
     t.string   "user_station_id"
     t.string   "user_id"
     t.datetime "created_at"
-    t.string   "email",                 limit: 191
+    t.string   "email",           limit: 191
+    t.string   "css_id"
   end
 
   add_index "searches", ["created_at"], name: "searches_created_at", using: :btree

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -4,7 +4,8 @@ RSpec.feature "Downloads" do
   before do
     @user_download = Download.where(
       user_station_id: "116",
-      user_id: "123123"
+      user_id: "123123",
+      css_id: "123123"
     )
     allow(GetDownloadManifestJob).to receive(:perform_later)
     allow(GetDownloadFilesJob).to receive(:perform_later)

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -63,7 +63,8 @@ describe Search do
         @existing_download = Download.create!(
           user_id: "NICKSABAN",
           user_station_id: "200",
-          file_number: "22223333"
+          file_number: "22223333",
+          css_id: "NICKSABAN"
         )
       end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,6 +29,8 @@ Sniffybara::Driver.path_exclusions << /samlva/
 Sniffybara::Driver.configuration_file = File.expand_path("../support/VA-axe-configuration.json", __FILE__)
 Sniffybara::Driver.issue_id_exceptions += []
 
+ActiveRecord::Migration.maintain_test_schema!
+
 # Convenience methods for stubbing current user
 module StubbableUser
   module ClassMethods


### PR DESCRIPTION
1. Rename `user_id` to `css_id` in `searches` and `downloads`
2. Add `users` table, add `user_id` to `searches` and `downloads`
3. Fix code to use `css_id` instead of `user_id`

Next steps:
1. Remove columns: css_id, email, user_station_id from `searches` and `downloads`
2. Re-factor code to access user data through the `users` table 

connects #325 
