### PR TITLE
User.id bug

### DIFF
--- a/app/controllers/api/v1/files_controller.rb
+++ b/app/controllers/api/v1/files_controller.rb
@@ -27,6 +27,6 @@ class Api::V1::FilesController < Api::V1::ApplicationController
   end
 
   def download
-    @download ||= Download.find_or_create_by_user_and_file(current_user, id)
+    @download ||= Download.find_or_create_by_user_and_file(current_user.id, id)
   end
 end

--- a/app/models/serializers/v1/download_serializer.rb
+++ b/app/models/serializers/v1/download_serializer.rb
@@ -12,7 +12,7 @@ class Serializers::V1::DownloadSerializer < ActiveModel::Serializer
   end
 
   attribute :documents do
-    object.documents.map do |document|
+    object.documents.order(:id).map do |document|
       {
         id: document.id,
         type_id: document.type_id,

--- a/spec/requests/api/v1/file_spec.rb
+++ b/spec/requests/api/v1/file_spec.rb
@@ -268,13 +268,7 @@ describe "File API v1", type: :request do
       it "doesn't download files added within 3 hours of calling the endpoint" do
         get "/api/v1/files", nil, headers
 
-        vbms_documents.concat([
-                                OpenStruct.new(
-                                  document_id: "3",
-                                  received_at: "5/6/2017",
-                                  type_id: "123")
-                              ])
-        allow(VBMSService).to receive(:fetch_documents_for).and_return(vbms_documents)
+        expect(VBMSService).to receive(:fetch_documents_for).exactly(0).times
 
         get "/api/v1/files", nil, headers
 

--- a/spec/requests/api/v1/file_spec.rb
+++ b/spec/requests/api/v1/file_spec.rb
@@ -235,10 +235,10 @@ describe "File API v1", type: :request do
               vva_error: false,
               documents: [
                 {
-                  id: download.documents[2].id,
-                  type_id: "825",
-                  received_at: "2015-09-06T01:00:00.000Z",
-                  external_document_id: document.document_id
+                  id: download.documents[0].id,
+                  type_id: "124",
+                  received_at: "2017-04-03T00:00:00.000Z",
+                  external_document_id: "2"
                 },
                 {
                   id: download.documents[1].id,
@@ -247,10 +247,10 @@ describe "File API v1", type: :request do
                   external_document_id: "1"
                 },
                 {
-                  id: download.documents[0].id,
-                  type_id: "124",
-                  received_at: "2017-04-03T00:00:00.000Z",
-                  external_document_id: "2"
+                  id: download.documents[2].id,
+                  type_id: "825",
+                  received_at: "2015-09-06T01:00:00.000Z",
+                  external_document_id: document.document_id
                 }
               ]
             }
@@ -259,6 +259,23 @@ describe "File API v1", type: :request do
       end
 
       it "returns existing and new files" do
+        get "/api/v1/files", nil, headers
+
+        expect(response.code).to eq("200")
+        expect(response.body).to eq(response_body)
+      end
+
+      it "doesn't download files added within 3 hours of calling the endpoint" do
+        get "/api/v1/files", nil, headers
+
+        vbms_documents.concat([
+                                OpenStruct.new(
+                                  document_id: "3",
+                                  received_at: "5/6/2017",
+                                  type_id: "123")
+                              ])
+        allow(VBMSService).to receive(:fetch_documents_for).and_return(vbms_documents)
+
         get "/api/v1/files", nil, headers
 
         expect(response.code).to eq("200")


### PR DESCRIPTION
Connects: #2873

For some reason this bug seems to manifest itself on UAT but not locally. It seems on UAT rails correctly converts user -> user.id when it tries to find the record. But if that record is not found it appears to convert user -> nil when creating the record. I cannot seem to reproduce this locally, but it is tested on UAT and appears to fix the problem.