### PR TITLE
Records need to be associated with the manifest source table

### DIFF
--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -1,7 +1,7 @@
 class Manifest < ActiveRecord::Base
-  has_many :manifest_statuses
+  has_many :sources, class_name: "ManifestSource"
   has_many :user_manifests
-  has_many :records
+  has_many :records, through: :sources
 
   validates :file_number, presence: true, uniqueness: true
 end

--- a/app/models/manifest_source.rb
+++ b/app/models/manifest_source.rb
@@ -6,6 +6,7 @@ class ManifestSource < ActiveRecord::Base
   }
 
   belongs_to :manifest
+  has_many :records
 
   validates :manifest, :source, presence: true
 end

--- a/app/models/manifest_source.rb
+++ b/app/models/manifest_source.rb
@@ -1,4 +1,4 @@
-class ManifestStatus < ActiveRecord::Base
+class ManifestSource < ActiveRecord::Base
   enum status: {
     pending: 0,
     success: 1,

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -1,6 +1,6 @@
 class Record < ActiveRecord::Base
-  belongs_to :manifest
+  belongs_to :manifest_source
 
-  validates :manifest, :external_document_id, presence: true
+  validates :manifest_source, :external_document_id, presence: true
   validates :external_document_id, uniqueness: true
 end

--- a/db/migrate/20171122161202_rename_manifest_statuses_to_manifest_sources.rb
+++ b/db/migrate/20171122161202_rename_manifest_statuses_to_manifest_sources.rb
@@ -1,0 +1,5 @@
+class RenameManifestStatusesToManifestSources < ActiveRecord::Migration
+  def change
+    rename_table :manifest_statuses, :manifest_sources
+  end
+end

--- a/db/migrate/20171122161559_rename_manifest_id_to_manifest_source_id_in_records.rb
+++ b/db/migrate/20171122161559_rename_manifest_id_to_manifest_source_id_in_records.rb
@@ -1,0 +1,5 @@
+class RenameManifestIdToManifestSourceIdInRecords < ActiveRecord::Migration
+  def change
+    rename_column :records, :manifest_id, :manifest_source_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171115193142) do
+ActiveRecord::Schema.define(version: 20171122161559) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,7 +85,7 @@ ActiveRecord::Schema.define(version: 20171115193142) do
   add_index "downloads", ["manifest_fetched_at"], name: "downloads_manifest_fetched_at", using: :btree
   add_index "downloads", ["user_id"], name: "index_downloads_on_user_id", using: :btree
 
-  create_table "manifest_statuses", force: :cascade do |t|
+  create_table "manifest_sources", force: :cascade do |t|
     t.integer  "manifest_id"
     t.integer  "status",      default: 0
     t.string   "source"
@@ -107,7 +107,7 @@ ActiveRecord::Schema.define(version: 20171115193142) do
   add_index "manifests", ["file_number"], name: "index_manifests_on_file_number", using: :btree
 
   create_table "records", force: :cascade do |t|
-    t.integer  "manifest_id"
+    t.integer  "manifest_source_id"
     t.integer  "status",               default: 0
     t.string   "external_document_id"
     t.string   "mime_type"

--- a/docs/v2/database_structure.md
+++ b/docs/v2/database_structure.md
@@ -43,7 +43,7 @@ We think this structure has three main advantages:
 
 ```
   # Having this separately will allow us to start fetching manifests in parallel
-  create_table :manifest_statuses do |t|
+  create_table :manifest_sources do |t|
     t.integer  "manifest_id"
     t.integer  "status",  default: 0       # Values: success, failed, pending
     t.string   "source"                    # "VBMS" or "VVA"
@@ -66,7 +66,7 @@ We think this structure has three main advantages:
 
 ```
   create_table "records" do |t|
-    t.integer  "manifest_id"
+    t.integer  "manifest_source_id"
     t.integer  "status",  default: 0
     t.string   "external_document_id"
     t.string   "mime_type"


### PR DESCRIPTION
Update to the v2 data model. We need to connect `records` to `manifest_sources` so we know where the document came from.

Reference: https://github.com/department-of-veterans-affairs/caseflow-efolder/blob/master/docs/v2/database_structure.md 