### PR TITLE
Update metrics service to send to DataDog

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ gem "sentry-raven"
 
 gem 'newrelic_rpm'
 
+gem "dogapi" 
+
 # SSOI
 gem 'omniauth-saml-va', git: 'https://github.com/department-of-veterans-affairs/omniauth-saml-va', branch: 'paultag/css'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,8 @@ GEM
     database_cleaner (1.5.3)
     diff-lcs (1.2.5)
     docile (1.1.5)
+    dogapi (1.28.0)
+      multi_json
     dotenv (2.2.1)
     dotenv-rails (2.2.1)
       dotenv (= 2.2.1)
@@ -469,6 +471,7 @@ DEPENDENCIES
   connect_vbms!
   connect_vva!
   database_cleaner
+  dogapi
   dotenv-rails
   jbuilder (~> 2.0)
   jquery-rails

--- a/app/services/data_dog_service.rb
+++ b/app/services/data_dog_service.rb
@@ -1,0 +1,27 @@
+require "dogapi"
+
+class DataDogService
+  datadog_api_key = ENV["DATADOG_API_KEY"]
+  if datadog_api_key.nil?
+    Rails.logger.warn "Env var DATADOG_API_KEY is not set, so DataDog metrics will not be tracked."
+    # Setting the API key to an empty string will make tracking requests silently fail, which is what we want.
+    datadog_api_key = ""
+  end
+
+  @dog = Dogapi::Client.new(datadog_api_key)
+
+  # rubocop:disable Metrics/ParameterLists
+  def self.emit_datadog_point(
+    metric_group:, metric_name:, metric_value:, app_name:, attrs: {}, metric_type: "counter"
+  )
+    extra_tags = attrs.reduce([]) do |tags, (key, val)|
+      tags << "#{key}:#{val}"
+    end
+    @dog.emit_point("dsva-appeals.#{metric_group}.#{metric_name}", metric_value,
+                    host: `hostname`.strip, type: metric_type,
+                    tags: [
+                      "app:#{app_name}",
+                      "env:#{Rails.env}"
+                    ] + extra_tags)
+  end
+end

--- a/app/services/data_dog_service.rb
+++ b/app/services/data_dog_service.rb
@@ -9,6 +9,7 @@ class DataDogService
   end
 
   @dog = Dogapi::Client.new(datadog_api_key)
+  @host = `curl http://instance-data/latest/meta-data/instance-id || echo "not-ec2"`.strip
 
   # rubocop:disable Metrics/ParameterLists
   def self.emit_datadog_point(
@@ -18,7 +19,7 @@ class DataDogService
       tags << "#{key}:#{val}"
     end
     @dog.emit_point("dsva-appeals.#{metric_group}.#{metric_name}", metric_value,
-                    host: `hostname`.strip, type: metric_type,
+                    host: @host, type: metric_type,
                     tags: [
                       "app:#{app_name}",
                       "env:#{Rails.env}"

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -1,11 +1,21 @@
 require "benchmark"
+require "dogapi"
 
 # see https://dropwizard.github.io/metrics/3.1.0/getting-started/ for abstractions on metric types
 class MetricsService
+  datadog_api_key = ENV["DATADOG_API_KEY"]
+  if datadog_api_key.nil?
+    Rails.logger.warn "Env var DATADOG_API_KEY is not set, so DataDog metrics will not be tracked."
+    # Setting the API key to an empty string will make tracking requests silently fail, which is what we want.
+    datadog_api_key = ""
+  end
+
+  @dog = Dogapi::Client.new(datadog_api_key)
+  @app = "eFolder"
+
   # rubocop:disable Metrics/MethodLength
   def self.record(description, service: nil, name: "unknown")
     return_value = nil
-    app = "eFolder"
 
     Rails.logger.info("STARTED #{description}")
     stopwatch = Benchmark.measure do
@@ -15,7 +25,9 @@ class MetricsService
     if service
       metric = PrometheusService.send("#{service}_request_latency".to_sym)
 
-      metric.set({ app: app, name: name }, stopwatch.real)
+      latency = stopwatch.real
+      metric.set({ app: @app, name: name }, latency)
+      emit_datadog_point("request_latency", latency, service, name)
 
     end
 
@@ -24,16 +36,29 @@ class MetricsService
   rescue
     if service
       metric = PrometheusService.send("#{service}_request_error_counter".to_sym)
-      metric.increment(app: app, name: name)
+      metric.increment(app: @app, name: name)
+      emit_datadog_point("request_error", 1, service, name)
     end
 
-    # Reraise the same error. We don't want to interfere at all in normal error handling
-    # this is just to capture the metric
+    # Re-raise the same error. We don't want to interfere at all in normal error handling.
+    # This is just to capture the metric
     raise
   ensure
     if service
       metric = PrometheusService.send("#{service}_request_attempt_counter".to_sym)
-      metric.increment(app: app, name: name)
+      metric.increment(app: @app, name: name)
+      emit_datadog_point("request_attempt", 1, service, name)
     end
+  end
+
+  private_class_method def self.emit_datadog_point(metric_name, metric_value, service, endpoint_name)
+    @dog.emit_point("caseflow.service.#{metric_name}", metric_value,
+                    host: `hostname`.strip, type: "counter",
+                    tags: [
+                      "app:#{@app}",
+                      "service:#{service}",
+                      "env:#{Rails.env}",
+                      "endpoint_name:#{endpoint_name}"
+                    ])
   end
 end

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -18,8 +18,16 @@ class MetricsService
 
       latency = stopwatch.real
       metric.set({ app: @app, name: name }, latency)
-      emit_datadog_point("request_latency", latency, service, name)
-
+      DataDogService.emit_gauge(
+        metric_group: "service",
+        metric_name: "request_latency",
+        metric_value: latency,
+        app_name: @app,
+        attrs: {
+          service: service,
+          endpoint: name
+        }
+      )
     end
 
     Rails.logger.info("FINISHED #{description}: #{stopwatch}")
@@ -28,7 +36,7 @@ class MetricsService
     if service
       metric = PrometheusService.send("#{service}_request_error_counter".to_sym)
       metric.increment(app: @app, name: name)
-      emit_datadog_point("request_error", 1, service, name)
+      increment_datadog_counter("request_error", service, name)
     end
 
     # Re-raise the same error. We don't want to interfere at all in normal error handling.
@@ -38,17 +46,17 @@ class MetricsService
     if service
       metric = PrometheusService.send("#{service}_request_attempt_counter".to_sym)
       metric.increment(app: @app, name: name)
-      emit_datadog_point("request_attempt", 1, service, name)
+      increment_datadog_counter("request_attempt", service, name)
     end
   end
 
-  private_class_method def self.emit_datadog_point(metric_name, metric_value, _service, endpoint_name)
-    DataDogService.emit_datadog_point(
+  private_class_method def self.increment_datadog_counter(metric_name, service, endpoint_name)
+    DataDogService.increment_counter(
       metric_group: "service",
       metric_name: metric_name,
-      metric_value: metric_value,
       app_name: @app,
       attrs: {
+        service: service,
         endpoint: endpoint_name
       }
     )

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -32,7 +32,7 @@ class MetricsService
     end
 
     # Re-raise the same error. We don't want to interfere at all in normal error handling.
-    # This is just to capture the metric
+    # This is just to capture the metric.
     raise
   ensure
     if service


### PR DESCRIPTION
This PR matches https://github.com/department-of-veterans-affairs/caseflow/pull/4160.

I tested this with the following in the console:

```
MetricsService.record("test description", service: :image_magick, name: "image_magick_convert_tiff_to_pdf") do puts "fake" end
```

and then checked to see that metric show in up DataDog.