### PR TITLE
Nemo/Changed rubyzip version to 1.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -318,7 +318,7 @@ GEM
       sexp_processor (~> 4.0)
     ruby_parser (3.7.3)
       sexp_processor (~> 4.1)
-    rubyzip (1.2.0)
+    rubyzip (1.2.1)
     rufus-scheduler (3.3.2)
       tzinfo
     safe_yaml (1.0.4)


### PR DESCRIPTION
This was causing build breakage due to security vulnerability issue. 