### PR TITLE
Progress bar: fix the progress on the second and later download attempts

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -98,6 +98,21 @@ class DownloadsController < ApplicationController
   end
   helper_method :recent_downloads
 
+  def documents_in_progress
+    @download.documents.pending
+  end
+  helper_method :documents_in_progress
+
+  def completed_documents
+    @download.documents.success
+  end
+  helper_method :completed_documents
+
+  def failed_documents
+    @download.documents.failed
+  end
+  helper_method :failed_documents
+
   def current_tab
     params[:current_tab] || (@download.complete? ? "completed" : "progress")
   end

--- a/app/jobs/demo_get_download_manifest_job.rb
+++ b/app/jobs/demo_get_download_manifest_job.rb
@@ -14,7 +14,7 @@ class DemoGetDownloadManifestJob < ActiveJob::Base
     },
     "DEMO3" => {
       manifest_load: 4,
-      num_docs: 100,
+      num_docs: 20,
       max_file_load: 4,
       error: true
     },

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -120,7 +120,7 @@ class Download < ActiveRecord::Base
   def reset!
     Download.transaction do
       update_attributes!(status: :pending_documents)
-      documents.update_all(filepath: nil, download_status: 0)
+      documents.update_all(filepath: nil, download_status: 0, completed_at: nil)
     end
   end
 

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -141,10 +141,6 @@ class Download < ActiveRecord::Base
     started_at ? (started_at + HOURS_UNTIL_EXPIRY.hours).strftime("%m/%d") : nil
   end
 
-  def calculate_remaining_documents
-    documents.where(completed_at: nil).count
-  end
-
   def number_of_documents
     documents.count
   end

--- a/app/views/downloads/_progress.html.erb
+++ b/app/views/downloads/_progress.html.erb
@@ -1,6 +1,6 @@
 <div class="cf-app-segment cf-app-segment--alt">
   <% if @download.complete? %>
-    <% if @download.documents.failed.any? %>
+    <% if failed_documents.any? %>
       <div class="usa-alert usa-alert-error" role="alert">
         <div class="usa-alert-body">
           <h3 class="usa-alert-heading">Some files couldn't be added to eFolder</h3>
@@ -52,7 +52,7 @@
     <p class="ee-fetching-files">
       <% if @download.estimated_to_complete_at %>
         Estimated time left: <%= distance_of_time_in_words(@download.estimated_to_complete_at, Time.zone.now, include_seconds: true) %>
-        (<%= @download.calculate_remaining_documents %> of <%= @download.number_of_documents %> files remaining)
+        (<%= documents_in_progress.count %> of <%= @download.number_of_documents %> files remaining)
       <% end %>
     </p>
 
@@ -65,16 +65,16 @@
 
   <div class="cf-tab-navigation">
     <button class="cf-tab <% if current_tab == "progress" %>cf-active<% end %>" data-tab="progress"
-      <% if @download.documents.where(download_status: 0).empty? %>disabled<% end %>>
-      <%= svg_icon(:progress) %> Progress (<%= @download.documents.where(download_status: 0).count %>)
+      <% if documents_in_progress.empty? %>disabled<% end %>>
+      <%= svg_icon(:progress) %> Progress (<%= documents_in_progress.count %>)
     </button>
     <button class="cf-tab <% if current_tab == "completed" %>cf-active<% end %>" data-tab="completed"
-      <% if @download.documents.where(download_status: 1).empty? %>disabled<% end %>>
-      <%= svg_icon(:success) %> Completed (<%= @download.documents.where(download_status: 1).count %>)
+      <% if completed_documents.empty? %>disabled<% end %>>
+      <%= svg_icon(:success) %> Completed (<%= completed_documents.count %>)
     </button>
     <button class="cf-tab <% if current_tab == "errored" %>cf-active<% end %>" data-tab="errored"
-      <% if @download.documents.where(download_status: 2).empty? %>disabled<% end %>>
-     <%= svg_icon(:failed) %> Errors (<%= @download.documents.where(download_status: 2).count %>)
+      <% if failed_documents.empty? %>disabled<% end %>>
+     <%= svg_icon(:failed) %> Errors (<%= failed_documents.count %>)
     </button>
   </div>
 

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -277,6 +277,36 @@ RSpec.feature "Downloads" do
     expect(page).to_not have_css ".document-pending", text: "yawn.pdf"
   end
 
+  scenario "Progress bar shows correct information" do
+    download = @user_download.create(status: :pending_documents)
+    download.documents.create(
+      vbms_filename: "yawn.pdf",
+      mime_type: "application/pdf",
+      started_at: 1.minute.ago,
+      download_status: :pending)
+    download.documents.create(
+      vbms_filename: "yawn.pdf",
+      mime_type: "application/pdf",
+      started_at: 1.minute.ago,
+      download_status: :pending)
+    download.documents.create(
+      vbms_filename: "smiley.pdf",
+      mime_type: "application/pdf",
+      started_at: 2.minutes.ago,
+      completed_at: 1.minute.ago,
+      download_status: :success)
+    download.documents.create(
+      doc_type: "129",
+      document_id: "{1234-1234-1234-5555}",
+      mime_type: "application/pdf",
+      started_at: 2.minutes.ago,
+      download_status: :failed
+    )
+
+    visit download_path(download)
+    expect(page).to have_content "2 of 4 files remaining"
+  end
+
   scenario "Completed with at least one failed document download" do
     download = @user_download.create(file_number: "12", status: :pending_documents)
     download.documents.create(vbms_filename: "roll.pdf", mime_type: "application/pdf", download_status: :failed)

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -247,37 +247,7 @@ RSpec.feature "Downloads" do
     expect(page).to have_content("Retrieving Files ...")
   end
 
-  scenario "Download progress shows documents in tabs based on their status" do
-    download = @user_download.create(status: :pending_documents)
-    download.documents.create(vbms_filename: "yawn.pdf", mime_type: "application/pdf", download_status: :pending)
-    download.documents.create(vbms_filename: "smiley.pdf", mime_type: "application/pdf", download_status: :success)
-    download.documents.create(
-      doc_type: "129",
-      document_id: "{1234-1234-1234-5555}",
-      mime_type: "application/pdf",
-      download_status: :failed
-    )
-
-    visit download_path(download)
-    expect(page).to have_css ".cf-tab.cf-active", text: "Progress (1)"
-    expect(page).to have_css ".document-pending", text: "yawn.pdf"
-    expect(page).to_not have_css ".document-success", text: "smiley.pdf"
-    expect(page).to_not have_css ".document-failed", text: "poo.pdf"
-
-    click_on "Completed"
-    expect(page).to have_css ".cf-tab.cf-active", text: "Completed (1)"
-    expect(page).to have_css ".document-success", text: "smiley.pdf"
-    expect(page).to_not have_css ".document-pending", text: "yawn.pdf"
-    expect(page).to_not have_css ".document-failed", text: "poo.pdf"
-
-    click_on "Errors"
-    expect(page).to have_css ".cf-tab.cf-active", text: "Errors (1)"
-    expect(page).to have_css ".document-failed", text: "VA 21-509 Statement of Dependency of Parents 1234-1234-1234-5555"
-    expect(page).to_not have_css ".document-success", text: "smiley.pdf"
-    expect(page).to_not have_css ".document-pending", text: "yawn.pdf"
-  end
-
-  scenario "Progress bar shows correct information" do
+  scenario "Download progress shows correct information" do
     download = @user_download.create(status: :pending_documents)
     download.documents.create(
       vbms_filename: "yawn.pdf",
@@ -304,6 +274,23 @@ RSpec.feature "Downloads" do
     )
 
     visit download_path(download)
+    expect(page).to have_css ".cf-tab.cf-active", text: "Progress (2)"
+    expect(page).to have_css ".document-pending", text: "yawn.pdf"
+    expect(page).to_not have_css ".document-success", text: "smiley.pdf"
+    expect(page).to_not have_css ".document-failed", text: "poo.pdf"
+
+    click_on "Completed"
+    expect(page).to have_css ".cf-tab.cf-active", text: "Completed (1)"
+    expect(page).to have_css ".document-success", text: "smiley.pdf"
+    expect(page).to_not have_css ".document-pending", text: "yawn.pdf"
+    expect(page).to_not have_css ".document-failed", text: "poo.pdf"
+
+    click_on "Errors"
+    expect(page).to have_css ".cf-tab.cf-active", text: "Errors (1)"
+    expect(page).to have_css ".document-failed", text: "VA 21-509 Statement of Dependency of Parents 1234-1234-1234-5555"
+    expect(page).to_not have_css ".document-success", text: "smiley.pdf"
+    expect(page).to_not have_css ".document-pending", text: "yawn.pdf"
+
     expect(page).to have_content "2 of 4 files remaining"
   end
 

--- a/spec/models/download_spec.rb
+++ b/spec/models/download_spec.rb
@@ -143,8 +143,12 @@ describe "Download" do
       expect(download.reload).to be_pending_documents
       expect(@documents.first.reload).to be_pending
       expect(@documents.first.filepath).to be_nil
+      expect(@documents.first.completed_at).to eq nil
+      expect(@documents.first.pending?).to eq true
       expect(@documents.last.reload).to be_pending
       expect(@documents.last.filepath).to be_nil
+      expect(@documents.last.completed_at).to eq nil
+      expect(@documents.last.pending?).to eq true
     end
   end
 


### PR DESCRIPTION
For a progress bar "X of XXX files remaining", use `download_status` to count in-progress documents instead of `completed_at` timestamp. Using `completed_at` would work on the first attempt to download the documents but it would not work on the second attempt because documents with `success` status were marked as completed on the first attempt. 

![image](https://cloud.githubusercontent.com/assets/3811786/22375025/79a9077e-e476-11e6-948c-3d8c34b87932.png)


connects #353 