### PR TITLE
Retrieving Files | Estimated time disappears 

### DIFF
--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -109,7 +109,9 @@ class Download < ActiveRecord::Base
   end
 
   def estimated_to_complete_at
-    @estimated_to_complete_at ||= calculate_estimated_to_complete_at
+    binding.pry
+    if !@estimated_to_complete_at.nil? && (@estimated_to_complete_at ||= calculate_estimated_to_complete_at)
+    end
   end
 
   def case_exists?

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -109,9 +109,7 @@ class Download < ActiveRecord::Base
   end
 
   def estimated_to_complete_at
-    binding.pry
-    if !@estimated_to_complete_at.nil? && (@estimated_to_complete_at ||= calculate_estimated_to_complete_at)
-    end
+    @estimated_to_complete_at ||= calculate_estimated_to_complete_at
   end
 
   def case_exists?

--- a/app/views/downloads/_progress.html.erb
+++ b/app/views/downloads/_progress.html.erb
@@ -58,10 +58,8 @@
 
     <h1 class="cf-txt-c">Retrieving Files ...</h1>
     <p class="ee-fetching-files">
-      <% if @download.estimated_to_complete_at %>
         Estimated time left: <%= distance_of_time_in_words(@download.estimated_to_complete_at, Time.zone.now, include_seconds: true) %>
-        (<%= documents_in_progress.count %> of <%= @download.number_of_documents %> files remaining)
-      <% end %>
+        <%= documents_in_progress.count %> of <%= @download.number_of_documents %> files remaining
     </p>
 
     <div class="progress-bar">

--- a/app/views/downloads/_progress.html.erb
+++ b/app/views/downloads/_progress.html.erb
@@ -58,10 +58,8 @@
 
     <h1 class="cf-txt-c">Retrieving Files ...</h1>
     <p class="ee-fetching-files">
-       <% if @download.estimated_to_complete_at %>
         Estimated time left: <%= distance_of_time_in_words(@download.estimated_to_complete_at, Time.zone.now, include_seconds: true) %>
         (<%= documents_in_progress.count %> of <%= @download.number_of_documents %> files remaining)
-      <% end %>
     </p>
 
     <div class="progress-bar">

--- a/app/views/downloads/_progress.html.erb
+++ b/app/views/downloads/_progress.html.erb
@@ -58,7 +58,7 @@
 
     <h1 class="cf-txt-c">Retrieving Files ...</h1>
     <p class="ee-fetching-files">
-        Estimated time left: <%= distance_of_time_in_words(@download.estimated_to_complete_at, Time.zone.now, include_seconds: true) %>
+        Estimated time left: <%= distance_of_time_in_words(@download.estimated_to_complete_at, Time.zone.now, include_seconds: true) unless @download.estimated_to_complete_at.blank? %>
         (<%= documents_in_progress.count %> of <%= @download.number_of_documents %> files remaining)
     </p>
 

--- a/app/views/downloads/_progress.html.erb
+++ b/app/views/downloads/_progress.html.erb
@@ -58,8 +58,10 @@
 
     <h1 class="cf-txt-c">Retrieving Files ...</h1>
     <p class="ee-fetching-files">
+       <% if @download.estimated_to_complete_at %>
         Estimated time left: <%= distance_of_time_in_words(@download.estimated_to_complete_at, Time.zone.now, include_seconds: true) %>
-        <%= documents_in_progress.count %> of <%= @download.number_of_documents %> files remaining
+        (<%= documents_in_progress.count %> of <%= @download.number_of_documents %> files remaining)
+      <% end %>
     </p>
 
     <div class="progress-bar">


### PR DESCRIPTION
Connects #587 

### AC
When retrieving files from eFolder,
estimated time disappears here and there for some strange reason.

![efolder](https://user-images.githubusercontent.com/23080951/32860620-2fe26cd0-ca20-11e7-82c8-b1ff2ec695c1.gif)
