### PR TITLE
Update connect vva to reject DH key exchange

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ gem 'active_model_serializers'
 gem 'redis-namespace'
 
 gem 'connect_vbms', git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "87d0cab4bb5a87e70d6e2dab81e1da17fc512571"
-gem 'connect_vva', git: "https://github.com/department-of-veterans-affairs/connect_vva.git", ref: "65112ad14e083f3046c3ad856edbf164024a4dc2"
+gem 'connect_vva', git: "https://github.com/department-of-veterans-affairs/connect_vva.git", ref: "f1389dab28158076d856f614ed85af0cf167522f"
 gem 'bgs', git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", :branch => 'master'
 #gem 'connect_vbms', git: 'https://github.com/department-of-veterans-affairs/connect_vbms.git'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,8 +35,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vva.git
-  revision: 65112ad14e083f3046c3ad856edbf164024a4dc2
-  ref: 65112ad14e083f3046c3ad856edbf164024a4dc2
+  revision: f1389dab28158076d856f614ed85af0cf167522f
+  ref: f1389dab28158076d856f614ed85af0cf167522f
   specs:
     connect_vva (0.1)
       savon (~> 2.11, >= 2.11.0)


### PR DESCRIPTION
This points to the latest version of connect VVA. 
Description of the problem here:
https://github.com/department-of-veterans-affairs/connect_vva/issues/13 