### PR TITLE
Normalize user email address and css_id

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -60,7 +60,7 @@ class Api::V1::ApplicationController < BaseController
   end
 
   def css_id
-    request.headers["HTTP_CSS_ID"].try(:upcase)
+    request.headers["HTTP_CSS_ID"]
   end
 
   def capture_error(e)

--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -60,7 +60,7 @@ class Api::V1::ApplicationController < BaseController
   end
 
   def css_id
-    request.headers["HTTP_CSS_ID"]
+    request.headers["HTTP_CSS_ID"].try(:upcase!)
   end
 
   def capture_error(e)

--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -60,7 +60,7 @@ class Api::V1::ApplicationController < BaseController
   end
 
   def css_id
-    request.headers["HTTP_CSS_ID"].try(:upcase!)
+    request.headers["HTTP_CSS_ID"].try(:upcase)
   end
 
   def capture_error(e)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,7 +48,7 @@ class User < ActiveRecord::Base
     def from_session(session, request)
       return nil unless session["user"]
       user = session["user"]
-      find_or_create_by(css_id: user["css_id"], station_id: user["station_id"]).tap do |u|
+      find_or_create_by(css_id: user["css_id"].try(:upcase), station_id: user["station_id"]).tap do |u|
         u.name = user["name"]
         u.email = user["email"]
         u.roles = user["roles"]
@@ -64,7 +64,7 @@ class User < ActiveRecord::Base
 
       {
         id: auth_hash.uid,
-        css_id: auth_hash.uid,
+        css_id: auth_hash.uid.try(:upcase),
         email: raw_css_response["http://vba.va.gov/css/common/emailAddress"],
         name: "#{first_name} #{last_name}",
         roles: raw_css_response.attributes["http://vba.va.gov/css/caseflow/role"],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,8 +73,8 @@ class User < ActiveRecord::Base
     end
 
     def find_or_create_by(args)
-      args[:css_id].try(:upcase!)
-      args[:email].try(:strip!)
+      args[:css_id] = args[:css_id].try(:upcase)
+      args[:email] = args[:email].try(:strip)
       super
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,8 +7,8 @@ class User < ActiveRecord::Base
   has_many :manifests, through: :user_manifests
 
   after_initialize do |u|
-    u.email.try(:strip!)
-    u.css_id.try(:upcase!)
+    u.email.try(:strip!) if new_record?
+    u.css_id.try(:upcase!) if new_record?
   end
 
   NO_EMAIL = "No Email Recorded".freeze

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,11 @@ class User < ActiveRecord::Base
   has_many :user_manifests
   has_many :manifests, through: :user_manifests
 
+  after_initialize do |u|
+    u.email.try(:strip!)
+    u.css_id.try(:upcase!)
+  end
+
   NO_EMAIL = "No Email Recorded".freeze
 
   attr_accessor :name, :roles, :ip_address

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,10 +6,10 @@ class User < ActiveRecord::Base
   has_many :user_manifests
   has_many :manifests, through: :user_manifests
 
-  after_initialize do |u|
-    u.email.try(:strip!) if new_record?
-    u.css_id.try(:upcase!) if new_record?
-  end
+  validates :css_id, format: {
+    with: /\b[^a-z]+\b/,
+    message: "CSS_IDs cannot contain lowercase letters to avoid duplicate User records with differently cased CSS_IDs"
+  }
 
   NO_EMAIL = "No Email Recorded".freeze
 
@@ -48,7 +48,7 @@ class User < ActiveRecord::Base
     def from_session(session, request)
       return nil unless session["user"]
       user = session["user"]
-      find_or_create_by(css_id: user["css_id"].try(:upcase), station_id: user["station_id"]).tap do |u|
+      find_or_create_by(css_id: user["css_id"], station_id: user["station_id"]).tap do |u|
         u.name = user["name"]
         u.email = user["email"]
         u.roles = user["roles"]
@@ -64,12 +64,18 @@ class User < ActiveRecord::Base
 
       {
         id: auth_hash.uid,
-        css_id: auth_hash.uid.try(:upcase),
+        css_id: auth_hash.uid,
         email: raw_css_response["http://vba.va.gov/css/common/emailAddress"],
         name: "#{first_name} #{last_name}",
         roles: raw_css_response.attributes["http://vba.va.gov/css/caseflow/role"],
         station_id: raw_css_response["http://vba.va.gov/css/common/stationId"]
       }
+    end
+
+    def find_or_create_by(args)
+      args[:css_id].try(:upcase!)
+      args[:email].try(:strip!)
+      super
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,10 +6,9 @@ class User < ActiveRecord::Base
   has_many :user_manifests
   has_many :manifests, through: :user_manifests
 
-  validates :css_id, format: {
-    with: /\b[^a-z]+\b/,
-    message: "CSS_IDs cannot contain lowercase letters to avoid duplicate User records with differently cased CSS_IDs"
-  }
+  validates :css_id, uniqueness: { scope: :station_id, case_sensitive: false }
+
+  before_save { |u| u.email.try(:strip!) }
 
   NO_EMAIL = "No Email Recorded".freeze
 
@@ -72,10 +71,35 @@ class User < ActiveRecord::Base
       }
     end
 
-    def find_or_create_by(args)
-      args[:css_id] = args[:css_id].try(:upcase)
-      args[:email] = args[:email].try(:strip)
-      super
+    # TODO: (lowell) Re-implement ActiveRecord's find_or_create_by() method in order to properly call find_by()
+    # from within find_or_create_by() since ActiveRecord::Relation.find_or_create_by() (by way of ActiveRecord::Base?)
+    # is not calling User.find_by() as I expected it would. Perhaps this is because of some way ruby/ActiveRecord
+    # handles inheritance and child class method overriding? It does not appear as if ActiveRecord::Relation is an
+    # abstract class that ActiveRecord::Base implements, but then I still do not fully understand how rails does all
+    # of its magic.
+    #
+    # Link to ActiveRecord::Relation's find_or_create_by() implementation:
+    # https://apidock.com/rails/v4.0.2/ActiveRecord/Relation/find_or_create_by
+    #
+    # One other thought is that our reliance on hijacking a library's internal implementation details to accomplish
+    # our objective (that is, this fix relies on the ActiveRecord::Relation.find_or_create_by() calling find_by() and
+    # will fail should that internal implementation detail change this fix will fail to function) may indicate that
+    # we are solving this in a less-than-ideal fashion and we should consider better/easier/more direct solutions.
+    def find_or_create_by(attributes, &block)
+      find_by(attributes) || create(attributes, &block)
+    end
+
+    def find_by(args)
+      attrs = args.clone
+      # If css_id is an argument, remove it from the list so we can search
+      # case-insensitively on css_id in ther second where clause.
+      conditions = []
+      if attrs[:css_id]
+        conditions = ["upper(css_id) = upper(?)", attrs[:css_id]]
+        attrs.delete(:css_id)
+      end
+
+      where(attrs).where(conditions).first
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -40,6 +40,20 @@ describe User do
     end
   end
 
+  context "validation on object instantiation" do
+    let(:email) { "   email_address with leading_and_trailing_whitespace@zombo.com  " }
+    let(:css_id) { "lowercase_string" }
+    subject { User.new(email: email, css_id: css_id) }
+
+    it "trims leading and trailing whitespace from User's email address" do
+      expect(subject.email).to eq email.strip
+    end
+
+    it "capitalizes all letters in the css_id" do
+      expect(subject.css_id).to eq css_id.upcase
+    end
+  end
+
   context ".from_session" do
     let(:request) { OpenStruct.new(remote_ip: "123.123.222.222") }
     let(:session) { { "user" => user.as_json.merge("roles" => user.roles, "name" => user.name) } }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -41,12 +41,13 @@ describe User do
   end
 
   context "validation on object instantiation" do
-    let(:email) { "   email_address with leading_and_trailing_whitespace@zombo.com  " }
+    let(:core_email) { "core_email address@zombo.com" }
+    let(:email) { "  #{core_email}    " }
     let(:css_id) { "lowercase_string" }
     subject { User.new(email: email, css_id: css_id) }
 
     it "trims leading and trailing whitespace from User's email address" do
-      expect(subject.email).to eq email.strip
+      expect(subject.email).to eq core_email
     end
 
     it "capitalizes all letters in the css_id" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -40,19 +40,17 @@ describe User do
     end
   end
 
-  context "validation on object instantiation" do
-    let(:core_email) { "core_email address@zombo.com" }
-    let(:email) { "  #{core_email}    " }
-    let(:css_id) { "lowercase_string" }
-    let(:station_id) { 101 }
-    subject { User.find_or_create_by(email: email, css_id: css_id, station_id: station_id) }
+  context "case-insensitive css_id in find_or_create_by()" do
+    let(:station_id) { Random.rand(900) + 1 }
+    let(:lowercase_css_id) { "tony_hawk" }
+    let(:uppercase_css_id) { lowercase_css_id.upcase }
+    let(:orig_user) { User.create(css_id: lowercase_css_id, station_id: station_id) }
 
-    it "trims leading and trailing whitespace from User's email address" do
-      expect(subject.email).to eq core_email
-    end
+    before { orig_user.save }
 
-    it "capitalizes all letters in the css_id" do
-      expect(subject.css_id).to eq css_id.upcase
+    it "returns original user record with differently cased css_id" do
+      u = User.find_or_create_by(css_id: uppercase_css_id, station_id: station_id)
+      expect(u.css_id).to eq(lowercase_css_id)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -44,7 +44,8 @@ describe User do
     let(:core_email) { "core_email address@zombo.com" }
     let(:email) { "  #{core_email}    " }
     let(:css_id) { "lowercase_string" }
-    subject { User.new(email: email, css_id: css_id) }
+    let(:station_id) { 101 }
+    subject { User.find_or_create_by(email: email, css_id: css_id, station_id: station_id) }
 
     it "trims leading and trailing whitespace from User's email address" do
       expect(subject.email).to eq core_email


### PR DESCRIPTION
Connects #569.

Trims leading and trailing whitespace from email addresses when creating a new User object. Combining existing records will be left for a future ticket.