### PR TITLE
Real S3 service doesn't return the file when you call store

### DIFF
--- a/app/models/fetcher.rb
+++ b/app/models/fetcher.rb
@@ -22,6 +22,8 @@ class Fetcher
     converted_image = ImageConverterService.new(
       image: external_service.fetch_document_file(document), mime_type: document.mime_type).process
     S3Service.store_file(document.s3_filename, converted_image)
+
+    converted_image
   end
 
   def download_from_service_and_record


### PR DESCRIPTION
Connects: https://github.com/department-of-veterans-affairs/caseflow/issues/3782

This is hard to reproduce locally since my staging env is not hooked up to S3, but am using the fake S3 service. But I'm pretty convinced this will fix the current issues with eFolder.

The behavior we're seeing in UAT is that cases fail the first time their downloaded and succeed the second time if you clear the cache. When looking at the downloaded pdf files in the zip file from the first download, we see that the file contents are `#<Aws::S3::Object:0x007fce682bfac8>`. Looking at the code, we expect `S3.store_file` to return the file. While the fake version does, the real version does not. We add an explicit return to fix this.

It works on a subsequent download because the right value was cached in S3, and that is what we pull down.

**Test Plan**
- [ ] Validated by pushing branch to UAT and downloading a case with and without a TIFF