### PR TITLE
Connects to Left Align table headers in IE (#622)

### DIFF
--- a/app/assets/stylesheets/_download.scss
+++ b/app/assets/stylesheets/_download.scss
@@ -12,7 +12,7 @@
 }
 
 .ee-filename-row {
-  width: 70%;
+  min-width: 626px;
 }
 
 .ee-doc-id-row {


### PR DESCRIPTION
Connects #622 
AC
1. Verify that all table headers: Document Type, Source, and Receipt Date display as left aligned in all browsers.
**IE**
<img width="980" alt="screen shot 2017-09-17 at 7 49 29 pm" src="https://user-images.githubusercontent.com/23080951/30526149-038353ee-9be4-11e7-9750-f9e3815ae2c2.png">

**FireFox**
<img width="662" alt="screen shot 2017-09-17 at 7 25 11 pm" src="https://user-images.githubusercontent.com/23080951/30526182-5c9521ec-9be4-11e7-8b97-4dc480870b80.png">

