### PR TITLE
Allow arbitrary DEMO### veteran IDs

### DIFF
--- a/app/jobs/restart_stalled_downloads_job.rb
+++ b/app/jobs/restart_stalled_downloads_job.rb
@@ -14,7 +14,7 @@ class RestartStalledDownloadsJob < ActiveJob::Base
 
     download.touch
 
-    if download.file_number =~ /DEMO/
+    if download.file_number =~ /^DEMO/
       Fakes::DownloadFilesJob.perform_later(download)
     else
       DownloadFilesJob.perform_later(download)

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -51,7 +51,7 @@ class Download < ActiveRecord::Base
   end
 
   def demo?
-    file_number =~ /DEMO/
+    !!(file_number =~ /^DEMO/)
   end
 
   def missing_veteran_info?

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -16,7 +16,7 @@ class Search < ActiveRecord::Base
 
   def valid_file_number?
     number = sanitized_file_number
-    return true if number =~ /DEMO/
+    return true if number =~ /^DEMO/
 
     return false if /\D+/ =~ number
     # We don't want to render an error message on initial pageload.

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -5,7 +5,7 @@ class Fakes::BGSService
   cattr_accessor :sensitive_files
 
   def demo?(file_number)
-    file_number =~ /DEMO/
+    !!(file_number =~ /^DEMO/)
   end
 
   def demo_veteran_info

--- a/lib/fakes/document_service.rb
+++ b/lib/fakes/document_service.rb
@@ -103,7 +103,8 @@ class Fakes::DocumentService
   end
 
   def self.list_fake_documents(file_number)
-    demo = DEMOS[file_number] || DEMOS["DEMODEFAULT"]
+    demo = DEMOS[file_number]
+    demo = DEMOS["DEMODEFAULT"] if !demo && file_number =~ /^DEMO/
     return [] if !demo || demo[:num_docs] <= 0
 
     sleep_manifest_load(demo[:manifest_load])

--- a/lib/fakes/document_service.rb
+++ b/lib/fakes/document_service.rb
@@ -103,7 +103,7 @@ class Fakes::DocumentService
   end
 
   def self.list_fake_documents(file_number)
-    demo = DEMOS[file_number]
+    demo = DEMOS[file_number] || DEMOS["DEMODEFAULT"]
     return [] if !demo || demo[:num_docs] <= 0
 
     sleep_manifest_load(demo[:manifest_load])

--- a/spec/models/download_spec.rb
+++ b/spec/models/download_spec.rb
@@ -4,12 +4,13 @@ describe "Download" do
   let(:veteran_first_name) { "Stan" }
   let(:veteran_last_name) { "Lee" }
   let(:veteran_last_four_ssn) { "0987" }
+  let(:file_number) { "1234" }
 
   before do
     Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
 
     Fakes::BGSService.veteran_info = {
-      "1234" => {
+      file_number => {
         "veteran_first_name" => veteran_first_name,
         "veteran_last_name" => veteran_last_name,
         "veteran_last_four_ssn" => veteran_last_four_ssn
@@ -19,7 +20,6 @@ describe "Download" do
   end
   after { Timecop.return }
 
-  let(:file_number) { "1234" }
   let(:download) { Download.create(file_number: file_number) }
 
   context ".new" do
@@ -28,7 +28,7 @@ describe "Download" do
     context "when file number is set" do
       before do
         Fakes::BGSService.veteran_info = {
-          "1234" => {
+          file_number => {
             "veteran_first_name" => veteran_first_name,
             "veteran_last_name" => veteran_last_name,
             "veteran_last_four_ssn" => veteran_last_four_ssn


### PR DESCRIPTION
Connects #662.

Allows access to demo cases with arbitrary numbers in veteran ID following "DEMO". This behaviour appears to have been inadvertently disabled as part of a larger change (https://github.com/department-of-veterans-affairs/caseflow-efolder/pull/634/files#diff-7f299968f69db6bfed17c513dd12bd34). I chatted with the Sunil and he seems to recall removing it to test the case where an incorrect veteran ID triggers the appropriate alert. We can still trigger that alert so I don't think this change is a regression.

Also, makes the pattern for demo veteran IDs more strict (allows only ^DEMO.* now, previously was .*DEMO.*), and makes demo? functions return boolean values.