### PR TITLE
API Error Cases

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -42,8 +42,8 @@ class Api::V1::ApplicationController < BaseController
     # passed in the header. Otherwise we try to create the current user from the session
     # and authorize based on the presence of the Reader role.
     if authenticate_with_token
-      return missing_header('Station ID') unless station_id
-      return missing_header('CSS ID') unless css_id
+      return missing_header("Station ID") unless station_id
+      return missing_header("CSS ID") unless css_id
       @current_user = User.find_or_create_by(css_id: css_id, station_id: station_id)
     elsif !user_has_role
       unauthorized

--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -20,7 +20,7 @@ class Api::V1::ApplicationController < BaseController
     render json: { status: "unauthorized" }, status: 401
   end
 
-  def bad_request(header)
+  def missing_header(header)
     render json: { status: "missing header: #{header}" }, status: 400
   end
 
@@ -42,8 +42,8 @@ class Api::V1::ApplicationController < BaseController
     # passed in the header. Otherwise we try to create the current user from the session
     # and authorize based on the presence of the Reader role.
     if authenticate_with_token
-      return bad_request('Station ID') unless station_id
-      return bad_request('CSS ID') unless css_id
+      return missing_header('Station ID') unless station_id
+      return missing_header('CSS ID') unless css_id
       @current_user = User.find_or_create_by(css_id: css_id, station_id: station_id)
     elsif !user_has_role
       unauthorized

--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -20,6 +20,10 @@ class Api::V1::ApplicationController < BaseController
     render json: { status: "unauthorized" }, status: 401
   end
 
+  def bad_request(header)
+    render json: { status: "missing header: #{header}" }, status: 400
+  end
+
   def authenticate_with_token
     @authenticate_with_token ||= authenticate_with_http_token do |token, _options|
       token == Rails.application.config.api_key
@@ -38,6 +42,8 @@ class Api::V1::ApplicationController < BaseController
     # passed in the header. Otherwise we try to create the current user from the session
     # and authorize based on the presence of the Reader role.
     if authenticate_with_token
+      return bad_request('Station ID') unless station_id
+      return bad_request('CSS ID') unless css_id
       @current_user = User.find_or_create_by(css_id: css_id, station_id: station_id)
     elsif !user_has_role
       unauthorized

--- a/app/controllers/api/v1/files_controller.rb
+++ b/app/controllers/api/v1/files_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::FilesController < Api::V1::ApplicationController
   def index
-    return bad_request("File Number") unless id
+    return missing_header("File Number") unless id
     render json: json_files
   end
 

--- a/app/controllers/api/v1/files_controller.rb
+++ b/app/controllers/api/v1/files_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::FilesController < Api::V1::ApplicationController
   def index
+    return bad_request("File Number") unless id
     render json: json_files
   end
 

--- a/spec/requests/api/v1/file_spec.rb
+++ b/spec/requests/api/v1/file_spec.rb
@@ -133,6 +133,56 @@ describe "File API v1", type: :request do
     end
   end
 
+  context "When headers are missing" do
+    context "missing CSS ID" do
+      let(:headers) do
+        {
+          "HTTP_FILE_NUMBER" => veteran_id,
+          "HTTP_STATION_ID" => user.station_id,
+          "HTTP_AUTHORIZATION" => "Token token=#{token}"
+        }
+      end
+
+      it "returns bad request" do
+        get "/api/v1/files", nil, headers
+        expect(response.code).to eq("400")
+        expect(response.body).to eq("{\"status\":\"missing header: CSS ID\"}")
+      end
+    end
+
+    context "missing Station ID" do
+      let(:headers) do
+        {
+          "HTTP_FILE_NUMBER" => veteran_id,
+          "HTTP_CSS_ID" => user.css_id,
+          "HTTP_AUTHORIZATION" => "Token token=#{token}"
+        }
+      end
+
+      it "returns bad request" do
+        get "/api/v1/files", nil, headers
+        expect(response.code).to eq("400")
+        expect(response.body).to eq("{\"status\":\"missing header: Station ID\"}")
+      end
+    end
+
+    context "missing File Number" do
+      let(:headers) do
+        {
+          "HTTP_STATION_ID" => user.station_id,
+          "HTTP_CSS_ID" => user.css_id,
+          "HTTP_AUTHORIZATION" => "Token token=#{token}"
+        }
+      end
+
+      it "returns bad request" do
+        get "/api/v1/files", nil, headers
+        expect(response.code).to eq("400")
+        expect(response.body).to eq("{\"status\":\"missing header: File Number\"}")
+      end
+    end
+  end
+
   context "When the file exists in VBMS or VVA" do
     before do
       allow(VVAService).to receive(:fetch_documents_for).and_return([])

--- a/spec/requests/api/v1/file_spec.rb
+++ b/spec/requests/api/v1/file_spec.rb
@@ -143,7 +143,7 @@ describe "File API v1", type: :request do
         }
       end
 
-      it "returns bad request" do
+      it "returns 400" do
         get "/api/v1/files", nil, headers
         expect(response.code).to eq("400")
         expect(response.body).to eq("{\"status\":\"missing header: CSS ID\"}")
@@ -159,7 +159,7 @@ describe "File API v1", type: :request do
         }
       end
 
-      it "returns bad request" do
+      it "returns 400" do
         get "/api/v1/files", nil, headers
         expect(response.code).to eq("400")
         expect(response.body).to eq("{\"status\":\"missing header: Station ID\"}")
@@ -175,7 +175,7 @@ describe "File API v1", type: :request do
         }
       end
 
-      it "returns bad request" do
+      it "returns 400" do
         get "/api/v1/files", nil, headers
         expect(response.code).to eq("400")
         expect(response.body).to eq("{\"status\":\"missing header: File Number\"}")

--- a/spec/requests/api/v1/file_spec.rb
+++ b/spec/requests/api/v1/file_spec.rb
@@ -146,7 +146,8 @@ describe "File API v1", type: :request do
       it "returns 400" do
         get "/api/v1/files", nil, headers
         expect(response.code).to eq("400")
-        expect(response.body).to eq("{\"status\":\"missing header: CSS ID\"}")
+        body = JSON.parse(response.body)
+        expect(body["status"]).to match /missing.+CSS.+ID/
       end
     end
 
@@ -162,7 +163,8 @@ describe "File API v1", type: :request do
       it "returns 400" do
         get "/api/v1/files", nil, headers
         expect(response.code).to eq("400")
-        expect(response.body).to eq("{\"status\":\"missing header: Station ID\"}")
+        body = JSON.parse(response.body)
+        expect(body["status"]).to match /missing.+Station.+ID/
       end
     end
 
@@ -178,8 +180,9 @@ describe "File API v1", type: :request do
       it "returns 400" do
         get "/api/v1/files", nil, headers
         expect(response.code).to eq("400")
-        expect(response.body).to eq("{\"status\":\"missing header: File Number\"}")
-      end
+        body = JSON.parse(response.body)
+        expect(body["status"]).to match /missing.+File.+Number/
+        end
     end
   end
 

--- a/spec/requests/api/v1/file_spec.rb
+++ b/spec/requests/api/v1/file_spec.rb
@@ -147,7 +147,7 @@ describe "File API v1", type: :request do
         get "/api/v1/files", nil, headers
         expect(response.code).to eq("400")
         body = JSON.parse(response.body)
-        expect(body["status"]).to match /missing.+CSS.+ID/
+        expect(body["status"]).to match(/missing.+CSS.+ID/)
       end
     end
 
@@ -164,7 +164,7 @@ describe "File API v1", type: :request do
         get "/api/v1/files", nil, headers
         expect(response.code).to eq("400")
         body = JSON.parse(response.body)
-        expect(body["status"]).to match /missing.+Station.+ID/
+        expect(body["status"]).to match(/missing.+Station.+ID/)
       end
     end
 
@@ -181,8 +181,8 @@ describe "File API v1", type: :request do
         get "/api/v1/files", nil, headers
         expect(response.code).to eq("400")
         body = JSON.parse(response.body)
-        expect(body["status"]).to match /missing.+File.+Number/
-        end
+        expect(body["status"]).to match(/missing.+File.+Number/)
+      end
     end
   end
 


### PR DESCRIPTION
Connects: #535

We currently don't handle error cases properly. If a user doesn't pass the correct headers, we get a sentry error. This change updates the API to return 400's if any headers are missing. 