### PR TITLE
Re-enable GA

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -47,16 +47,14 @@
 
 -->
 
-  <% if !Rails.configuration.analytics_account.nil? %>
-      <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-        ga('create', '<%= Rails.configuration.analytics_account %>', 'auto');
-        ga('send', 'pageview', '<%= current_ga_path %>');
-      </script>
-  <% end %>
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    ga('create', '<%= Rails.configuration.analytics_account %>', 'auto');
+    ga('send', 'pageview', '<%= current_ga_path %>');
+  </script>
 
   <%= favicon_link_tag %>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,6 @@ module CaseflowEfolder
 
     config.cache_store = :redis_store, Rails.application.secrets.redis_url_cache, { expires_in: 24.hours }
 
-    # default to no analytics (production only)
-    config.analytics_account = nil
+    config.analytics_account = "UA-74789258-2"
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,6 +81,4 @@ Rails.application.configure do
   config.s3_bucket_name = ENV["AWS_BUCKET_NAME"]
 
   config.api_key = ENV["EFOLDER_API_KEY"]
-
-  config.google_analytics_account = "UA-74789258-2"
 end


### PR DESCRIPTION
Connect #548.

To test, log into GA and see metrics showing up. For instance:

![image](https://user-images.githubusercontent.com/829827/28538824-9b2beca2-707d-11e7-8f08-fd46d4f19143.png)

Our past implementation tried to avoid sending data when running not in production. I suspect that additional complexity is why we accidentally were not sending data for anything, including production. It's dangerous when developers cannot verify the correct behavior locally.

Instead, we log all data. In the GA interface, we can use filtering tools to limit queries to only be the prod domain.