### PR TITLE
Do not log EOFError to Sentry

### DIFF
--- a/app/jobs/download_files_job.rb
+++ b/app/jobs/download_files_job.rb
@@ -1,6 +1,14 @@
 class DownloadFilesJob < ActiveJob::Base
   queue_as :default
 
+  # Sometimes, a VA backend will randomly fail. When we retry, it generally works.
+  # We will explicitly rescue and retry here, because otherwise the first
+  # failure will be logged to Sentry. For this error, we only want the last one
+  # to be logged to Sentry.
+  rescue_from EOFError do
+    retry_job
+  end
+
   def perform(download)
     download_documents = DownloadDocuments.new(download: download)
 

--- a/app/jobs/download_files_job.rb
+++ b/app/jobs/download_files_job.rb
@@ -1,14 +1,6 @@
 class DownloadFilesJob < ActiveJob::Base
   queue_as :default
 
-  # Sometimes, a VA backend will randomly fail. When we retry, it generally works.
-  # We will explicitly rescue and retry here, because otherwise the first
-  # failure will be logged to Sentry. For this error, we only want the last one
-  # to be logged to Sentry.
-  rescue_from EOFError do
-    retry_job
-  end
-
   def perform(download)
     download_documents = DownloadDocuments.new(download: download)
 

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -3,9 +3,7 @@ if ENV['SENTRY_DSN']
     config.dsn = ENV['SENTRY_DSN']
 
     # Sometimes, a VA backend will randomly fail. When we retry, it generally works.
-    # We will explicitly rescue and retry here, because otherwise the first
-    # failure will be logged to Sentry. For this error, we only want the last one
-    # to be logged to Sentry.
+    # We do not need to log this to Sentry, because it's not actionable for us.
     config.excluded_exceptions += ['EOFError']
   end
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,11 @@
 if ENV['SENTRY_DSN']
   Raven.configure do |config|
     config.dsn = ENV['SENTRY_DSN']
+
+    # Sometimes, a VA backend will randomly fail. When we retry, it generally works.
+    # We will explicitly rescue and retry here, because otherwise the first
+    # failure will be logged to Sentry. For this error, we only want the last one
+    # to be logged to Sentry.
+    config.excluded_exceptions += ['EOFError']
   end
 end


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/25331532/32920751-8bc9783a-caf8-11e7-8c3d-2d9f4c2e2c6a.png)

Connect #669.

## Test
I used a Sentry processor to trigger a breakpoint when Sentry was going to log an exception. I applied the following diff:

```diff
diff --git a/app/jobs/fakes/download_files_job.rb b/app/jobs/fakes/download_files_job.rb
index 5f51068..2d5fc5f 100644
--- a/app/jobs/fakes/download_files_job.rb
+++ b/app/jobs/fakes/download_files_job.rb
@@ -2,6 +2,8 @@ class Fakes::DownloadFilesJob < ActiveJob::Base
   queue_as :default
 
   def perform(download)
+    puts "~~~~~ ++++++== ================ raising error fak ============================="
+    raise 'fak'
     demo = Fakes::DocumentService::DEMOS[download.file_number] || Fakes::DocumentService::DEMOS["DEMODEFAULT"]
 
     Fakes::DocumentService.errors = demo[:error]
diff --git a/config/initializers/sentry.rb b/config/initializers/sentry.rb
index 66f61c5..3e113f9 100644
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,9 +1,17 @@
+class MyJobProcessor < Raven::Processor
+  def process(data)
+    binding.pry
+  end
+end
+
 if ENV['SENTRY_DSN']
   Raven.configure do |config|
     config.dsn = ENV['SENTRY_DSN']
-
+    
     # Sometimes, a VA backend will randomly fail. When we retry, it generally works.
     # We do not need to log this to Sentry, because it's not actionable for us.
     config.excluded_exceptions += ['EOFError']
+
+    config.processors += [MyJobProcessor]
   end
 end

```

I ran the following command:

```
$ SENTRY_SECRET_KEY=fake SENTRY_DSN=the_actual_value bundle exec sidekiq -v
```

By modifying the diff above, I was able to validate:

1. Without this PR, `EOFError`s are sent to Sentry.
1. With this PR, `EOFError`s are no longer sent to Sentry.
1. With this PR, Other errors are still sent to Sentry.
