### PR TITLE
update styles for 404 page and add validation for entered veteran ID …

### DIFF
--- a/app/views/downloads/_confirm.html.erb
+++ b/app/views/downloads/_confirm.html.erb
@@ -7,23 +7,17 @@
 
 <% fetch_button_text = "Start retrieving eFolder" %>
 
-<div class="cf-app-segment cf-app-segment--alt">
+<div class="<%= 'cf-app-msg-screen' if @download.no_documents? %> cf-app-segment cf-app-segment--alt">
 
   <% if @download.fetching_manifest? %>
     <%= render "user_header" %>
     <%= page_loading_indicator "We are gathering the list of files in the eFolder now..." %>
 
   <% elsif @download.no_documents? %>
-    <%= render "user_header" %>
-    <div class="usa-alert usa-alert-error" role="alert">
-      <div class="usa-alert-body">
-        <h3 class="usa-alert-heading">Couldn't find documents in eFolder</h3>
-        <p class="usa-alert-text">
-          eFolder Express could not find any documents in the eFolder with ID <%= @download.file_number %>. It's possible this eFolder does not exist.
-        </p>
-        <p class="usa-alert-text"><%= link_to "Search again", root_path %>.</p>
-      </div>
-    </div>
+      <h1 class="cf-msg-screen-heading">No Documents in eFolder</h1>
+      <h2 class="cf-msg-screen-deck">eFolder Express could not find any documents in the eFolder with Veteran ID #<%= @download.file_number %>.
+        It's possible this eFolder does not exist. </h2>
+      <p class="cf-msg-screen-text">Please check the Veteran ID number and <%= link_to "search again", root_path %>.</p>
 
   <% elsif @download.vbms_connection_error? %>
     <%= render "user_header" %>

--- a/app/views/downloads/new.html.erb
+++ b/app/views/downloads/new.html.erb
@@ -3,9 +3,10 @@
     <p>
       <div class="usa-alert usa-alert-error" role="alert">
         <div class="usa-alert-body">
-          <h3 class="usa-alert-heading">Couldn't find an eFolder with that ID</h3>
+          <h3 class="usa-alert-heading">Could not find an eFolder with that Veteran ID</h3>
           <p class="usa-alert-text">
-            It looks like there's no folder with this ID. Check to make sure you entered the ID correctly and try again.
+            eFolder Express could not find an eFolder with the Veteran ID #<%= @search.file_number %>.<br />
+            Check to make sure you entered the ID correctly and try again.
           </p>
         </div>
       </div>
@@ -22,7 +23,7 @@
       </div>
     </p>
   <% end %>
-  
+
   <div class="ee-heading">
     <h1>Welcome to eFolder Express!</h1>
 

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -133,10 +133,9 @@ RSpec.feature "Downloads" do
     fill_in "Search for a Veteran ID number below to get started.", with: "abcd"
     click_button "Search"
 
-    expect(page).to have_content "Couldn't find an eFolder with that ID"
-
     search = Search.where(user: @user).first
     expect(search).to be_veteran_not_found
+    expect(page).to have_content(search.file_number)
   end
 
   scenario "Using demo mode" do
@@ -198,9 +197,10 @@ RSpec.feature "Downloads" do
     download = @user_download.create(status: :no_documents)
     visit download_path(download)
 
-    expect(page).to have_css ".usa-alert-error", text: "Couldn't find documents in eFolder"
+    expect(page).to have_css ".cf-app-msg-screen", text: "No Documents in eFolder"
+    expect(page).to have_content download.file_number
 
-    click_on "Search again"
+    click_on "search again"
     expect(page).to have_current_path(root_path)
   end
 


### PR DESCRIPTION
…number

References issue #210 

Scenario 1 (veteran ID does not exist):
![screen shot 2017-01-06 at 1 34 48 pm](https://cloud.githubusercontent.com/assets/4773320/21728589/fcc35d84-d414-11e6-8408-1ea60ece8704.png)

Scenario 2 (veteran ID exists with no documents):
![screen shot 2017-01-06 at 1 34 35 pm](https://cloud.githubusercontent.com/assets/4773320/21728599/0b367fcc-d415-11e6-8de6-b1cd8b5501b7.png)
^ I know the above scenario looks slightly different from what's presented in the issue, but this is the closest I could get with the available styles.