### PR TITLE
Table header scrolls with the doc manifest

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -172,6 +172,7 @@ table td {
 .ee-documents-table {
   margin-top: 0;
   margin-bottom: 0;
+  display: block;
 }
 
 
@@ -237,27 +238,7 @@ table td {
   border-bottom: 0;
 }
 
-// .ee-document-scroll {
-//   display: block;
-//   width: 500px;
-//   height: 200px;
-//   background: pink;
-//   overflow: auto;
-// }
-
-// .ee-document-name {
-//   display: block;
-//   width: 500px;
-//   overflow: auto;
-//   color: #fff;
-//   background: #000;
-// }
-
-table thead tr {
-    display: block;
-}
-
-table  tbody {
+.ee-document-scroll {
   display: block;
   height: 600px;
   overflow-y: scroll;

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -61,7 +61,6 @@ a {
 table th,
 table td {
   border-color: $color-gray-lighter;
-  // width: 66%;
 }
 
 .cf-stats-section {

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -61,6 +61,7 @@ a {
 table th,
 table td {
   border-color: $color-gray-lighter;
+  // width: 66%;
 }
 
 .cf-stats-section {
@@ -150,8 +151,6 @@ table td {
 .ee-document-list {
   border: 1px solid $color-gray-lighter;
   padding-top: 1px;
-  max-height: 600px;
-  overflow-y: scroll;
   border-bottom: 0;
 }
 
@@ -174,6 +173,7 @@ table td {
   margin-top: 0;
   margin-bottom: 0;
 }
+
 
 .cf-help-divider {
   margin: 5px 25px 30px auto;
@@ -235,4 +235,62 @@ table td {
 
 .cf-tab-content {
   border-bottom: 0;
+}
+
+// .ee-document-scroll {
+//   display: block;
+//   width: 500px;
+//   height: 200px;
+//   background: pink;
+//   overflow: auto;
+// }
+
+// .ee-document-name {
+//   display: block;
+//   width: 500px;
+//   overflow: auto;
+//   color: #fff;
+//   background: #000;
+// }
+
+table thead tr {
+    display: block;
+}
+
+table  tbody {
+  display: block;
+  height: 600px;
+  overflow-y: scroll;
+}
+
+.usa-sr-only {
+  min-width: 19px;
+}
+
+.document-col {
+  min-width: 627px;
+}
+
+.source-col {
+  min-width: 93px;
+}
+
+.receipt-col {
+  min-width: 128px;
+}
+
+.ee-status {
+  min-width: 49px;
+}
+
+.ee-document-id {
+  min-width: 340px;
+}
+
+.sources-col {
+  min-width: 116px;
+}
+
+.upload-col {
+  min-width: 152px;
 }

--- a/app/views/downloads/_confirm.html.erb
+++ b/app/views/downloads/_confirm.html.erb
@@ -71,7 +71,7 @@
         <tr>
           <th class ="document-col" scope="col">Document Type</th>
           <th class ="sources-col" scope="col" id="vva-tour-3">Source</th>
-          <th class ="upload-col" scope="col">Upload Date</th>
+          <th class ="upload-col" scope="col">Receipt Date</th>
         </tr>
       </thead>
       

--- a/app/views/downloads/_confirm.html.erb
+++ b/app/views/downloads/_confirm.html.erb
@@ -69,21 +69,19 @@
       <table class="usa-table-borderless ee-documents-table" summary="Files in veteran's eFolder">
       <thead>
         <tr>
-          <th scope="col">Document Type</th>
-          <th scope="col" id="vva-tour-3">Source</th>
-          <th scope="col">Upload Date</th>
+          <th class ="document-col" scope="col">Document Type</th>
+          <th class ="sources-col" scope="col" id="vva-tour-3">Source</th>
+          <th class ="upload-col" scope="col">Upload Date</th>
         </tr>
       </thead>
       
         <tbody>
         <% @download.documents.each do |document| %>
-        
           <tr>
-            <td class="ee-filename-row"><%= document.type_name %></td>
-            <td><%= document.from_vva? ? "VVA/LCM" : "VBMS" %></td>
-            <td><%= document.received_at && document.received_at.to_formatted_s(:short_date) %></td>
+            <td class ="document-col"><%= document.type_name %></td>
+            <td class ="sources-col"><%= document.from_vva? ? "VVA/LCM" : "VBMS" %></td>
+            <td class ="upload-col"><%= document.received_at && document.received_at.to_formatted_s(:short_date) %></td>
           </tr>
-        
         <% end %>
         </tbody>
       </table>

--- a/app/views/downloads/_confirm.html.erb
+++ b/app/views/downloads/_confirm.html.erb
@@ -75,7 +75,7 @@
         </tr>
       </thead>
       
-        <tbody>
+        <tbody class ="ee-document-scroll" >
         <% @download.documents.each do |document| %>
           <tr>
             <td class ="document-col"><%= document.type_name %></td>

--- a/app/views/downloads/_progress.html.erb
+++ b/app/views/downloads/_progress.html.erb
@@ -107,28 +107,28 @@
       <table class="usa-table-borderless ee-documents-table" summary="Status of veteran eFolder file downloads">
       <thead>
         <tr>
-          <th scope="col"><span class="usa-sr-only">Status</span></th>
-          <th scope="col">Document Type</th>
+          <th class="ee-status" scope="col"><span class="usa-sr-only">Status</span></th>
+          <th class="ee-filename-row" scope="col">Document Type</th>
           <% if current_tab == "errored" %>
-            <th scope="col">Document ID</th>
+            <th class="ee-document-id"scope="col">Document ID</th>
           <% end %>
-          <th scope="col">Source</th>
-          <th scope="col">Receipt Date</th>
+          <th class="source-col" scope="col">Source</th>
+          <th class="receipt-col" scope="col">Receipt Date</th>
         </tr>
       </thead>
 
       <tbody>
         <% @download.documents.where(download_status: current_document_status).each do |document| %>
           <tr class="document-<%= document.download_status %>">
-            <td class="ee-status-row">
+            <td class="ee-status">
               <%= svg_icon(document.download_status_icon) %>
             </td>
             <td class="ee-filename-row"><%= document.type_name %></td>
             <% if current_tab == "errored" %>
               <td class="ee-doc-id-row"><%= document.filename_doc_id %></td>
             <% end %>
-            <td><%= document.from_vva? ? "VVA/LCM" : "VBMS" %></td>
-            <td><%= document.received_at && document.received_at.to_formatted_s(:short_date) %></td>
+            <td class="source-col"><%= document.from_vva? ? "VVA/LCM" : "VBMS" %></td>
+            <td class="receipt-col"><%= document.received_at && document.received_at.to_formatted_s(:short_date) %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/downloads/_progress.html.erb
+++ b/app/views/downloads/_progress.html.erb
@@ -106,7 +106,7 @@
     <% else %>
       <table class="usa-table-borderless ee-documents-table" summary="Status of veteran eFolder file downloads">
       <thead>
-        <tr>
+       <tr>
           <th class="ee-status" scope="col"><span class="usa-sr-only">Status</span></th>
           <th class="ee-filename-row" scope="col">Document Type</th>
           <% if current_tab == "errored" %>
@@ -115,9 +115,9 @@
           <th class="source-col" scope="col">Source</th>
           <th class="receipt-col" scope="col">Receipt Date</th>
         </tr>
-      </thead>
+     </thead>
 
-      <tbody>
+      <tbody class ="ee-document-scroll">
         <% @download.documents.where(download_status: current_document_status).each do |document| %>
           <tr class="document-<%= document.download_status %>">
             <td class="ee-status">

--- a/app/views/help/_faqs.html.erb
+++ b/app/views/help/_faqs.html.erb
@@ -1,8 +1,7 @@
 <h1 id="faq">Frequently Asked Questions</h1>
 
    <div class="cf-help-divider"></div>
-
-     
+ 
    <ul id="toc" class="usa-unstyled-list">
     <li><a href="#what-is-efolder-express">1. What is eFolder Express?</a></li>
     <li><a href="#what-does-efolder-express-do">2. How was eFolder Express developed? Who was involved?</a></li>

--- a/app/views/help/_faqs_with_vva.html.erb
+++ b/app/views/help/_faqs_with_vva.html.erb
@@ -142,7 +142,6 @@
   <p>
     If you encounter any problems while using eFolder Express, you should ask your supervisor for assistance. If you and your supervisor are unable to resolve the issue, please reach out to the Caseflow Product Support Team by calling 1-844-876-5548 or emailing <a href="mailto: caseflow@va.gov">caseflow@va.gov.</a>
   </p>
-  </p>
 
   <h2 id="share-feedback">18. How do I share my feedback for improving eFolder Express?</h2>
 

--- a/app/views/help/_faqs_with_vva.html.erb
+++ b/app/views/help/_faqs_with_vva.html.erb
@@ -1,8 +1,7 @@
 <h1 id="faq">Frequently Asked Questions</h1>
 
 <div class="cf-help-divider"></div>
-
-     
+   
   <ul id="toc" class="usa-unstyled-list">
     <li><a href="#what-is-efolder-express">1. What is eFolder Express?</a></li>
     <li><a href="#what-does-efolder-express-do">2. How was eFolder Express developed? Who was involved?</a></li>
@@ -141,7 +140,8 @@
   <h2 id="encounter-problems">17. What should I do if I encounter problems?</h2>
 
   <p>
-    If you encounter any problems while using eFolder Express, you should ask your supervisor for assistance. If you and your supervisor are unable to resolve the issue, please reach out to the Caseflow Product Support Team by calling 1-844-876-5548 or emailing caseflow@va.gov.
+    If you encounter any problems while using eFolder Express, you should ask your supervisor for assistance. If you and your supervisor are unable to resolve the issue, please reach out to the Caseflow Product Support Team by calling 1-844-876-5548 or emailing <a href="mailto: caseflow@va.gov">caseflow@va.gov.</a>
+  </p>
   </p>
 
   <h2 id="share-feedback">18. How do I share my feedback for improving eFolder Express?</h2>
@@ -153,5 +153,5 @@
   <h2 id="need-help">19. What if I still need help?</h2>
 
   <p>
-    If you still encounter issues or have questions that are not answered here, reach out to the Caseflow Product Support Team by calling 1-844-876-5548 or emailing caseflow@va.gov.
+    If you still encounter issues or have questions that are not answered here, reach out to the Caseflow Product Support Team by calling 1-844-876-5548 or emailing<a href="mailto: caseflow@va.gov">caseflow@va.gov.</a>
   </p>

--- a/app/views/help/_faqs_with_vva.html.erb
+++ b/app/views/help/_faqs_with_vva.html.erb
@@ -152,5 +152,5 @@
   <h2 id="need-help">19. What if I still need help?</h2>
 
   <p>
-    If you still encounter issues or have questions that are not answered here, reach out to the Caseflow Product Support Team by calling 1-844-876-5548 or emailing<a href="mailto: caseflow@va.gov">caseflow@va.gov.</a>
+    If you still encounter issues or have questions that are not answered here, reach out to the Caseflow Product Support Team by calling 1-844-876-5548 or emailing <a href="mailto: caseflow@va.gov">caseflow@va.gov.</a>
   </p>


### PR DESCRIPTION
Connects #574 
### AC
1. As a user I would like to be able to see the column labels when I scroll through the list of files eX is retrieving. Currently the table headings scroll with the doc list.

![header](https://user-images.githubusercontent.com/23080951/29151599-61104bfa-7d50-11e7-893d-f0ac32e618da.gif)
