### PR TITLE
Anya/375 sikekiq not found

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,6 +106,7 @@ group :test do
   # to save and open specific page in capybara tests
   gem 'launchy'
   gem 'database_cleaner'
+  gem 'test_after_commit'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -393,6 +393,8 @@ GEM
     temple (0.7.7)
     terminal-table (1.7.3)
       unicode-display_width (~> 1.1.1)
+    test_after_commit (1.1.0)
+      activerecord (>= 3.2)
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
       ref
@@ -473,6 +475,7 @@ DEPENDENCIES
   simplecov
   sniffybara!
   sqlite3
+  test_after_commit
   therubyracer
   therubyrhino
   timecop

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -40,8 +40,8 @@ class Download < ActiveRecord::Base
     end
   end
 
-  # Sidekiq is finding out about the job before the database record has it committed,
-  # so use after_commit on: :create.
+  # Wait for the record to be committed to the DB and only then start the Sidekiq job
+  # Here is the issue: https://github.com/mperham/sidekiq/issues/322
   after_commit :start_fetch_manifest, on: :create
 
   def veteran_name

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -187,11 +187,7 @@ class Download < ActiveRecord::Base
   private
 
   def start_fetch_manifest
-    if demo?
-      DemoGetDownloadManifestJob.perform_later(self)
-    else
-      GetDownloadManifestJob.perform_later(self)
-    end
+    demo? ? DemoGetDownloadManifestJob.perform_later(self) : GetDownloadManifestJob.perform_later(self)
   end
 
   def calculate_estimated_to_complete_at

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -42,7 +42,7 @@ class Download < ActiveRecord::Base
 
   # Sidekiq is finding out about the job before the database record has it committed,
   # so use after_commit on: :create.
-  after_commit :start_fetch_manifest, :on => :create
+  after_commit :start_fetch_manifest, on: :create
 
   def veteran_name
     "#{veteran_first_name} #{veteran_last_name}" if veteran_last_name

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -25,7 +25,6 @@ class Search < ActiveRecord::Base
       update_attributes!(status: :download_created)
       download.save!
     end
-    start_fetch_manifest
     true
   end
 
@@ -63,13 +62,5 @@ class Search < ActiveRecord::Base
     end
 
     true
-  end
-
-  def start_fetch_manifest
-    if download.demo?
-      DemoGetDownloadManifestJob.perform_later(download)
-    else
-      GetDownloadManifestJob.perform_later(download)
-    end
   end
 end

--- a/spec/models/download_spec.rb
+++ b/spec/models/download_spec.rb
@@ -55,6 +55,19 @@ describe "Download" do
     end
   end
 
+  context ".create" do
+    subject { Download.create(file_number: file_number) }
+
+    before do
+      allow(GetDownloadManifestJob).to receive(:perform_later)
+    end
+
+    it "creates a job to fetch the download manifest" do
+      subject
+      expect(GetDownloadManifestJob).to have_received(:perform_later)
+    end
+  end
+
   context "veteran_name" do
     subject { download.veteran_name }
     it { is_expected.to eq("Stan Lee") }

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -48,11 +48,6 @@ describe Search do
       expect(search.download.user.station_id).to eq("200")
     end
 
-    it "creates a job to fetch the download manifest" do
-      expect(subject).to be_truthy
-      expect(GetDownloadManifestJob).to have_received(:perform_later)
-    end
-
     it "saves its status as download_created" do
       expect(subject).to be_truthy
       expect(search.reload).to be_download_created


### PR DESCRIPTION
connects #375 

1. `Record not found` issue -  Sidekiq is finding out about the job before the database record has it committed, so use after_commit on: :create.
2. Add test_after_commit gem to actually test `after_commit` hook in rspec.

