### PR TITLE
Exposing HTTP header for Reader

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -32,10 +32,14 @@ module CaseflowEfolder
     # from eFolder Express to reduce load on Caseflow. Since Caseflow and eFolder
     # are in different sub-domains, we need to enable CORS.
     config.middleware.insert_before 0, "Rack::Cors" do
-      allow do
-        origins (ENV["CORS_URL"] || "http://localhost:3000")
-        resource '*', headers: :any, methods: :any, credentials: true
-      end
+        allow do
+          origins ENV["CORS_URL"]
+          resource '/api/v1/*', 
+            :headers     => :any, 
+            :methods     => :get, 
+            :expose      => ['Accept-Ranges'],
+            :credentials => true
+        end
     end
 
     config.active_job.queue_adapter = :sidekiq

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,5 +1,4 @@
 require File.expand_path('../boot', __FILE__)
-
 require 'rails/all'
 
 # Require the gems listed in Gemfile, including any gems
@@ -31,13 +30,21 @@ module CaseflowEfolder
     # Currently the Caseflow client makes calls to get document content directly
     # from eFolder Express to reduce load on Caseflow. Since Caseflow and eFolder
     # are in different sub-domains, we need to enable CORS.
+    cors_origins = ENV["CORS_URL"]
+
+    # Enable localhost CORS for development and test environments and get rid of null values
+    # if the environment variable isn't set
+    cors_origins ||= "http://localhost:3000" unless Rails.env.production?
+
     config.middleware.insert_before 0, "Rack::Cors" do
         allow do
-          origins ENV["CORS_URL"]
-          resource '/api/v1/*', 
-            :headers     => :any, 
-            :methods     => :get, 
-            :expose      => ['Accept-Ranges'],
+          origins cors_origins
+          resource '/api/v1/*',
+            :headers     => :any, # Headers to allow in the request
+            :methods     => :get,
+            # when making a cross-origin request, only Cache-Control, Content-Language, 
+            # Content-Type, Expires, Last-Modified, Pragma are exposed. PDF.js requires some additional headers to be sent as well
+            :expose      => ['content-range, content-length, accept-ranges'], # Headers to send in response
             :credentials => true
         end
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,12 +40,12 @@ module CaseflowEfolder
         allow do
           origins cors_origins
           resource '/api/v1/*',
-            :headers     => :any, # Headers to allow in the request
-            :methods     => :get,
+            headers:     :any, # Headers to allow in the request
+            methods:     :get,
             # when making a cross-origin request, only Cache-Control, Content-Language, 
             # Content-Type, Expires, Last-Modified, Pragma are exposed. PDF.js requires some additional headers to be sent as well
-            :expose      => ['content-range, content-length, accept-ranges'], # Headers to send in response
-            :credentials => true
+            expose:      ['content-range, content-length, accept-ranges'], # Headers to send in response
+            credentials: true
         end
     end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,6 +42,20 @@ Rails.application.configure do
   config.s3_enabled = !ENV['AWS_ACCESS_KEY_ID'].nil?
   config.s3_bucket_name = "dsva-appeals-efolder-uat"
 
+  # Currently the Caseflow client makes calls to get document content directly
+  # from eFolder Express to reduce load on Caseflow. Since Caseflow and eFolder
+  # are in different sub-domains, we need to enable CORS.
+   config.middleware.insert_before 0, "Rack::Cors" do
+        allow do
+          origins ENV["CORS_URL"], "http://localhost:3000", "127.0.0.1:3000"
+          resource '/api/v1/*', 
+            :headers     => :any, 
+            :methods     => :get, 
+            :expose      => ['Accept-Ranges'],
+            :credentials => true
+        end
+    end
+
   config.api_key = "token"
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,20 +42,6 @@ Rails.application.configure do
   config.s3_enabled = !ENV['AWS_ACCESS_KEY_ID'].nil?
   config.s3_bucket_name = "dsva-appeals-efolder-uat"
 
-  # Currently the Caseflow client makes calls to get document content directly
-  # from eFolder Express to reduce load on Caseflow. Since Caseflow and eFolder
-  # are in different sub-domains, we need to enable CORS.
-   config.middleware.insert_before 0, "Rack::Cors" do
-        allow do
-          origins ENV["CORS_URL"], "http://localhost:3000", "127.0.0.1:3000"
-          resource '/api/v1/*', 
-            :headers     => :any, 
-            :methods     => :get, 
-            :expose      => ['Accept-Ranges'],
-            :credentials => true
-        end
-    end
-
   config.api_key = "token"
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true


### PR DESCRIPTION
- Connects #556 
- Connects https://github.com/department-of-veterans-affairs/caseflow/issues/2340

- Exposes `Accept-Ranges` so PDF.js can read the value
- Limits access through CORS

To test:
- Run Caseflow on port 3000, and eFolder on port 4000. Enable the feature flag and make sure we get the documents from eFolder.
    - Enable the feature flag by executing `FeatureToggle.enable!(:efolder_docs_api)` in the rails console for Caseflow
- Load the document list (http://localhost:3000/reader/appeal/reader_id1/documents) and click on any document in the list
- Ensure all requests to efolder complete with a HTTP status of 200 and there are no errors stating `Refused to get unsafe header "Accept-Ranges"`