### PR TITLE
Poll less aggressively

### DIFF
--- a/app/assets/javascripts/application/download_status.js
+++ b/app/assets/javascripts/application/download_status.js
@@ -1,22 +1,31 @@
 window.DownloadStatus = (function($) {
-  var id, currentStatus;
+  var id, currentStatus, openRequests = 0;
 
   // public
   return {
     intervalID: null,
     recheck: function() {
       if (id) {
+        openRequests++;
         $.getJSON("/downloads/" + id).then(function(download) {
+          openRequests-- ;
           if (download.status != currentStatus) { location.reload(); }
+        }, function(){
+          openRequests--;
         });
       }
     },
 
     init: function(downloadId, downloadStatus) {
+      var recheck = this.recheck;
       id = downloadId;
       currentStatus = downloadStatus;
 
-      this.intervalID = window.setInterval(this.recheck, 1000);
+      this.intervalID = window.setInterval(function() {
+        if (openRequests <= 2) {
+          recheck();
+        }
+      }, 1000);
     }
   };
 })($);

--- a/app/assets/javascripts/application/download_status.js
+++ b/app/assets/javascripts/application/download_status.js
@@ -11,6 +11,7 @@ window.DownloadStatus = (function($) {
           openRequests-- ;
           if (download.status != currentStatus) { location.reload(); }
         }, function(){
+          // error block. decrement openRequests so we send a new one.
           openRequests--;
         });
       }
@@ -22,6 +23,8 @@ window.DownloadStatus = (function($) {
       currentStatus = downloadStatus;
 
       this.intervalID = window.setInterval(function() {
+        // Only keep 2 requests open at a time, so they don't pile up
+        // due to network slowness (e.g. VA VPN)
         if (openRequests <= 2) {
           recheck();
         }


### PR DESCRIPTION
Polls less aggressively on the client side so slow connections to the VA network don't cause occasional browser hangs.

This issue was reported due to the `setInterval` in  `download_status.js`, but I fixed it in `download_progress.js` too for good measure.

Fixes #373.

Test plan:
Added a sleep to `downloads_controller#show`, and a bunch of console.logs. Verified that no more than the permitted # of requests are fired off at a time. 
```
  def show
    @download = downloads.find(params[:id])
    sleep 3
    respond_to do |format|
      format.html
      format.json { render json: @download.to_json }
    end
  end
```