### PR TITLE
Remove user_id from searches and downloads

### DIFF
--- a/db/migrate/20161221143629_remove_user_id_from_searches_and_downloads.rb
+++ b/db/migrate/20161221143629_remove_user_id_from_searches_and_downloads.rb
@@ -1,0 +1,6 @@
+class RemoveUserIdFromSearchesAndDownloads < ActiveRecord::Migration
+  def change
+    remove_column :searches, :user_id
+    remove_column :downloads, :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161220180421) do
+ActiveRecord::Schema.define(version: 20161221143629) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,7 +59,6 @@ ActiveRecord::Schema.define(version: 20161220180421) do
     t.datetime "created_at",                        null: false
     t.datetime "updated_at",                        null: false
     t.string   "user_station_id"
-    t.string   "user_id"
     t.integer  "lock_version"
     t.datetime "manifest_fetched_at"
     t.datetime "started_at"
@@ -71,14 +70,12 @@ ActiveRecord::Schema.define(version: 20161220180421) do
   end
 
   add_index "downloads", ["completed_at"], name: "downloads_completed_at", using: :btree
-  add_index "downloads", ["user_id", "user_station_id"], name: "index_downloads_on_user_id_and_user_station_id", using: :btree
 
   create_table "searches", force: :cascade do |t|
     t.integer  "download_id"
     t.string   "file_number"
     t.integer  "status",                      default: 0
     t.string   "user_station_id"
-    t.string   "user_id"
     t.datetime "created_at"
     t.string   "email",           limit: 191
     t.string   "css_id"


### PR DESCRIPTION
Connected to #325. This is PR 3 that just removes `user_id` from the `searches` and `downloads` tables. Details are in #325. 

Testing:
* Migration ran without errors