### PR TITLE
Use VBMS eFolder service v1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source ENV['GEM_SERVER_URL'] || 'https://rubygems.org'
 
-gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "fd406fe"
+gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "03a58cbc802f3a29a1e6f8a941fd3babf9eb74f5"
 
 gem "moment_timezone-rails"
 

--- a/Gemfile
+++ b/Gemfile
@@ -56,9 +56,12 @@ gem "sidekiq-cron", "~> 0.4.0"
 
 gem 'rubyzip'
 
+# use to_b method to convert string to boolean
+gem 'wannabe_bool'
+
 gem 'zaru'
 
-gem 'connect_vbms', git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "b5e43ac1ade8e02cfb6658caf13f159710db8b5c"
+gem 'connect_vbms', git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "431b529fe06770a70297f4ff1745881100e6cfe1"
 gem 'bgs', git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", :branch => 'master'
 #gem 'connect_vbms', git: 'https://github.com/department-of-veterans-affairs/connect_vbms.git'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/caseflow-commons
-  revision: fd406fe2d47e1272933d28b8b0d52e620a00cc13
-  ref: fd406fe
+  revision: 03a58cbc802f3a29a1e6f8a941fd3babf9eb74f5
+  ref: 03a58cbc802f3a29a1e6f8a941fd3babf9eb74f5
   specs:
     caseflow (0.1.6)
       aws-sdk (~> 2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,14 +21,15 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vbms.git
-  revision: b5e43ac1ade8e02cfb6658caf13f159710db8b5c
-  ref: b5e43ac1ade8e02cfb6658caf13f159710db8b5c
+  revision: 431b529fe06770a70297f4ff1745881100e6cfe1
+  ref: 431b529fe06770a70297f4ff1745881100e6cfe1
   specs:
     connect_vbms (1.0.0)
       httpclient (~> 2.8.0)
       httpi (~> 2.4)
       mail
       nokogiri (~> 1.6)
+      nori
       xmldsig (~> 0.3.1)
       xmlenc (~> 0.5.0)
 
@@ -397,6 +398,7 @@ GEM
     uglifier (3.0.4)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.1.2)
+    wannabe_bool (0.6.0)
     wasabi (3.5.0)
       httpi (~> 2.0)
       nokogiri (>= 1.4.2)
@@ -460,6 +462,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   uswds-rails!
+  wannabe_bool
   zaru
 
 BUNDLED WITH

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -35,7 +35,7 @@ class Document < ActiveRecord::Base
   end
 
   def s3_filename
-    "#{download_id}-#{id}-#{vbms_filename}"
+    "#{download_id}-#{id}.#{preferred_extension}"
   end
 
   def download_status_icon
@@ -46,7 +46,7 @@ class Document < ActiveRecord::Base
   end
 
   def type_name
-    TYPES[doc_type.to_i] || vbms_filename
+    type_description || TYPES[doc_type.to_i] || vbms_filename
   end
 
   def self.historical_average_download_rate

--- a/app/services/download_documents.rb
+++ b/app/services/download_documents.rb
@@ -2,6 +2,8 @@ require "vbms"
 require "zip"
 
 class DownloadDocuments
+  include DocumentTypes
+
   def initialize(opts = {})
     @download = opts[:download]
     @vbms_documents = DownloadDocuments.filter_vbms_documents(opts[:vbms_documents] || [])
@@ -16,6 +18,7 @@ class DownloadDocuments
           document_id: vbms_document.document_id,
           vbms_filename: vbms_document.filename,
           doc_type: vbms_document.doc_type,
+          type_description: vbms_document.try(:type_description) || TYPES[vbms_document.doc_type.to_i],
           source: vbms_document.source,
           mime_type: vbms_document.mime_type,
           received_at: vbms_document.received_at

--- a/app/services/download_documents.rb
+++ b/app/services/download_documents.rb
@@ -2,7 +2,7 @@ require "vbms"
 require "zip"
 
 class DownloadDocuments
-  include DocumentTypes
+  include Caseflow::DocumentTypes
 
   def initialize(opts = {})
     @download = opts[:download]

--- a/app/services/vbms_service.rb
+++ b/app/services/vbms_service.rb
@@ -5,7 +5,7 @@ class VBMSService
   def self.fetch_documents_for(download)
     @client ||= init_client
 
-    request = if ENV["USE_VBMS_V5"].to_b
+    request = if FeatureToggle.enabled?(:vbms_efolder_service_v1)
                 VBMS::Requests::FindDocumentSeriesReference.new(download.file_number)
               else
                 VBMS::Requests::ListDocuments.new(download.file_number)
@@ -19,7 +19,7 @@ class VBMSService
   def self.fetch_document_file(document)
     @client ||= init_client
 
-    request = if ENV["USE_VBMS_V5"].to_b
+    request = if FeatureToggle.enabled?(:vbms_efolder_service_v1)
                 VBMS::Requests::GetDocumentContent.new(document.document_id)
               else
                 VBMS::Requests::FetchDocumentById.new(document.document_id)

--- a/app/services/vbms_service.rb
+++ b/app/services/vbms_service.rb
@@ -5,7 +5,11 @@ class VBMSService
   def self.fetch_documents_for(download)
     @client ||= init_client
 
-    request = VBMS::Requests::ListDocuments.new(download.file_number)
+    request = if ENV["USE_VBMS_V5"].to_b
+                VBMS::Requests::FindDocumentSeriesReference.new(download.file_number)
+              else
+                VBMS::Requests::ListDocuments.new(download.file_number)
+              end
     @client.send_request(request)
   rescue => e
     Rails.logger.error "#{e.message}\n#{e.backtrace.join("\n")}"
@@ -15,7 +19,11 @@ class VBMSService
   def self.fetch_document_file(document)
     @client ||= init_client
 
-    request = VBMS::Requests::FetchDocumentById.new(document.document_id)
+    request = if ENV["USE_VBMS_V5"].to_b
+                VBMS::Requests::GetDocumentContent.new(document.document_id)
+              else
+                VBMS::Requests::FetchDocumentById.new(document.document_id)
+              end
     result = @client.send_request(request)
     result && result.content
   rescue => e

--- a/db/migrate/20170314163630_add_type_description_to_documents.rb
+++ b/db/migrate/20170314163630_add_type_description_to_documents.rb
@@ -1,0 +1,5 @@
+class AddTypeDescriptionToDocuments < ActiveRecord::Migration
+  def change
+    add_column :documents, :type_description, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -34,7 +34,7 @@ ActiveRecord::Schema.define(version: 20170316204433) do
 
   create_table "documents", force: :cascade do |t|
     t.integer  "download_id"
-    t.integer  "download_status", default: 0
+    t.integer  "download_status",  default: 0
     t.string   "document_id"
     t.string   "vbms_filename"
     t.string   "filepath"
@@ -42,12 +42,13 @@ ActiveRecord::Schema.define(version: 20170316204433) do
     t.string   "source"
     t.string   "mime_type"
     t.datetime "received_at"
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
     t.datetime "started_at"
     t.datetime "completed_at"
     t.integer  "lock_version"
     t.string   "type_id"
+    t.string   "type_description"
   end
 
   add_index "documents", ["download_id"], name: "index_documents_on_download_id", using: :btree

--- a/spec/jobs/get_download_manifest_job_spec.rb
+++ b/spec/jobs/get_download_manifest_job_spec.rb
@@ -28,8 +28,8 @@ describe GetDownloadManifestJob do
       before do
         allow(VBMSService).to receive(:fetch_documents_for).and_return(
           [
-            VBMS::Responses::Document.new(document_id: "1"),
-            VBMS::Responses::Document.new(document_id: "2")
+            OpenStruct.new(document_id: "1"),
+            OpenStruct.new(document_id: "2")
           ])
 
         GetDownloadManifestJob.perform_now(download)

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -17,10 +17,10 @@ describe Document do
     subject { document.s3_filename }
 
     let(:document) do
-      Document.new(vbms_filename: "keep-stamping.pdf", mime_type: "application/pdf", download_id: 45)
+      Document.new(id: 5, mime_type: "application/pdf", download_id: 45)
     end
 
-    it { is_expected.to eq("45-#{document.id}-keep-stamping.pdf") }
+    it { is_expected.to eq("#{document.download_id}-#{document.id}.pdf") }
   end
 
   context "#filename" do

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -20,7 +20,7 @@ describe Document do
       Document.new(id: 5, mime_type: "application/pdf", download_id: 45)
     end
 
-    it { is_expected.to eq("#{document.download_id}-#{document.id}.pdf") }
+    it { is_expected.to eq("45-5.pdf") }
   end
 
   context "#filename" do

--- a/spec/services/download_documents_spec.rb
+++ b/spec/services/download_documents_spec.rb
@@ -19,10 +19,10 @@ describe DownloadDocuments do
 
   let(:vbms_documents) do
     [
-      VBMS::Responses::Document.new(document_id: "1", filename: "filename.pdf", doc_type: "123",
-                                    source: "SRC", received_at: Time.zone.now,
-                                    mime_type: "application/pdf"),
-      VBMS::Responses::Document.new(document_id: "2", received_at: 1.hour.ago)
+      OpenStruct.new(document_id: "1", filename: "filename.pdf", doc_type: "123",
+                     source: "SRC", received_at: Time.zone.now,
+                     mime_type: "application/pdf", type_description: "VA 9 Appeal to Board of Appeals"),
+      OpenStruct.new(document_id: "2", received_at: 1.hour.ago)
     ]
   end
 
@@ -78,10 +78,11 @@ describe DownloadDocuments do
 
       document = Document.first
       expect(document.document_id).to eq("1")
-      expect(document.filename).to eq("VA 21-4185 Report of Income from Property or Business-20150101-1.pdf")
+      expect(document.filename).to eq("VA 9 Appeal to Board of Appeals-20150101-1.pdf")
       expect(document.doc_type).to eq("123")
       expect(document.source).to eq("SRC")
       expect(document.mime_type).to eq("application/pdf")
+      expect(document.type_description).to eq "VA 9 Appeal to Board of Appeals"
       expect(document).to be_pending
 
       expect(download.manifest_fetched_at).to eq(Time.zone.now)
@@ -113,7 +114,7 @@ describe DownloadDocuments do
       it "saves download state for each document" do
         successful_document = Document.first
         expect(successful_document).to be_success
-        expect(successful_document.filepath).to eq((Rails.root + "tmp/files/#{download.id}/00010-VA 21-4185 Report of Income from Property or Business-20150101-1.pdf").to_s)
+        expect(successful_document.filepath).to eq((Rails.root + "tmp/files/#{download.id}/00010-VA 9 Appeal to Board of Appeals-20150101-1.pdf").to_s)
         expect(successful_document.started_at).to eq(Time.zone.now)
         expect(successful_document.completed_at).to eq(Time.zone.now)
 
@@ -138,12 +139,12 @@ describe DownloadDocuments do
 
       let(:vbms_documents) do
         [
-          VBMS::Responses::Document.new(document_id: "1", filename: "filename.pdf", doc_type: "123",
-                                        source: "SRC", received_at: Time.zone.now,
-                                        mime_type: "application/pdf"),
-          VBMS::Responses::Document.new(document_id: "1", filename: "filename.pdf", doc_type: "123",
-                                        source: "SRC", received_at: Time.zone.now,
-                                        mime_type: "application/pdf")
+          OpenStruct.new(document_id: "1", filename: "filename.pdf", doc_type: "123",
+                         source: "SRC", received_at: Time.zone.now,
+                         mime_type: "application/pdf"),
+          OpenStruct.new(document_id: "1", filename: "filename.pdf", doc_type: "123",
+                         source: "SRC", received_at: Time.zone.now,
+                         mime_type: "application/pdf")
         ]
       end
 
@@ -163,9 +164,9 @@ describe DownloadDocuments do
     let(:file) { IO.binread(Rails.root + "spec/support/test.pdf") }
     let(:vbms_documents) do
       [
-        VBMS::Responses::Document.new(document_id: "1", filename: "keep-stamping.pdf", doc_type: "123",
-                                      source: "SRC", received_at: Time.zone.now,
-                                      mime_type: "application/pdf")
+        OpenStruct.new(document_id: "1", filename: "keep-stamping.pdf", doc_type: "123",
+                       source: "SRC", received_at: Time.zone.now,
+                       mime_type: "application/pdf")
       ]
     end
 
@@ -227,10 +228,10 @@ describe DownloadDocuments do
     context "when one document errors" do
       let(:vbms_documents) do
         [
-          VBMS::Responses::Document.new(document_id: "1", filename: "filename.pdf", doc_type: "123",
-                                        source: "SRC", received_at: Time.zone.now,
-                                        mime_type: "application/pdf"),
-          VBMS::Responses::Document.new(document_id: "2")
+          OpenStruct.new(document_id: "1", filename: "filename.pdf", doc_type: "123",
+                         source: "SRC", received_at: Time.zone.now,
+                         mime_type: "application/pdf"),
+          OpenStruct.new(document_id: "2")
         ]
       end
 
@@ -264,8 +265,8 @@ describe DownloadDocuments do
     context "when some vbms files aren't supported" do
       let(:vbms_documents) do
         [
-          VBMS::Responses::Document.new(document_id: "1", doc_type: "352"),
-          VBMS::Responses::Document.new(document_id: "2", doc_type: "999981")
+          OpenStruct.new(document_id: "1", doc_type: "352"),
+          OpenStruct.new(document_id: "2", doc_type: "999981")
         ]
       end
 


### PR DESCRIPTION
1. Connect to VBMS eFolder service v1 if `USE_VBMS_V5` is enabled
2. Add `type_description` column to `documents`
3. Make the code work for both versions. 
4. Create subsequent tickets that will be implemented when we switch to a new service completely.
[#416](https://github.com/department-of-veterans-affairs/caseflow-efolder/issues/416)
[#415](https://github.com/department-of-veterans-affairs/caseflow-efolder/issues/415)

connects #418 