### PR TITLE
Add Content-Length header to zip download

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -62,7 +62,7 @@ class DownloadsController < ApplicationController
     file_exists = @download_documents.zip_exists_locally?
     return record_not_found unless file_exists
 
-    response.headers['Content-Length'] = (download.zipfile_size || File.size(@download_documents.zip_path)).to_s
+    response.headers["Content-Length"] = (download.zipfile_size || File.size(@download_documents.zip_path)).to_s
     send_file @download_documents.zip_path
   end
 

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -55,11 +55,15 @@ class DownloadsController < ApplicationController
   end
 
   def download
-    @download_documents = DownloadDocuments.new(download: downloads.find(params[:id]))
+    download = downloads.find(params[:id])
+    @download_documents = DownloadDocuments.new(download: download)
     @download_documents.fetch_zip_from_s3
 
     file_exists = @download_documents.zip_exists_locally?
-    file_exists ? send_file(@download_documents.zip_path) : record_not_found
+    return record_not_found unless file_exists
+
+    response.headers['Content-Length'] = (download.zipfile_size || File.size(@download_documents.zip_path)).to_s
+    send_file @download_documents.zip_path
   end
 
   def record_not_found

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -124,8 +124,9 @@ class Download < ActiveRecord::Base
     end
   end
 
-  def complete!
+  def complete!(zipfile_size)
     update_attributes(
+      zipfile_size: zipfile_size,
       completed_at: Time.zone.now,
       status: errors? ? :complete_with_errors : :complete_success
     )

--- a/app/services/download_documents.rb
+++ b/app/services/download_documents.rb
@@ -128,7 +128,7 @@ class DownloadDocuments
     end
 
     @s3.store_file(@download.s3_filename, zip_path, :filepath)
-    @download.complete!
+    @download.complete!(File.size(zip_path))
 
   rescue ActiveRecord::StaleObjectError
     Rails.logger.info "Duplicate packaging detected. Download ID: #{@download.id}"

--- a/db/migrate/20170106143608_add_zipfile_size_to_downloads.rb
+++ b/db/migrate/20170106143608_add_zipfile_size_to_downloads.rb
@@ -1,0 +1,5 @@
+class AddZipfileSizeToDownloads < ActiveRecord::Migration
+  def change
+    add_column :downloads, :zipfile_size, :integer, limit: 8
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170103161212) do
+ActiveRecord::Schema.define(version: 20170106143608) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,9 +66,11 @@ ActiveRecord::Schema.define(version: 20170103161212) do
     t.string   "veteran_first_name"
     t.string   "veteran_last_four_ssn"
     t.integer  "user_id"
+    t.integer  "zipfile_size",          limit: 8
   end
 
   add_index "downloads", ["completed_at"], name: "downloads_completed_at", using: :btree
+  add_index "downloads", ["manifest_fetched_at"], name: "downloads_manifest_fetched_at", using: :btree
   add_index "downloads", ["user_id"], name: "index_downloads_on_user_id", using: :btree
 
   create_table "searches", force: :cascade do |t|

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -370,6 +370,7 @@ RSpec.feature "Downloads" do
 
     first(:link, "Download eFolder").click
     expect(page.response_headers["Content-Type"]).to eq("application/zip")
+    expect(page.response_headers["Content-Length"]).to eq(File.size(download_documents.zip_path).to_s)
   end
 
   scenario "Recent download list expires old downloads" do

--- a/spec/services/download_documents_spec.rb
+++ b/spec/services/download_documents_spec.rb
@@ -203,13 +203,14 @@ describe DownloadDocuments do
       download_documents.create_documents
       download_documents.download_and_package
 
-      Zip::File.open(Rails.root + "tmp/files/#{download.id}/#{download.package_filename}") do |zip_file|
+      zip_path = Rails.root + "tmp/files/#{download.id}/#{download.package_filename}"
+      Zip::File.open(zip_path) do |zip_file|
         expect(zip_file.glob("00010-VA 21-4185 Report of Income from Property or Business-20150101-1.pdf").first).to_not be_nil
       end
-
       expect(download).to be_complete_success
       expect(download.started_at).to eq(Time.zone.now)
       expect(download.completed_at).to eq(Time.zone.now)
+      expect(download.zipfile_size).to eq(File.size(zip_path))
     end
 
     it "works even if zip exists" do


### PR DESCRIPTION
Also, store the filesize to the database as a way of caching it because `File.size` can
take several seconds on files of ~1GB. Additionally allows us to query
the size of downloads.

connects #299

Before:
<img width="914" alt="screen shot 2017-01-06 at 9 32 43 am" src="https://cloud.githubusercontent.com/assets/1596259/21724959/605f4a44-d404-11e6-93e2-24a0bd74fc42.png">

After:
<img width="590" alt="screen shot 2017-01-06 at 10 26 17 am" src="https://cloud.githubusercontent.com/assets/1596259/21724967/678aabc4-d404-11e6-81b9-e1bc1c190a07.png">
