### PR TITLE
Connects to Errors tab - source and receipt date are off (#686)

### DIFF
--- a/app/assets/stylesheets/_download.scss
+++ b/app/assets/stylesheets/_download.scss
@@ -12,7 +12,7 @@
 }
 
 .ee-filename-row {
-  min-width: 626px;
+  width: 70%;
 }
 
 .ee-doc-id-row {


### PR DESCRIPTION
Connects #686 

AC:
1. Source and Receipt Date should be present for each failed documents.
2. Ensure Source and Receipt Date are inside the tab.

![efolder-header](https://user-images.githubusercontent.com/23080951/32565904-4ef7ab58-c485-11e7-857f-8b39986c8ced.gif)
