### PR TITLE
Table header scrolls with the doc manifest (#574)

### DIFF
--- a/app/assets/javascripts/application/download_progress.js
+++ b/app/assets/javascripts/application/download_progress.js
@@ -20,11 +20,11 @@ window.DownloadProgress = (function($) {
         openRequests++
         $.get("/downloads/" + id + "/progress?current_tab=" + this.currentTab).then(function(fragment) {
           openRequests--;
-          var scrollTop = $(".cf-tab-content")[0].scrollTop;
+          var scrollTop = $(".ee-document-list")[0].scrollTop;
           $("#download-progress").html(fragment);
 
           if (!changingTabs) {
-            $(".cf-tab-content")[0].scrollTop = scrollTop;
+            $(".ee-document-list")[0].scrollTop = scrollTop;
           }
 
           self.initTabs();

--- a/app/views/downloads/_progress.html.erb
+++ b/app/views/downloads/_progress.html.erb
@@ -98,7 +98,7 @@
     </button>
   </div>
 
-  <div class="cf-tab-content">
+  <div class="ee-document-list">
     <%if @download.documents.where(download_status: current_document_status).empty? %>
       <p class="cf-txt-c">
         There are no documents here.


### PR DESCRIPTION
Table header scrolls with the doc manifest (#574)

Removed the class that was hovering the header and replaced it with a class that leaves header fixed.