### PR TITLE
Use Jenkins deploy node for deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ def APP_VERSION = env.APP_VERSION ?: 'HEAD';
 /************************ Common Pipeline boilerplate ************************/
 
 def commonPipeline;
-node {
+node('deploy') {
 
   // withCredentials allows us to expose the secrets in Credential Binding
   // Plugin to get the credentials from Jenkins secrets.


### PR DESCRIPTION
This minor change force the deployment pipeline to use Jenkins deploy node. This is needed because the Deploy node is in Utility VPC, and has connectivity to UAT and Prod VPC.