### PR TITLE
Fixing typo

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,7 +80,7 @@ Rails.application.configure do
   config.s3_enabled = true
   config.s3_bucket_name = ENV["AWS_BUCKET_NAME"]
 
-  conig.api_key = ENV["EFOLDER_API_KEY"]
+  config.api_key = ENV["EFOLDER_API_KEY"]
 
   config.google_analytics_account = "UA-74789258-2"
 end


### PR DESCRIPTION
config was spelled conig in production.rb.