### PR TITLE
[WIP] Add manual 304

### DIFF
--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -1,6 +1,5 @@
 class Api::V1::DocumentsController < Api::V1::ApplicationController
-  before_action :can_access?
-  before_action :client_has_cached?
+  before_action :client_has_cached?, :can_access?
 
   def show
     # Enable document caching for a month.

--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::DocumentsController < Api::V1::ApplicationController
   before_action :can_access?
+  before_action :client_has_cached?
 
   def show
     # Enable document caching for a month.
@@ -16,6 +17,10 @@ class Api::V1::DocumentsController < Api::V1::ApplicationController
   end
 
   private
+
+  def client_has_cached?
+    render nothing: true, status: 304 if request.headers["If-None-Match"] || request.headers["If-Modified-Since"]
+  end
 
   def document_download_failed(error_kind)
     status = 500

--- a/spec/requests/api/v1/documents_spec.rb
+++ b/spec/requests/api/v1/documents_spec.rb
@@ -107,6 +107,18 @@ describe "Documents API v1", type: :request do
       end
     end
 
+    context "returns 304" do
+      it "when If-None-Match header is sent" do
+        get "/api/v1/documents/#{document.id}", nil, "If-None-Match": "something"
+        expect(response.code).to eq("304")
+      end
+
+      it "when If-Modified-Since header is sent" do
+        get "/api/v1/documents/#{document.id}", nil, "If-Modified-Since": "something"
+        expect(response.code).to eq("304")
+      end
+    end
+
     it "returns 500 on any other error" do
       allow_any_instance_of(Fetcher).to receive(:content).and_raise("Much random error")
       expect(Raven).to receive(:capture_exception)


### PR DESCRIPTION
Currently if a user requests a document for which they supply either an eTag or a last modified date, then we want to tell them to just use their cache. Currently this happens by us serving the request, rails hashing the response body, determining that it's the same, and sending a 304. Instead we'd like to short circuit and return the 304 immediately.

**Test Plan**
- [ ] Test with Reader hooked up to a local eFolder Express and ensure documents still download properly.