### PR TITLE
Add new from_api flag to DB

### DIFF
--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -217,8 +217,9 @@ class Download < ActiveRecord::Base
     end
 
     def find_or_create_by_user_and_file(user_id, file_id)
-      Download.includes(:documents).where(user_id: user_id, file_number: file_id, from_api: true).last ||
-        Download.create(user_id: user_id, file_number: file_id, from_api: true)
+      download_scope = Download.where(user_id: user_id, file_number: file_id, from_api: true)
+
+      download_scope.includes(:documents).last || download_scope.create!
     end
   end
 

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -217,8 +217,8 @@ class Download < ActiveRecord::Base
     end
 
     def find_or_create_by_user_and_file(user_id, file_id)
-      Download.includes(:documents).where(user_id: user_id, file_number: file_id).last ||
-        Download.create(user_id: user_id, file_number: file_id)
+      Download.includes(:documents).where(user_id: user_id, file_number: file_id, from_api: true).last ||
+        Download.create(user_id: user_id, file_number: file_id, from_api: true)
     end
   end
 

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -55,7 +55,8 @@ class Search < ActiveRecord::Base
   def download_scope
     Download.active.where(
       file_number: sanitized_file_number,
-      user: user
+      user: user,
+      from_api: [false, nil]
     ).where.not(status: [1, 7, 8])
   end
 

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -56,7 +56,7 @@ class Search < ActiveRecord::Base
     Download.active.where(
       file_number: sanitized_file_number,
       user: user,
-      from_api: [false, nil]
+      from_api: false
     ).where.not(status: [1, 7, 8])
   end
 

--- a/db/migrate/20170809174911_add_from_api_to_downloads.rb
+++ b/db/migrate/20170809174911_add_from_api_to_downloads.rb
@@ -1,0 +1,5 @@
+class AddFromApiToDownloads < ActiveRecord::Migration
+  def change
+    add_column :downloads, :from_api, :boolean
+  end
+end

--- a/db/migrate/20170809174911_add_from_api_to_downloads.rb
+++ b/db/migrate/20170809174911_add_from_api_to_downloads.rb
@@ -1,5 +1,5 @@
 class AddFromApiToDownloads < ActiveRecord::Migration
   def change
-    add_column :downloads, :from_api, :boolean
+    add_column :downloads, :from_api, :boolean, default: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170721203804) do
+ActiveRecord::Schema.define(version: 20170809174911) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -74,6 +74,7 @@ ActiveRecord::Schema.define(version: 20170721203804) do
     t.string   "veteran_last_four_ssn"
     t.integer  "user_id"
     t.integer  "zipfile_size",          limit: 8
+    t.boolean  "from_api"
   end
 
   add_index "downloads", ["completed_at"], name: "downloads_completed_at", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -63,8 +63,8 @@ ActiveRecord::Schema.define(version: 20170809174911) do
     t.string   "request_id"
     t.string   "file_number"
     t.integer  "status",                          default: 0
-    t.datetime "created_at",                                  null: false
-    t.datetime "updated_at",                                  null: false
+    t.datetime "created_at",                                      null: false
+    t.datetime "updated_at",                                      null: false
     t.integer  "lock_version"
     t.datetime "manifest_fetched_at"
     t.datetime "started_at"
@@ -74,7 +74,7 @@ ActiveRecord::Schema.define(version: 20170809174911) do
     t.string   "veteran_last_four_ssn"
     t.integer  "user_id"
     t.integer  "zipfile_size",          limit: 8
-    t.boolean  "from_api"
+    t.boolean  "from_api",                        default: false
   end
 
   add_index "downloads", ["completed_at"], name: "downloads_completed_at", using: :btree

--- a/spec/models/download_spec.rb
+++ b/spec/models/download_spec.rb
@@ -241,9 +241,16 @@ describe "Download" do
     let(:user) { User.create(css_id: "WALTER", station_id: "123") }
     let(:file_number) { "123" }
 
-    context "retrieves most recent existing record" do
-      let!(:old_download) { Download.create(user: user, file_number: file_number, created_at: 2.seconds.ago) }
-      let!(:new_download) { Download.create(user: user, file_number: file_number, created_at: 1.second.ago) }
+    context "retrieves most recent existing record with from_api: true" do
+      let!(:old_download) do
+        Download.create(user: user, file_number: file_number, created_at: 3.seconds.ago, from_api: true)
+      end
+      let!(:new_download) do
+        Download.create(user: user, file_number: file_number, created_at: 2.seconds.ago, from_api: true)
+      end
+      let!(:non_api_download) do
+        Download.create(user: user, file_number: file_number, created_at: 1.second.ago)
+      end
 
       it { is_expected.to eq(new_download) }
     end
@@ -252,6 +259,7 @@ describe "Download" do
       it do
         expect(subject.user_id).to eq(user.id)
         expect(subject.file_number).to eq(file_number)
+        expect(subject.from_api).to eq(true)
       end
     end
   end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -96,6 +96,18 @@ describe Search do
           expect(search.download.id).to_not eq(@existing_download.id)
         end
       end
+
+      context "when that download was created by the api" do
+        before do
+          @existing_download.update_attributes!(from_api: true)
+        end
+
+        it "creates a new download" do
+          expect(subject).to be_truthy
+          expect(search.reload).to be_download_created
+          expect(search.download.id).to_not eq(@existing_download.id)
+        end
+      end
     end
 
     context "when case is not found in BGS" do

--- a/spec/requests/api/v1/file_spec.rb
+++ b/spec/requests/api/v1/file_spec.rb
@@ -8,6 +8,7 @@ describe "File API v1", type: :request do
   let(:veteran_id) { "21012" }
   let(:download) do
     Download.create(
+      from_api: true,
       user_id: user.id,
       file_number: veteran_id,
       veteran_first_name: "George",


### PR DESCRIPTION
Connects: https://github.com/department-of-veterans-affairs/caseflow-efolder/issues/586

In order to separate the effects of the new eFolder API from the UI we're adding a flag to the Download table that will mark downloads as coming from the api or not. The API should only update documents that were created via the API and the UI should only update documents that were created via the UI.

**Test Plan**
- [x] Enter DEMO1 into the UI and download it. Then curl the files endpoint with: curl "localhost:4000/api/v1/files" -H "Authorization: Token token=token" -H "css-id: CSFLOW4" -H "station-id: 283" -H "file-number: DEMO1". Ensure there are two DB entries.
- [x] Enter DEMO1 into the UI twice. Ensure only one DB entry is created.
- [x] Enter DEMO1 into the API twice. Ensure only one DB entry is created.