### PR TITLE
Set the current user in the request store

### DIFF
--- a/app/jobs/download_files_job.rb
+++ b/app/jobs/download_files_job.rb
@@ -2,6 +2,8 @@ class DownloadFilesJob < ActiveJob::Base
   queue_as :default
 
   def perform(download)
+    RequestStore.store[:current_user] = download.user
+
     download_documents = DownloadDocuments.new(download: download)
 
     download_documents.download_and_package


### PR DESCRIPTION
`DownloadFilesJob` might make BGS calls if veteran info is nil on the download object. BGS service requires current user information.
This should fix Sentry alert: https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/601/

connects #704 

Steps to Reproduce
1. Find a download that has nil for either ssn, first_name or last_name
2. Search for a manifest, check that one of those fields are nil in the download record
3. Start retrieving files, observe if Sentry receives the alert https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/601/