### PR TITLE
Remove css_id, user_station_id, email from searches and downloads

### DIFF
--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -160,6 +160,7 @@ class Download < ActiveRecord::Base
 
   def self.top_users(downloads:)
     users = downloads_by_user(downloads: downloads)
+    binding.pry
     sorted = users.sort_by { |_k, v| -v[:count] }
     sorted.map { |values| { id: values[1][:email] + " " + values[0], count: values[1][:count] } }.first(3)
   end

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -160,7 +160,6 @@ class Download < ActiveRecord::Base
 
   def self.top_users(downloads:)
     users = downloads_by_user(downloads: downloads)
-    binding.pry
     sorted = users.sort_by { |_k, v| -v[:count] }
     sorted.map { |values| { id: values[1][:email] + " " + values[0], count: values[1][:count] } }.first(3)
   end

--- a/db/migrate/20170103161212_remove_css_id_station_id_from_downloads_searches.rb
+++ b/db/migrate/20170103161212_remove_css_id_station_id_from_downloads_searches.rb
@@ -1,0 +1,19 @@
+class RemoveCssIdStationIdFromDownloadsSearches < ActiveRecord::Migration
+  def up
+    remove_column :searches, :user_station_id
+    remove_column :searches, :css_id
+    remove_column :searches, :email
+
+    remove_column :downloads, :user_station_id
+    remove_column :downloads, :css_id
+  end
+
+  def down
+    add_column :searches, :user_station_id, :string
+    add_column :searches, :css_id, :string
+    add_column :searches, :email, :string
+
+    add_column :downloads, :user_station_id, :string
+    add_column :downloads, :css_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161222194523) do
+ActiveRecord::Schema.define(version: 20170103161212) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,7 +58,6 @@ ActiveRecord::Schema.define(version: 20161222194523) do
     t.integer  "status",                default: 0
     t.datetime "created_at",                        null: false
     t.datetime "updated_at",                        null: false
-    t.string   "user_station_id"
     t.integer  "lock_version"
     t.datetime "manifest_fetched_at"
     t.datetime "started_at"
@@ -66,7 +65,6 @@ ActiveRecord::Schema.define(version: 20161222194523) do
     t.string   "veteran_last_name"
     t.string   "veteran_first_name"
     t.string   "veteran_last_four_ssn"
-    t.string   "css_id"
     t.integer  "user_id"
   end
 
@@ -76,11 +74,8 @@ ActiveRecord::Schema.define(version: 20161222194523) do
   create_table "searches", force: :cascade do |t|
     t.integer  "download_id"
     t.string   "file_number"
-    t.integer  "status",                      default: 0
-    t.string   "user_station_id"
+    t.integer  "status",      default: 0
     t.datetime "created_at"
-    t.string   "email",           limit: 191
-    t.string   "css_id"
     t.integer  "user_id"
   end
 

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -79,7 +79,6 @@ RSpec.feature "Stats Dashboard" do
         completed_at: 3.hours.ago
       )
     end
-    Stats.calculate_all!
   end
 
   after { Timecop.return }

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -79,6 +79,7 @@ RSpec.feature "Stats Dashboard" do
         completed_at: 3.hours.ago
       )
     end
+    Stats.calculate_all!
   end
 
   after { Timecop.return }
@@ -108,8 +109,6 @@ RSpec.feature "Stats Dashboard" do
     expect(page).to have_content("Time to Manifest (median) 16.37 sec")
     expect(page).to have_content("Time to Files (median) 60.00 min")
     expect(page).to have_content("No Email Recorded (ROCKY - Station 203) 3 Downloads")
-    expect(page).to have_content("thunderlips@example.com (THUNDERLIPS - Station 206) 1 Download")
-    expect(page).to have_content("No Email Recorded (DRAGO - Station 205) 1 Download")
   end
 
   scenario "Toggle median to 95th percentile" do


### PR DESCRIPTION
This is the last PR to remove `css_id`, `user_station_id` and `email` from downloads and searches. 

Note: I have been debating whether I should be raising `ActiveRecord::IrreversibleMigration` in `down` method because the actual data is not reversible. 

connects #325 