### PR TITLE
Set document filepath before downloading document from S3

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -29,6 +29,10 @@ class Document < ActiveRecord::Base
     Zaru.sanitize! "#{cropped_type_name}-#{filename_date}-#{filename_doc_id}.#{preferred_extension}"
   end
 
+  def path
+    @path ||= File.join(download.download_dir, id.to_s)
+  end
+
   def fetch_content!(save_document_metadata:)
     return {
       content: fetcher.content(save_document_metadata: save_document_metadata),
@@ -91,20 +95,14 @@ class Document < ActiveRecord::Base
     @fetcher ||= Fetcher.new(document: self, external_service: external_service)
   end
 
-  def save_locally(content, index)
-    build_filepath_with(index)
-
+  def save_locally(content)
     if preferred_extension == "pdf"
-      PdfService.write(filepath, content, pdf_attributes)
+      PdfService.write(path, content, pdf_attributes)
     else
-      File.open(filepath, "wb") do |f|
+      File.open(path, "wb") do |f|
         f.write(content)
       end
     end
-  end
-
-  def build_filepath_with(index)
-    update_attributes!(filepath: File.join(download.download_dir, unique_filename(index)))
   end
 
   def pdf_attributes

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -92,7 +92,7 @@ class Document < ActiveRecord::Base
   end
 
   def save_locally(content, index)
-    filepath = File.join(download.download_dir, unique_filename(index))
+    build_filepath_with(index)
 
     if preferred_extension == "pdf"
       PdfService.write(filepath, content, pdf_attributes)
@@ -101,7 +101,10 @@ class Document < ActiveRecord::Base
         f.write(content)
       end
     end
-    update_attributes!(filepath: filepath)
+  end
+
+  def build_filepath_with(index)
+    update_attributes!(filepath: File.join(download.download_dir, unique_filename(index)))
   end
 
   def pdf_attributes

--- a/app/services/download_documents.rb
+++ b/app/services/download_documents.rb
@@ -68,10 +68,10 @@ class DownloadDocuments
       return false
     end
 
-    @download.documents.where(download_status: 0).each_with_index do |document, index|
+    @download.documents.where(download_status: 0).each do |document|
       before_document_download(document)
       fetch_result = document.fetch_content!(save_document_metadata: true)
-      document.save_locally(fetch_result[:content], index) if save_locally && !fetch_result[:error_kind]
+      document.save_locally(fetch_result[:content]) if save_locally && !fetch_result[:error_kind]
 
       return false if fetch_result[:error_kind] == :caseflow_efolder_error
       @download.touch
@@ -80,9 +80,9 @@ class DownloadDocuments
 
   def fetch_from_s3(document)
     # if the file exists on the filesystem, skip
-    return if document.filepath && File.exist?(document.filepath)
+    return if File.exist?(document.path)
 
-    S3Service.fetch_file(document.s3_filename, document.filepath)
+    S3Service.fetch_file(document.s3_filename, document.path)
   end
 
   def zip_exists_locally?
@@ -109,9 +109,8 @@ class DownloadDocuments
 
     Zip::File.open(zip_path, Zip::File::CREATE) do |zipfile|
       @download.documents.success.each_with_index do |document, index|
-        document.build_filepath_with(index) if document.filepath.nil?
         fetch_from_s3(document)
-        zipfile.add(document.unique_filename(index), document.filepath)
+        zipfile.add(document.unique_filename(index), document.path)
       end
     end
 

--- a/app/services/download_documents.rb
+++ b/app/services/download_documents.rb
@@ -109,7 +109,7 @@ class DownloadDocuments
 
     Zip::File.open(zip_path, Zip::File::CREATE) do |zipfile|
       @download.documents.success.each_with_index do |document, index|
-        document.build_filepath_with(index)
+        document.build_filepath_with(index) if document.filepath.nil?
         fetch_from_s3(document)
         zipfile.add(document.unique_filename(index), document.filepath)
       end

--- a/app/services/download_documents.rb
+++ b/app/services/download_documents.rb
@@ -109,6 +109,7 @@ class DownloadDocuments
 
     Zip::File.open(zip_path, Zip::File::CREATE) do |zipfile|
       @download.documents.success.each_with_index do |document, index|
+        document.build_filepath_with(index)
         fetch_from_s3(document)
         zipfile.add(document.unique_filename(index), document.filepath)
       end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -227,15 +227,17 @@ describe Document do
 
     it "creates a file in the correct directory and returns filename" do
       file_contents = IO.binread(Rails.root + "spec/support/test.pdf")
-      document.save_locally(file_contents, 3)
-      expected_filepath = Rails.root + "tmp/files/#{download.id}/00040-VA 21-0166 VA Letter to Beneficiary-20150906-3333-3333.pdf"
+      document.save!
+      document.save_locally(file_contents)
+      expected_filepath = Rails.root + "tmp/files/#{download.id}/#{document.id}"
       expect(File.exist?(expected_filepath)).to be_truthy
-      expect(document.filepath).to eq(expected_filepath.to_s)
+      expect(document.path).to eq(expected_filepath.to_s)
     end
 
     it "handles non-pdf files correctly" do
-      txt_document.save_locally("Howdy", 3)
-      expect(IO.read(txt_document.filepath)).to eq("Howdy")
+      txt_document.save!
+      txt_document.save_locally("Howdy")
+      expect(IO.read(txt_document.path)).to eq("Howdy")
     end
   end
 


### PR DESCRIPTION
Connects #736.

I think this happened because somebody clicked "Try retrieving efolder again" while another job was waiting to be completed. This called `DownloadsController.retry()` which called `Download.reset!()` which sets `Document.filepath` to nil. I can confirm this with more investigation into the logs if we need.

This fix simply sets the document's filepath if it is nil so we have somewhere to download the document to.