### PR TITLE
Implement FE changes for VVA

### DIFF
--- a/app/assets/stylesheets/_download.scss
+++ b/app/assets/stylesheets/_download.scss
@@ -12,7 +12,7 @@
 }
 
 .ee-filename-row {
-  width: 80%;
+  width: 70%;
 }
 
 .ee-doc-id-row {

--- a/app/jobs/demo_get_download_files_job.rb
+++ b/app/jobs/demo_get_download_files_job.rb
@@ -1,9 +1,10 @@
-class FakeVBMSService
+class FakeService
   cattr_accessor :errors, :max_time
 
   def self.fetch_document_file(_document)
-    sleep(rand(FakeVBMSService.max_time))
-    fail VBMS::ClientError if FakeVBMSService.errors && rand(5) == 3
+    sleep(rand(FakeService.max_time))
+    fail VBMS::ClientError if FakeService.errors && rand(5) == 3
+    fail VVA::ClientError if FakeService.errors && rand(5) == 2
     "this is some document, woah!"
   end
 end
@@ -14,10 +15,10 @@ class DemoGetDownloadFilesJob < ActiveJob::Base
   def perform(download)
     demo = DemoGetDownloadManifestJob::DEMOS[download.file_number] || DemoGetDownloadManifestJob::DEMOS["DEMODEFAULT"]
 
-    FakeVBMSService.errors = demo[:error]
-    FakeVBMSService.max_time = demo[:max_file_load]
+    FakeService.errors = demo[:error]
+    FakeService.max_time = demo[:max_file_load]
 
-    download_documents = DownloadDocuments.new(download: download, vbms_service: FakeVBMSService)
+    download_documents = DownloadDocuments.new(download: download, vbms_service: FakeService, vva_service: FakeService)
     download_documents.download_and_package
   end
 end

--- a/app/jobs/demo_get_download_files_job.rb
+++ b/app/jobs/demo_get_download_files_job.rb
@@ -1,10 +1,10 @@
-class FakeService
+class FakeDocumentService
   cattr_accessor :errors, :max_time
 
   def self.fetch_document_file(_document)
-    sleep(rand(FakeService.max_time))
-    fail VBMS::ClientError if FakeService.errors && rand(5) == 3
-    fail VVA::ClientError if FakeService.errors && rand(5) == 2
+    sleep(rand(FakeDocumentService.max_time))
+    fail VBMS::ClientError if FakeDocumentService.errors && rand(5) == 3
+    fail VVA::ClientError if FakeDocumentService.errors && rand(5) == 2
     "this is some document, woah!"
   end
 end
@@ -15,10 +15,14 @@ class DemoGetDownloadFilesJob < ActiveJob::Base
   def perform(download)
     demo = DemoGetDownloadManifestJob::DEMOS[download.file_number] || DemoGetDownloadManifestJob::DEMOS["DEMODEFAULT"]
 
-    FakeService.errors = demo[:error]
-    FakeService.max_time = demo[:max_file_load]
+    FakeDocumentService.errors = demo[:error]
+    FakeDocumentService.max_time = demo[:max_file_load]
 
-    download_documents = DownloadDocuments.new(download: download, vbms_service: FakeService, vva_service: FakeService)
+    download_documents = DownloadDocuments.new(
+      download: download,
+      vbms_service: FakeDocumentService,
+      vva_service: FakeDocumentService
+    )
     download_documents.download_and_package
   end
 end

--- a/app/jobs/demo_get_download_manifest_job.rb
+++ b/app/jobs/demo_get_download_manifest_job.rb
@@ -88,7 +88,8 @@ class DemoGetDownloadManifestJob < ActiveJob::Base
         type_id: Document::TYPES.keys.sample,
         document_id: "{#{SecureRandom.hex(4).upcase}-#{SecureRandom.hex(2).upcase}-#{SecureRandom.hex(2).upcase}-#{SecureRandom.hex(2).upcase}-#{SecureRandom.hex(6).upcase}}",
         mime_type: "text/plain",
-        received_at: (i * 2).days.ago
+        received_at: (i * 2).days.ago,
+        downloaded_from: rand(5) == 3 ? "VVA" : "VBMS"
       )
     end
 

--- a/app/views/downloads/_confirm.html.erb
+++ b/app/views/downloads/_confirm.html.erb
@@ -60,6 +60,7 @@
       <thead>
         <tr>
           <th scope="col">Filename</th>
+          <th scope="col">Source</th>
           <th scope="col">Receipt Date</th>
         </tr>
       </thead>
@@ -67,6 +68,7 @@
         <% @download.documents.each do |document| %>
           <tr>
             <td class="ee-filename-row"><%= document.type_name %></td>
+            <td><%= document.downloaded_from %> </td>
             <td><%= document.received_at && document.received_at.to_formatted_s(:short_date) %></td>
           </tr>
         <% end %>

--- a/app/views/downloads/_progress.html.erb
+++ b/app/views/downloads/_progress.html.erb
@@ -25,9 +25,11 @@
             All of the documents in the VBMS eFolder for #<%= @download.file_number %> are ready to download.
             Click the "Download eFolder" button below.
           </p>
-          <p>
-            (Remember that Virtual VA documents are not included in this download)
-          </p>
+          <% unless FeatureToggle.enabled?(:vva_service) %>
+            <p>
+              (Remember that Virtual VA documents are not included in this download)
+            </p>
+          <% end %>
           <%= link_to "Download eFolder", download_download_path(@download), {class: "usa-button"} %>
         </div>
       </div>
@@ -104,6 +106,7 @@
           <% if current_tab == "errored" %>
             <th scope="col">Document ID</th>
           <% end %>
+          <th scope="col">Source</th>
           <th scope="col">Receipt Date</th>
         </tr>
       </thead>
@@ -118,6 +121,7 @@
             <% if current_tab == "errored" %>
               <td class="ee-doc-id-row"><%= document.filename_doc_id %></td>
             <% end %>
+            <td><%= document.downloaded_from %></td>
             <td><%= document.received_at && document.received_at.to_formatted_s(:short_date) %></td>
           </tr>
         <% end %>

--- a/app/views/downloads/new.html.erb
+++ b/app/views/downloads/new.html.erb
@@ -48,10 +48,11 @@
         </button>
       </div>
     <% end %>
-
-    <p class="cf-txt-c">
-      <em>Note: eFolder Express does not currently support Virtual VA documents.</em>
-    </p>
+    <% unless FeatureToggle.enabled?(:vva_service) %>
+      <p class="cf-txt-c">
+        <em>Note: eFolder Express does not currently support Virtual VA documents.</em>
+      </p>
+    <% end %>
   </div>
 
   <% if recent_downloads.exists? %>

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -264,8 +264,8 @@ RSpec.feature "Downloads" do
 
     expect(page).to have_content "eFolder Express found 2 files in eFolder #3456"
     expect(page).to have_content "Steph Curry (3456)"
-    expect(page).to have_content "yawn.pdf 09/06/2015"
-    expect(page).to have_content "smiley.pdf 01/19/2015"
+    expect(page).to have_content "yawn.pdf VBMS 09/06/2015"
+    expect(page).to have_content "smiley.pdf VBMS 01/19/2015"
     expect(page.evaluate_script("window.DownloadStatus.intervalID")).to be_falsey
     first(:button, "Start retrieving eFolder").click
 


### PR DESCRIPTION
This is an FE piece for VVA. VVA is hidden behind the Feature Flag `vva_service` in UAT and Prod. Per agreement with Lara, `source` column will not be hidden behind the feature flag so it will be visible once this is merged. 

connects #488 

Example when the VVA flag is enabled:
![image](https://user-images.githubusercontent.com/3811786/27100480-47de121a-504c-11e7-8db8-bdd431167612.png)
