### PR TITLE
Do not attempt to create User db row unless we have CSS_ID and station_id

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,7 +42,10 @@ class User < ActiveRecord::Base
   class << self
     def from_session_and_request(session, request)
       return nil unless session["user"]
+
       sesh = CssAuthenticationSession.new(session["user"])
+      return nil unless sesh.css_id && sesh.station_id
+
       find_or_create_by(css_id: sesh.css_id, station_id: sesh.station_id).tap do |u|
         u.name = sesh.name
         u.email = sesh.email

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -64,6 +64,11 @@ describe User do
       let(:session) { { "user" => nil } }
       it { is_expected.to be_nil }
     end
+
+    context "when session user does not contain css_id" do
+      let(:session) { { "user" => { "roles" => ["Certify Appeal", "Establish Claim"], "station_id" => "283", "email" => "america@example.com", "name" => "Cave Johnson" } } }
+      it { is_expected.to be_nil }
+    end
   end
 
   context ".from_api_authenticated_values" do


### PR DESCRIPTION
Connects #717.

Caseflow was previously not saving the CSS ID to the "user" element of the session. [This PR for caseflow](https://github.com/department-of-veterans-affairs/caseflow/pull/4128) added the CSS ID to the default fake user (as well as the efolder role), so that should address the root of the problem.

The code changes in this PR allow for a more graceful handling of this state should it arise again.