### PR TITLE
Adding Prometheus

### DIFF
--- a/app/jobs/middleware/job_prometheus_metric_middleware.rb
+++ b/app/jobs/middleware/job_prometheus_metric_middleware.rb
@@ -1,0 +1,19 @@
+class JobPrometheusMetricMiddleware
+  def call(_worker, msg, _queue)
+    name = msg["args"][0]["job_class"]
+
+    yield
+
+  rescue
+    PrometheusService.background_jobs_error_counter.increment(name: name)
+
+    # reraise the same error. This lets Sidekiq's retry logic kick off
+    # as normal, but we still capture the error
+    raise
+  ensure
+    PrometheusService.background_jobs_attempt_counter.increment(name: name)
+
+    # No need to actually push in test/development/demo
+    PrometheusService.push_metrics! if Rails.env.production?
+  end
+end

--- a/app/middleware/metrics_collector.rb
+++ b/app/middleware/metrics_collector.rb
@@ -1,0 +1,44 @@
+# Simple middleware that collects gauge metrics whenever
+# a GET /metrics request is made. This ensures we regularly
+# get a snapshot of instance information
+class MetricsCollector
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    request = Rack::Request.new(env)
+
+    perform if request.path == "/metrics"
+
+    @app.call(env)
+  end
+
+  private
+
+  def perform
+    collect_postgres_metrics
+    collect_background_jobs_metrics
+  end
+
+  def collect_postgres_metrics
+    conns = ActiveRecord::Base.connection_pool.connections
+
+    active = conns.count { |c| c.in_use? && c.owner.alive? }
+    dead = conns.count { |c| c.in_use? && !c.owner.alive? }
+    idle = conns.count { |c| !c.in_use? }
+
+    PrometheusService.postgres_db_connections.set({ type: "active" }, active)
+    PrometheusService.postgres_db_connections.set({ type: "dead" }, dead)
+    PrometheusService.postgres_db_connections.set({ type: "idle" }, idle)
+  end
+
+  def collect_background_jobs_metrics
+    stats = Sidekiq::Stats.new
+
+    PrometheusService.background_jobs.set({ type: "processed" }, stats.processed)
+    PrometheusService.background_jobs.set({ type: "enqueued" }, stats.enqueued)
+    PrometheusService.background_jobs.set({ type: "failed" }, stats.failed)
+    PrometheusService.background_jobs.set({ type: "default_queue_latency" }, stats.default_queue_latency)
+  end
+end

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -17,15 +17,22 @@ class ExternalApi::BGSService
   end
 
   def fetch_veteran_info(file_number)
-    @client ||= init_client
-    veteran_data = @client.people.find_by_file_number(file_number)
-
-    parse_veteran_info(veteran_data) if veteran_data
+    @bgs_client ||= init_client
+    MetricsService.record("BGS: fetch veteran info for vbms id: #{file_number}",
+                          service: :bgs,
+                          name: "veteran.find_by_file_number") do
+      @veteran_data = @bgs_client.people.find_by_file_number(file_number)
+    end
+    parse_veteran_info(@veteran_data) if @veteran_data
   end
 
   def check_sensitivity(file_number)
-    @client ||= init_client
-    @client.can_access? file_number
+    @bgs_client ||= init_client
+    MetricsService.record("BGS: can_access? (find_flashes): #{file_number}",
+                          service: :bgs,
+                          name: "can_access?") do
+      @bgs_client.can_access? file_number
+    end
   end
 
   private

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -22,8 +22,8 @@ class ExternalApi::BGSService
       MetricsService.record("BGS: fetch veteran info for vbms id: #{file_number}",
                             service: :bgs,
                             name: "veteran.find_by_file_number") do
-      @bgs_client.people.find_by_file_number(file_number)
-    end
+        @bgs_client.people.find_by_file_number(file_number)
+      end
     parse_veteran_info(veteran_data) if veteran_data
   end
 

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -31,8 +31,9 @@ class ExternalApi::BGSService
     MetricsService.record("BGS: can_access? (find_flashes): #{file_number}",
                           service: :bgs,
                           name: "can_access?") do
-      @bgs_client.can_access? file_number
+      @can = @bgs_client.can_access? file_number
     end
+    @can
   end
 
   private

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -18,12 +18,13 @@ class ExternalApi::BGSService
 
   def fetch_veteran_info(file_number)
     @bgs_client ||= init_client
-    MetricsService.record("BGS: fetch veteran info for vbms id: #{file_number}",
-                          service: :bgs,
-                          name: "veteran.find_by_file_number") do
-      @veteran_data = @bgs_client.people.find_by_file_number(file_number)
+    veteran_data ||=
+      MetricsService.record("BGS: fetch veteran info for vbms id: #{file_number}",
+                            service: :bgs,
+                            name: "veteran.find_by_file_number") do
+      @bgs_client.people.find_by_file_number(file_number)
     end
-    parse_veteran_info(@veteran_data) if @veteran_data
+    parse_veteran_info(veteran_data) if veteran_data
   end
 
   def check_sensitivity(file_number)
@@ -31,9 +32,8 @@ class ExternalApi::BGSService
     MetricsService.record("BGS: can_access? (find_flashes): #{file_number}",
                           service: :bgs,
                           name: "can_access?") do
-      @can = @bgs_client.can_access? file_number
+      @bgs_client.can_access? file_number
     end
-    @can
   end
 
   private

--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -60,7 +60,7 @@ class ExternalApi::VBMSService
     MetricsService.record("sent VBMS request #{request.class} for #{id}",
                           service: :vbms,
                           name: name) do
-      @vbms_client.send_request(request)
+      return @vbms_client.send_request(request)
     end
   rescue VBMS::ClientError => e
     Rails.logger.error "#{e.message}\n#{e.backtrace.join("\n")}"

--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -11,7 +11,7 @@ class ExternalApi::VBMSService
                 VBMS::Requests::ListDocuments.new(download.file_number)
               end
     documents = send_and_log_request(download.file_number, request)
-    Rails.logger.info("Document list length: #{documents.length}")
+    Rails.logger.info("VBMS Document list length: #{documents.length}")
     documents
   end
 
@@ -23,7 +23,7 @@ class ExternalApi::VBMSService
               else
                 VBMS::Requests::FetchDocumentById.new(document.document_id)
               end
-    result = send_and_log_request(document.document.id, request)
+    result = send_and_log_request(document.document_id, request)
     result && result.content
   end
 

--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -10,7 +10,7 @@ class ExternalApi::VBMSService
               else
                 VBMS::Requests::ListDocuments.new(download.file_number)
               end
-    documents = send_and_log_request(file_number, request)
+    documents = send_and_log_request(download.file_number, request)
     Rails.logger.info("Document list length: #{documents.length}")
     documents
   end
@@ -23,7 +23,7 @@ class ExternalApi::VBMSService
               else
                 VBMS::Requests::FetchDocumentById.new(document.document_id)
               end
-    result = send_and_log_request(file_number, request)
+    result = send_and_log_request(document.document.id, request)
     result && result.content
   end
 
@@ -55,9 +55,9 @@ class ExternalApi::VBMSService
     )
   end
 
-  def self.send_and_log_request(file_number, request)
+  def self.send_and_log_request(id, request)
     name = request.class.name.split("::").last
-    MetricsService.record("sent VBMS request #{request.class} for #{file_number}",
+    MetricsService.record("sent VBMS request #{request.class} for #{id}",
                           service: :vbms,
                           name: name) do
       @vbms_client.send_request(request)

--- a/app/services/external_api/vva_service.rb
+++ b/app/services/external_api/vva_service.rb
@@ -4,19 +4,27 @@ require "vva"
 class ExternalApi::VVAService
   def self.fetch_documents_for(download)
     @client ||= init_client
-    @client.document_list.get_by_claim_number(download.file_number)
+    MetricsService.record("VVA: get document list for: #{download.file_number}",
+                          service: :vva,
+                          name: "document_list.get_by_claim_number") do
+      @client.document_list.get_by_claim_number(download.file_number)
+    end
   end
 
   def self.fetch_document_file(document)
     @client ||= init_client
-    result = @client.document_content.get_by_document_id(
-      document_id: document.document_id,
-      source: document.source,
-      format: document.preferred_extension,
-      jro: document.jro,
-      ssn: document.ssn
-    )
-    result && result.content
+    MetricsService.record("VVA: fetch document content for: #{document.document_id}",
+                          service: :vva,
+                          name: "document_content.get_by_document_id") do
+      @result = @client.document_content.get_by_document_id(
+        document_id: document.document_id,
+        source: document.source,
+        format: document.preferred_extension,
+        jro: document.jro,
+        ssn: document.ssn
+      )
+    end
+    @result && @result.content
   end
 
   def self.init_client

--- a/app/services/external_api/vva_service.rb
+++ b/app/services/external_api/vva_service.rb
@@ -3,20 +3,22 @@ require "vva"
 # Thin interface to talk to Virtual VA
 class ExternalApi::VVAService
   def self.fetch_documents_for(download)
-    @client ||= init_client
+    @vva_client ||= init_client
     MetricsService.record("VVA: get document list for: #{download.file_number}",
                           service: :vva,
                           name: "document_list.get_by_claim_number") do
-      @client.document_list.get_by_claim_number(download.file_number)
+      @documents = @vva_client.document_list.get_by_claim_number(download.file_number)
     end
+    Rails.logger.info("VVA Document list length: #{@documents.length}")
+    @documents
   end
 
   def self.fetch_document_file(document)
-    @client ||= init_client
+    @vva_client ||= init_client
     MetricsService.record("VVA: fetch document content for: #{document.document_id}",
                           service: :vva,
                           name: "document_content.get_by_document_id") do
-      @result = @client.document_content.get_by_document_id(
+      @result = @vva_client.document_content.get_by_document_id(
         document_id: document.document_id,
         source: document.source,
         format: document.preferred_extension,

--- a/app/services/external_api/vva_service.rb
+++ b/app/services/external_api/vva_service.rb
@@ -4,21 +4,21 @@ require "vva"
 class ExternalApi::VVAService
   def self.fetch_documents_for(download)
     @vva_client ||= init_client
-    MetricsService.record("VVA: get document list for: #{download.file_number}",
-                          service: :vva,
-                          name: "document_list.get_by_claim_number") do
-      @documents = @vva_client.document_list.get_by_claim_number(download.file_number)
+    documents ||= MetricsService.record("VVA: get document list for: #{download.file_number}",
+                                        service: :vva,
+                                        name: "document_list.get_by_claim_number") do
+      @vva_client.document_list.get_by_claim_number(download.file_number)
     end
     Rails.logger.info("VVA Document list length: #{@documents.length}")
-    @documents
+    documents
   end
 
   def self.fetch_document_file(document)
     @vva_client ||= init_client
-    MetricsService.record("VVA: fetch document content for: #{document.document_id}",
-                          service: :vva,
-                          name: "document_content.get_by_document_id") do
-      @result = @vva_client.document_content.get_by_document_id(
+    result ||= MetricsService.record("VVA: fetch document content for: #{document.document_id}",
+                                     service: :vva,
+                                     name: "document_content.get_by_document_id") do
+      @vva_client.document_content.get_by_document_id(
         document_id: document.document_id,
         source: document.source,
         format: document.preferred_extension,
@@ -26,7 +26,7 @@ class ExternalApi::VVAService
         ssn: document.ssn
       )
     end
-    @result && @result.content
+    result && result.content
   end
 
   def self.init_client

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -1,0 +1,39 @@
+require "benchmark"
+
+# see https://dropwizard.github.io/metrics/3.1.0/getting-started/ for abstractions on metric types
+class MetricsService
+  # rubocop:disable Metrics/MethodLength
+  def self.record(description, service: nil, name: "unknown")
+    return_value = nil
+    app = "eFolder"
+
+    Rails.logger.info("STARTED #{description}")
+    stopwatch = Benchmark.measure do
+      return_value = yield
+    end
+
+    if service
+      metric = PrometheusService.send("#{service}_request_latency".to_sym)
+
+      metric.set({ app: app, name: name }, stopwatch.real)
+
+    end
+
+    Rails.logger.info("FINISHED #{description}: #{stopwatch}")
+    return_value
+  rescue
+    if service
+      metric = PrometheusService.send("#{service}_request_error_counter".to_sym)
+      metric.increment(app: app, name: name)
+    end
+
+    # Reraise the same error. We don't want to interfere at all in normal error handling
+    # this is just to capture the metric
+    raise
+  ensure
+    if service
+      metric = PrometheusService.send("#{service}_request_attempt_counter".to_sym)
+      metric.increment(app: app, name: name)
+    end
+  end
+end

--- a/app/services/prometheus_service.rb
+++ b/app/services/prometheus_service.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+require "prometheus/client"
+require "prometheus/client/push"
+
+class PrometheusService
+  # :nocov:
+  class << self
+    def vbms_request_attempt_counter
+      @vbms_request_attempt_counter ||=
+        find_or_register_metric(:counter,
+                                :vbms_request_attempt_counter,
+                                "A counter of attempted VBMS requests")
+    end
+
+    def vbms_request_error_counter
+      @vbms_request_error_counter ||=
+        find_or_register_metric(:counter,
+                                :vbms_request_error_counter,
+                                "A counter of errored VBMS requests")
+    end
+
+    def vbms_request_latency
+      @vbms_request_latency ||=
+        find_or_register_gauge_and_summary(:vbms_request_latency,
+                                           "latency of completed VBMS requests")
+    end
+
+    def vva_request_attempt_counter
+      @vva_request_attempt_counter ||=
+        find_or_register_metric(:counter,
+                                :vva_request_attempt_counter,
+                                "A counter of attempted VVA requests")
+    end
+
+    def vva_request_error_counter
+      @vva_request_error_counter ||=
+        find_or_register_metric(:counter,
+                                :vva_request_error_counter,
+                                "A counter of errored VVA requests")
+    end
+
+    def vva_request_latency
+      @vva_request_latency ||=
+        find_or_register_gauge_and_summary(:vva_request_latency,
+                                           "latency of completed VVA requests")
+    end
+
+    def bgs_request_attempt_counter
+      @bgs_request_attempt_counter ||=
+        find_or_register_metric(:counter,
+                                :bgs_request_attempt_counter,
+                                "A counter of attempted BGS requests")
+    end
+
+    def bgs_request_error_counter
+      @bgs_request_error_counter ||=
+        find_or_register_metric(:counter,
+                                :bgs_request_error_counter,
+                                "A counter of errored BGS requests")
+    end
+
+    def bgs_request_latency
+      @bgs_request_latency ||=
+        find_or_register_gauge_and_summary(:bgs_request_latency,
+                                           "latency of completed BGS requests")
+    end
+
+    def app_server_threads
+      @app_server_threads ||=
+        find_or_register_gauge_and_summary(:app_server_threads,
+                                           "app server threads snapshot")
+    end
+
+    def postgres_db_connections
+      @postgres_db_connections ||=
+        find_or_register_gauge_and_summary(:postgres_db_connections,
+                                           "postgres db connection snapshot")
+    end
+
+    def background_jobs
+      @background_jobs ||=
+        find_or_register_gauge_and_summary(:background_jobs,
+                                           "sidekiq background jobs")
+    end
+
+    def background_jobs_attempt_counter
+      @background_jobs_attempt_counter ||=
+        find_or_register_metric(:counter,
+                                :background_jobs_attempt_counter,
+                                "counter of all sidekiq background jobs attempted (fail or succeed)")
+    end
+
+    def background_jobs_error_counter
+      @background_jobs_error_counter ||=
+        find_or_register_metric(:counter,
+                                :background_jobs_error_counter,
+                                "counter of all sidekiq background jobs that errored")
+    end
+
+    # This method pushes all registered metrics to the prometheus pushgateway
+    def push_metrics!
+      metrics = Prometheus::Client.registry
+      url = Rails.application.secrets.prometheus_push_gateway_url
+
+      Prometheus::Client::Push.new("push-gateway", nil, url).add(metrics)
+    end
+
+    private
+
+    def find_or_register_gauge_and_summary(name, description)
+      gauge = find_or_register_metric(:gauge, "#{name}_gauge".to_sym, description)
+      summary = find_or_register_metric(:summary, "#{name}_summary".to_sym, description)
+      PrometheusGaugeSummary.new(gauge, summary)
+    end
+
+    def find_metric(name)
+      Prometheus::Client.registry.metrics.find { |m| m.name == name }
+    end
+
+    def find_or_register_metric(type, name, description)
+      find_metric(name) || Prometheus::Client.registry.send(type, name, description)
+    end
+  end
+  # :nocov:
+end
+
+# This class is a wrapper for gauge & summary metrics.
+# In practice, we almost always want to create both a gauage
+# and a summary. This class provides a simple `.set()` interface
+# for updating both at the same time
+class PrometheusGaugeSummary
+  LAST_SUMMARY_OBSERVATION_REDIS_KEY_PREFIX = "prometheus_last_summary_observation".freeze
+  SUMMARY_OBSERVATION_THRESHOLD = 1.minute
+
+  attr_accessor :gauge, :summary
+  def initialize(gauge, summary)
+    @gauge = gauge
+    @summary = summary
+  end
+
+  def set(label, value)
+    gauge.set(label, value)
+    record_summary_observation(label, value) if should_observe_summary?
+  end
+
+  def last_summary_observation
+    Rails.cache.read(last_summary_observation_redis_key) || Time.at(0).utc
+  end
+
+  private
+
+  def last_summary_observation_redis_key
+    "#{LAST_SUMMARY_OBSERVATION_REDIS_KEY_PREFIX}_#{summary.name}"
+  end
+
+  def record_summary_observation(label, value)
+    summary.observe(label, value)
+    set_last_summary_observation
+  end
+
+  def set_last_summary_observation
+    Rails.cache.write(last_summary_observation_redis_key, Time.now.utc)
+  end
+
+  def should_observe_summary?
+    Time.now.utc > (last_summary_observation + SUMMARY_OBSERVATION_THRESHOLD)
+  end
+end

--- a/config.ru
+++ b/config.ru
@@ -5,6 +5,8 @@ require "rack"
 require "prometheus/client/rack/collector"
 require "prometheus/client/rack/exporter"
 
+require_relative "app/middleware/metrics_collector"
+
 # require basic auth for the /metrics route
 use MetricsAuth, "metrics" do |username, password|
   # if we mistakenly didn't set a password for this route, disable the route
@@ -16,6 +18,9 @@ end
 # use gzip for the '/metrics' route, since it can get big.
 use Rack::Deflater,
     if: -> (env, _status, _headers, _body) { env["PATH_INFO"] == "/metrics" }
+
+# Customized collector for our own metrics
+use MetricsCollector
 
 # traces all HTTP requests
 use Prometheus::Client::Rack::Collector

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,9 +1,15 @@
+require "#{Rails.root}/app/jobs/middleware/job_prometheus_metric_middleware"
+
 Sidekiq.configure_server do |config|
   config.redis = { url: Rails.application.secrets.redis_url_sidekiq }
 
   schedule_file = Rails.root + "config/sidekiq_cron.yml"
   if File.exists?(schedule_file) && Sidekiq.server?
     Sidekiq::Cron::Job.load_from_hash! YAML.load_file(schedule_file)
+  end
+
+  config.server_middleware do |chain|
+    chain.add JobPrometheusMetricMiddleware
   end
 end
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -14,6 +14,7 @@ development:
   secret_key_base: 8c6b64e47fa8d523a9ea3d7e7658dbd5ee916003785039b14ffdd076fae644afaedc04eb683fc705c47f6f07020184c8cf3a30e79f2258521a45b861ab8e7862
   redis_url_cache: <%= ENV["REDIS_URL_CACHE"] || "redis://localhost:6379/0/cache/" %>
   redis_url_sidekiq: <%= ENV["REDIS_URL_SIDEKIQ"] || "redis://localhost:6379" %>
+  prometheus_push_gateway_url: <%= ENV["PROMETHEUS_PUSH_GATEWAY_URL"] %>
   vbms:
     url: https://filenet.uat.vbms.aide.oit.va.gov/vbmsp2-cms/streaming/eDocumentService-v4
     env_dir: ../deployment/decrypted_creds/uat_creds
@@ -24,10 +25,18 @@ development:
     cacert: caseflow_uat_ca_cert
     cert: caseflow_uat_client_cert
 
+demo:
+  secret_key_base: 8c6b64e47fa8d523a9ea3d7e7658dbd5ee916003785039b14ffdd076fae644afaedc04eb683fc705c47f6f07020184c8cf3a30e79f2258521a45b861ab8e7862
+  redis_url_cache: <%= ENV["REDIS_URL_CACHE"] || "redis://localhost:6379/0/cache/" %>
+  redis_url_sidekiq: <%= ENV["REDIS_URL_SIDEKIQ"] || "redis://localhost:6379" %>
+  prometheus_push_gateway_url: <%= ENV["PROMETHEUS_PUSH_GATEWAY_URL"] %>
+
+
 test:
   secret_key_base: 35cf2535cc790c92a07bcab48a5f21bbd132a7071984947e8cc92d2ce8e60d582c62022b7ddcfa6f0eca34319dfe1482fbf21d2c78e50c12e884be9ea5fea7e0
   redis_url_cache: <%= ENV["REDIS_URL_CACHE"] || "redis://localhost:6379/0/cache/" %>
   redis_url_sidekiq: <%= ENV["REDIS_URL_SIDEKIQ"] || "redis://localhost:6379" %>
+  prometheus_push_gateway_url: <%= ENV["PROMETHEUS_PUSH_GATEWAY_URL"] %>
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
@@ -35,5 +44,6 @@ production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   redis_url_cache: <%= ENV["REDIS_URL_CACHE"] %>
   redis_url_sidekiq: <%= ENV["REDIS_URL_SIDEKIQ"] %>
+  prometheus_push_gateway_url: <%= ENV["PROMETHEUS_PUSH_GATEWAY_URL"] %>
   vbms:
       env: true

--- a/spec/jobs/job_prometheus_metric_middleware_spec.rb
+++ b/spec/jobs/job_prometheus_metric_middleware_spec.rb
@@ -1,0 +1,35 @@
+describe JobPrometheusMetricMiddleware do
+  before do
+    @middleware = JobPrometheusMetricMiddleware.new
+
+    @msg = {
+      "args" => [{
+        "job_class" => "FunTestJob"
+      }]
+    }
+    @yield_called = false
+    allow(PrometheusService).to receive(:push_metrics!).and_return(nil)
+    @labels = { name: "FunTestJob" }
+  end
+
+  context ".call" do
+    let(:call) { @middleware.call(nil, @msg, :default) { @yield_called = true } }
+
+    it "always increments attempts counter" do
+      expect(PrometheusService.background_jobs_attempt_counter.values[@labels]).to eq(nil)
+      expect(@yield_called).to be_falsey
+      call
+      expect(@yield_called).to be_truthy
+      expect(PrometheusService.background_jobs_attempt_counter.values[@labels]).to eq(1)
+    end
+
+    it "increments error counter on error" do
+      expect(PrometheusService.background_jobs_error_counter.values[@labels]).to eq(nil)
+      expect do
+        @middleware.call(nil, @msg, :default) { fail("test") }
+      end.to raise_error
+
+      expect(PrometheusService.background_jobs_error_counter.values[@labels]).to eq(1)
+    end
+  end
+end

--- a/spec/services/metrics_service_spec.rb
+++ b/spec/services/metrics_service_spec.rb
@@ -1,0 +1,57 @@
+describe PrometheusService do
+  context "PrometheusGaugeSummary" do
+    before do
+      @gauge = Prometheus::Client::Gauge.new(:foo_gauge, "foo")
+      @summary = Prometheus::Client::Summary.new(:foo_summary, "foo")
+      @metric = PrometheusGaugeSummary.new(@gauge, @summary)
+      @time = Timecop.freeze(Time.utc(2017, 2, 2))
+    end
+
+    context ".set" do
+      before do
+        @val = 5
+        @metric.set({}, @val)
+      end
+
+      it "sets values for gauge & summary" do
+        expect(@gauge.values[{}]).to eq(@val)
+        expect(@summary.values[{}][0.5]).to eq(@val)
+      end
+
+      it "sets a summary observation at most once every 5 minutes" do
+        new_val = 6
+        expect(@metric.last_summary_observation).to eq(@time)
+
+        # Call the metric set() again to record a 2nd value
+        @metric.set({}, new_val)
+
+        # Verify the gauge updated as expected
+        expect(@gauge.values[{}]).to eq(new_val)
+
+        # Verify the summary did *NOT* update
+        expect(@summary.values[{}][0.5]).to eq(@val)
+
+        new_time = Timecop.freeze(@time + 2.minutes)
+
+        # Call the metric set() again to record a 3rd value
+        @metric.set({}, new_val)
+
+        # Since 5 minutes have passed,
+        # verify the summary updated as expected,
+        expect(@summary.values[{}][0.5]).to eq(new_val)
+        expect(@metric.last_summary_observation).to eq(new_time)
+      end
+
+      it "does not clash with other summary metric's last_observation" do
+        gauge2 = Prometheus::Client::Gauge.new(:bar_gauge, "bar")
+        summary2 = Prometheus::Client::Summary.new(:bar_summary, "bar")
+        metric2 = PrometheusGaugeSummary.new(gauge2, summary2)
+
+        # Verify no last_summary_observation has been set
+        expect(metric2.last_summary_observation).to eq(Time.at(0).utc)
+        metric2.set({}, 10)
+        expect(summary2.values[{}][0.5]).to eq(10)
+      end
+    end
+  end
+end

--- a/spec/services/metrics_service_spec.rb
+++ b/spec/services/metrics_service_spec.rb
@@ -1,6 +1,5 @@
 describe MetricsService do
   context ".timer" do
-
     let(:labels) { { app: "eFolder", name: "ListDocuments" } }
     let(:yield_val) { 5 }
     subject do

--- a/spec/services/metrics_service_spec.rb
+++ b/spec/services/metrics_service_spec.rb
@@ -1,9 +1,7 @@
 describe MetricsService do
   context ".timer" do
-    before do
-      RequestStore.store[:application] = "fake-app"
-    end
-    let(:labels) { { app: "fake-app", name: "ListDocuments" } }
+
+    let(:labels) { { app: "eFolder", name: "ListDocuments" } }
     let(:yield_val) { 5 }
     subject do
       MetricsService.record("fake api call", service: "vbms", name: "ListDocuments") { yield_val }
@@ -21,7 +19,7 @@ describe MetricsService do
 
       gauge = PrometheusService.vbms_request_latency.gauge
       gauge_labels = gauge.values.keys.first
-      expect(gauge_labels[:app]).to eq("fake-app")
+      expect(gauge_labels[:app]).to eq("eFolder")
       expect(gauge_labels[:name]).to eq("ListDocuments")
 
       expect(counter.values[labels]).to eq(current_counter + 1)

--- a/spec/services/prometheus_service_spec.rb
+++ b/spec/services/prometheus_service_spec.rb
@@ -1,0 +1,57 @@
+describe PrometheusService do
+  context "PrometheusGaugeSummary" do
+    before do
+      @gauge = Prometheus::Client::Gauge.new(:foo_gauge, "foo")
+      @summary = Prometheus::Client::Summary.new(:foo_summary, "foo")
+      @metric = PrometheusGaugeSummary.new(@gauge, @summary)
+      @time = Timecop.freeze(Time.utc(2017, 2, 2))
+    end
+
+    context ".set" do
+      before do
+        @val = 5
+        @metric.set({}, @val)
+      end
+
+      it "sets values for gauge & summary" do
+        expect(@gauge.values[{}]).to eq(@val)
+        expect(@summary.values[{}][0.5]).to eq(@val)
+      end
+
+      it "sets a summary observation at most once every 5 minutes" do
+        new_val = 6
+        expect(@metric.last_summary_observation).to eq(@time)
+
+        # Call the metric set() again to record a 2nd value
+        @metric.set({}, new_val)
+
+        # Verify the gauge updated as expected
+        expect(@gauge.values[{}]).to eq(new_val)
+
+        # Verify the summary did *NOT* update
+        expect(@summary.values[{}][0.5]).to eq(@val)
+
+        new_time = Timecop.freeze(@time + 2.minutes)
+
+        # Call the metric set() again to record a 3rd value
+        @metric.set({}, new_val)
+
+        # Since 5 minutes have passed,
+        # verify the summary updated as expected,
+        expect(@summary.values[{}][0.5]).to eq(new_val)
+        expect(@metric.last_summary_observation).to eq(new_time)
+      end
+
+      it "does not clash with other summary metric's last_observation" do
+        gauge2 = Prometheus::Client::Gauge.new(:bar_gauge, "bar")
+        summary2 = Prometheus::Client::Summary.new(:bar_summary, "bar")
+        metric2 = PrometheusGaugeSummary.new(gauge2, summary2)
+
+        # Verify no last_summary_observation has been set
+        expect(metric2.last_summary_observation).to eq(Time.at(0).utc)
+        metric2.set({}, 10)
+        expect(summary2.values[{}][0.5]).to eq(10)
+      end
+    end
+  end
+end


### PR DESCRIPTION
connects https://github.com/department-of-veterans-affairs/caseflow-efolder/issues/362
connects #438

Mainly copied Metrics services from Caseflow

- Refactored some service calls to add MetricsService aka Prometheus
- BGS/VBMS/VVA should all be pushed to prometheus

To test:
- Spin up using `RAILS_ENV=prod`
- Test any of the external API calls
- Watch prometheus yell at you that it can't push to your non-existent gateway.


```
background_jobs_summary{type="failed",quantile="0.5"} 228
background_jobs_summary{type="failed",quantile="0.9"} 228
background_jobs_summary{type="failed",quantile="0.99"} 228
background_jobs_summary_sum{type="failed"} 8436
background_jobs_summary_count{type="failed"} 37
background_jobs_summary{type="default_queue_latency",quantile="0.5"} 0
background_jobs_summary{type="default_queue_latency",quantile="0.9"} 0
background_jobs_summary{type="default_queue_latency",quantile="0.99"} 0
background_jobs_summary_sum{type="default_queue_latency"} 0
background_jobs_summary_count{type="default_queue_latency"} 35
# TYPE vbms_request_latency_gauge gauge
# HELP vbms_request_latency_gauge latency of completed VBMS requests
vbms_request_latency_gauge{app="eFolder",name="ListDocuments"} 1.20935323500089
# TYPE vbms_request_latency_summary summary
# HELP vbms_request_latency_summary latency of completed VBMS requests
vbms_request_latency_summary{app="eFolder",name="ListDocuments",quantile="0.5"} 3.3533283659999142
vbms_request_latency_summary{app="eFolder",name="ListDocuments",quantile="0.9"} 3.3533283659999142
vbms_request_latency_summary{app="eFolder",name="ListDocuments",quantile="0.99"} 3.3533283659999142
vbms_request_latency_summary_sum{app="eFolder",name="ListDocuments"} 3.3533283659999142
vbms_request_latency_summary_count{app="eFolder",name="ListDocuments"} 1
# TYPE vbms_request_attempt_counter counter
# HELP vbms_request_attempt_counter A counter of attempted VBMS requests
vbms_request_attempt_counter{app="eFolder",name="ListDocuments"} 2
# TYPE bgs_request_latency_gauge gauge
# HELP bgs_request_latency_gauge latency of completed BGS requests
bgs_request_latency_gauge{app="eFolder",name="veteran.find_by_file_number"} 0.8723335979993863
bgs_request_latency_gauge{app="eFolder",name="can_access?"} 1.3328420649995678
# TYPE bgs_request_latency_summary summary
# HELP bgs_request_latency_summary latency of completed BGS requests
bgs_request_latency_summary{app="eFolder",name="veteran.find_by_file_number",quantile="0.5"} 1.1878114299997833
bgs_request_latency_summary{app="eFolder",name="veteran.find_by_file_number",quantile="0.9"} 1.1878114299997833
bgs_request_latency_summary{app="eFolder",name="veteran.find_by_file_number",quantile="0.99"} 1.1878114299997833
bgs_request_latency_summary_sum{app="eFolder",name="veteran.find_by_file_number"} 1.1878114299997833
bgs_request_latency_summary_count{app="eFolder",name="veteran.find_by_file_number"} 1
# TYPE bgs_request_attempt_counter counter
# HELP bgs_request_attempt_counter A counter of attempted BGS requests
bgs_request_attempt_counter{app="eFolder",name="veteran.find_by_file_number"} 2
bgs_request_attempt_counter{app="eFolder",name="can_access?"} 1
```

<img width="1040" alt="screen shot 2017-08-04 at 8 39 35 am" src="https://user-images.githubusercontent.com/18075411/28969743-e4173a56-78f3-11e7-98e4-f0ed86ce26a9.png">
