### PR TITLE
Remove magnifying glass icon on "Search" button

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -175,3 +175,9 @@ table td {
 .cf-help-divider {
   margin: 5px 25px 30px auto;
 }
+
+// candidate for commons
+.usa-search [type="submit"] {
+  background-image: none;
+  background-image: none;
+}

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -179,5 +179,4 @@ table td {
 // candidate for commons
 .usa-search [type="submit"] {
   background-image: none;
-  background-image: none;
 }


### PR DESCRIPTION
Removes the magnifying that was underneath the eFolder "Search" button.
Connects https://github.com/department-of-veterans-affairs/caseflow/issues/1606
<img width="981" alt="screen shot 2017-05-12 at 2 03 21 pm" src="https://cloud.githubusercontent.com/assets/4773320/26010691/f0b2c9e8-371b-11e7-811a-e2a3cbdbe56d.png">
