### PR TITLE
Anya/395 capture document errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,9 @@ gem 'zaru'
 
 gem 'redis-namespace'
 
-gem 'connect_vbms', git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "df0adf84d1ffa643195ad68edc91b7d4e4142a95"
+gem "ruby-progressbar"
+
+gem 'connect_vbms', git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "5eef09470e0f91a2632128d3937b8ba8b3cb18ab"
 gem 'bgs', git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", :branch => 'master'
 #gem 'connect_vbms', git: 'https://github.com/department-of-veterans-affairs/connect_vbms.git'
 

--- a/Gemfile
+++ b/Gemfile
@@ -63,8 +63,6 @@ gem 'zaru'
 
 gem 'redis-namespace'
 
-gem "ruby-progressbar"
-
 gem 'connect_vbms', git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "5eef09470e0f91a2632128d3937b8ba8b3cb18ab"
 gem 'bgs', git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", :branch => 'master'
 #gem 'connect_vbms', git: 'https://github.com/department-of-veterans-affairs/connect_vbms.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,8 +21,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vbms.git
-  revision: df0adf84d1ffa643195ad68edc91b7d4e4142a95
-  ref: df0adf84d1ffa643195ad68edc91b7d4e4142a95
+  revision: 5eef09470e0f91a2632128d3937b8ba8b3cb18ab
+  ref: 5eef09470e0f91a2632128d3937b8ba8b3cb18ab
   specs:
     connect_vbms (1.0.0)
       httpclient (~> 2.8.0)
@@ -408,7 +408,7 @@ GEM
     websocket-extensions (0.1.2)
     xmldsig (0.3.2)
       nokogiri
-    xmlenc (0.6.8)
+    xmlenc (0.6.9)
       activemodel (>= 3.0.0)
       activesupport (>= 3.0.0)
       nokogiri (>= 1.6.0, < 2.0.0)

--- a/app/services/download_documents.rb
+++ b/app/services/download_documents.rb
@@ -53,8 +53,11 @@ class DownloadDocuments
         fetch_document(document, index)
         @download.touch
 
-      rescue VBMS::ClientError
-        document.update_attributes!(download_status: :failed)
+      rescue VBMS::ClientError => e
+        document.update_attributes!(
+          download_status: :failed,
+          error_message: "VBMS::ClientError::#{e.message}\n#{e.backtrace.join("\n")}"
+        )
         @download.touch
 
       rescue ActiveRecord::StaleObjectError

--- a/app/services/pdf_service.rb
+++ b/app/services/pdf_service.rb
@@ -15,7 +15,8 @@ class PdfService
     # pdftk will crash on corrupt PDFs with the "Error: Unable to find file";
     # if this happens, write the file without attributes
     unless stderr.empty?
-      Rails.logger.warn("cannot write pdf of size #{contents.size} via #{command}: #{stderr}")
+      # contents might come back as nil
+      Rails.logger.warn("cannot write pdf of size #{contents.try(:size).to_i} via #{command}: #{stderr}")
       File.open(filename, "wb") do |f|
         f.write(contents)
       end

--- a/app/services/vbms_service.rb
+++ b/app/services/vbms_service.rb
@@ -13,7 +13,7 @@ class VBMSService
     @client.send_request(request)
   rescue => e
     Rails.logger.error "#{e.message}\n#{e.backtrace.join("\n")}"
-    raise VBMS::ClientError
+    raise VBMS::ClientError, e
   end
 
   def self.fetch_document_file(document)
@@ -28,7 +28,7 @@ class VBMSService
     result && result.content
   rescue => e
     Rails.logger.error "#{e.message}\n#{e.backtrace.join("\n")}"
-    raise VBMS::ClientError
+    raise VBMS::ClientError, e
   end
 
   def self.vbms_config

--- a/db/migrate/20170406154656_add_error_message_to_documents.rb
+++ b/db/migrate/20170406154656_add_error_message_to_documents.rb
@@ -1,0 +1,5 @@
+class AddErrorMessageToDocuments < ActiveRecord::Migration
+  def change
+    add_column :documents, :error_message, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 20170407164842) do
     t.integer  "lock_version"
     t.string   "type_description"
     t.string   "type_id"
+    t.text     "error_message"
   end
 
   add_index "documents", ["download_id"], name: "index_documents_on_download_id", using: :btree

--- a/spec/services/download_documents_spec.rb
+++ b/spec/services/download_documents_spec.rb
@@ -123,7 +123,7 @@ describe DownloadDocuments do
         errored_document = Document.last
         expect(errored_document).to be_failed
         expect(errored_document.started_at).to eq(Time.zone.now)
-        expect(errored_document.error_message).to_not eq nil
+        expect(errored_document.error_message).to match /Failure/
       end
 
       it "stores successful document in s3" do

--- a/spec/services/download_documents_spec.rb
+++ b/spec/services/download_documents_spec.rb
@@ -104,7 +104,7 @@ describe DownloadDocuments do
     context "when one file errors" do
       before do
         allow(VBMSService).to receive(:fetch_document_file) do |document|
-          fail VBMS::ClientError if document.document_id != "1"
+          fail VBMS::ClientError, "Failure" if document.document_id != "1"
           file
         end
 
@@ -118,10 +118,12 @@ describe DownloadDocuments do
         expect(successful_document.filepath).to eq((Rails.root + "tmp/files/#{download.id}/00010-VA 9 Appeal to Board of Appeals-20150101-1.pdf").to_s)
         expect(successful_document.started_at).to eq(Time.zone.now)
         expect(successful_document.completed_at).to eq(Time.zone.now)
+        expect(successful_document.error_message).to eq nil
 
         errored_document = Document.last
         expect(errored_document).to be_failed
         expect(errored_document.started_at).to eq(Time.zone.now)
+        expect(errored_document.error_message).to_not eq nil
       end
 
       it "stores successful document in s3" do

--- a/spec/services/download_documents_spec.rb
+++ b/spec/services/download_documents_spec.rb
@@ -123,7 +123,7 @@ describe DownloadDocuments do
         errored_document = Document.last
         expect(errored_document).to be_failed
         expect(errored_document.started_at).to eq(Time.zone.now)
-        expect(errored_document.error_message).to match /Failure/
+        expect(errored_document.error_message).to match(/Failure/)
       end
 
       it "stores successful document in s3" do


### PR DESCRIPTION
1. Keep track of document errors in the documents table. 
2. Better handling of empty documents will lead to much less document errors. I created a ticket for Lara to determine what to do with empty documents. 

connects #395 