### PR TITLE
Update Gemfile to use newest caseflow-commons version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source ENV['GEM_SERVER_URL'] || 'https://rubygems.org'
 
-gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "c24ad69cf999c30b01deaadc0e8c13f6109c8c54"
+gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "a8d42e6563277144938f0a513ee601233814ff86"
 
 gem "moment_timezone-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/caseflow-commons
-  revision: c24ad69cf999c30b01deaadc0e8c13f6109c8c54
-  ref: c24ad69cf999c30b01deaadc0e8c13f6109c8c54
+  revision: a8d42e6563277144938f0a513ee601233814ff86
+  ref: a8d42e6563277144938f0a513ee601233814ff86
   specs:
     caseflow (0.1.6)
       aws-sdk (~> 2)


### PR DESCRIPTION
Updated caseflow-commons dependency to [newest version](https://github.com/department-of-veterans-affairs/caseflow-commons/commit/a8d42e6563277144938f0a513ee601233814ff86) from previous oldest version. The [only changes](https://github.com/department-of-veterans-affairs/caseflow-commons/pull/120) to caseflow-commons included in this upgrade are CSS changes to the remove a deprecated dark red color in favor of the lighter red we've settled on in [the style guide](http://dsva-appeals-certification-demo-1715715888.us-gov-west-1.elb.amazonaws.com/styleguide).