### PR TITLE
Fixing hanging download bug

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -30,13 +30,16 @@ class Search < ActiveRecord::Base
   def perform!
     return true if match_existing_download
 
-    self.download = download_scope.new
+    download = download_scope.new
 
-    return false unless validate!
+    return false unless validate!(download)
 
     transaction do
-      update_attributes!(status: :download_created)
       download.save!
+      update_attributes!(
+        status: :download_created,
+        download: download
+      )
     end
 
     # We fetch the veteran info from BGS before starting the job so that we do any DB
@@ -67,7 +70,7 @@ class Search < ActiveRecord::Base
     true
   end
 
-  def validate!
+  def validate!(download)
     if download.demo?
       return true
 


### PR DESCRIPTION
Connects: https://github.com/department-of-veterans-affairs/caseflow-efolder/issues/647

When you search for an eFolder via the UI we create a search object. If the download is new, we create a new download record to associate with the search object. We then do a validation on that download object to see if 1) the veteran exists, 2) the user has access to this case file's sensitivity. If either of these fail, the intention is for the download object not to be saved to the DB.

However, since we set the search object's download attribute to `self.download = Download.new()` if we ever save anything from this search record to the DB, we'll inadvertently save this download object as well #railsmagic. In the validate method if either of the failure cases exist: 1) the veteran exists, 2) the user has access to this case file's sensitivity, then we call `update_attributes` to set the status of the search object. This then saves the download object as well.

On a subsequent search, the search model will associate the new search with the old download object. The user is then forwarded to the download record's `show` page, and the user's browser will poll that page forever. Since this veteran doesn't actually exist, the user will never be notified that a download finished, since it never started.

With this change, we only save the download object if we pass the validation.

TL;DR: We should not save download records if the search fails.