### PR TITLE
Extra lines below last document in doc manifest

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -152,6 +152,7 @@ table td {
   padding-top: 1px;
   max-height: 600px;
   overflow-y: scroll;
+  border-bottom: 0;
 }
 
 .ee-subheading {
@@ -171,6 +172,7 @@ table td {
 
 .ee-documents-table {
   margin-top: 0;
+  margin-bottom: 0;
 }
 
 .cf-help-divider {
@@ -229,4 +231,8 @@ table td {
 
 .ee-download-button.ee-right-button {
   margin: 0;
+}
+
+.cf-tab-content {
+  border-bottom: 0;
 }


### PR DESCRIPTION
Connects #564 

## AC
Ensure that there is not an extra line below the last document in the doc manifest (e.g. below 'Birth Certificate' in the mock) on the the Retrieve eFolder page or on the Download eFolder page.

![efolder-extralines](https://user-images.githubusercontent.com/23080951/29008290-79efb82e-7ae2-11e7-986f-0a3ec06b5a1a.gif)
