### PR TITLE
Sentry - Ignore exceptions when VBMS/VVA are in maintenance

### DIFF
--- a/app/jobs/download_manifest_job.rb
+++ b/app/jobs/download_manifest_job.rb
@@ -33,16 +33,11 @@ class DownloadManifestJob < ActiveJob::Base
     download.update_attributes!(manifest_fetched_at_name => Time.zone.now)
     return nil, external_documents
   rescue client_error => e
-    capture_error(e)
+    ExceptionLogger.capture(e)
     return connection_error_tag, nil
   end
 
   private
-
-  def capture_error(e)
-    Rails.logger.error "#{e.message}\n#{e.backtrace.join("\n")}"
-    Raven.capture_exception(e)
-  end
 
   def create_documents(download, external_documents)
     download_documents = DownloadDocuments.new(

--- a/app/services/exception_logger.rb
+++ b/app/services/exception_logger.rb
@@ -1,0 +1,13 @@
+class ExceptionLogger
+  DEPENDENCY_MAINTENANCE = [/Could not get JDBC Connection/, /Maintenance.+VBMS/, /upstream connect error or disconnect/].freeze
+
+  def self.capture(e)
+    Rails.logger.error "#{e.message}\n#{e.backtrace.join("\n")}"
+    Raven.capture_exception(e) unless ignore_exception?(e)
+  end
+
+  # Do not send Sentry alerts when external systems are in maintenance mode
+  def self.ignore_exception?(e)
+    DEPENDENCY_MAINTENANCE.select { |m| m =~ e.to_s }.present?
+  end
+end

--- a/app/services/manifest_fetcher.rb
+++ b/app/services/manifest_fetcher.rb
@@ -12,12 +12,7 @@ class ManifestFetcher
     documents
   rescue *EXCEPTIONS => e
     manifest_source.update(status: :failed)
-    log_error(e)
+    ExceptionLogger.capture(e)
     []
-  end
-
-  def log_error(e)
-    Rails.logger.error "#{e.message}\n#{e.backtrace.join("\n")}"
-    Raven.capture_exception(e)
   end
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -5,5 +5,9 @@ if ENV['SENTRY_DSN']
     # Sometimes, a VA backend will randomly fail. When we retry, it generally works.
     # We do not need to log this to Sentry, because it's not actionable for us.
     config.excluded_exceptions += ['EOFError']
+
+    # Do not send Sentry alerts when external systems are in maintenance mode
+    # to test it: simulate these errors
+    config.excluded_exceptions += [/Could not get JDBC Connection/, /Maintenance - VBMS/, /upstream connect error or disconnect/]
   end
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -5,9 +5,5 @@ if ENV['SENTRY_DSN']
     # Sometimes, a VA backend will randomly fail. When we retry, it generally works.
     # We do not need to log this to Sentry, because it's not actionable for us.
     config.excluded_exceptions += ['EOFError']
-
-    # Do not send Sentry alerts when external systems are in maintenance mode
-    # to test it: simulate these errors
-    config.excluded_exceptions += [/Could not get JDBC Connection/, /Maintenance - VBMS/, /upstream connect error or disconnect/]
   end
 end

--- a/spec/services/exception_logger_spec.rb
+++ b/spec/services/exception_logger_spec.rb
@@ -1,0 +1,26 @@
+describe ExceptionLogger do
+  subject { ExceptionLogger.capture(error) }
+
+  context ".capture" do
+    before do
+      allow(Raven).to receive(:capture_exception)
+    end
+    context "when external system is in maintenance mode" do
+      let(:error) { OpenStruct.new(message: "Maintenance - VBMS", backtrace: []) }
+
+      it "should not log error in Sentry" do
+        subject
+        expect(Raven).to_not have_received(:capture_exception)
+      end
+    end
+
+    context "when external system is not in maintenance mode" do
+      let(:error) { OpenStruct.new(message: "Some other error", backtrace: []) }
+
+      it "should log error in Sentry" do
+        subject
+        expect(Raven).to have_received(:capture_exception)
+      end
+    end
+  end
+end


### PR DESCRIPTION
connects #763 

When VVA/VBMS is down, connect_vva and connect_vbms correctly catch the exception that is then passed to the eX and download gets a status of vva_connection_error or vbms_connection_error. 

When VBMS or VVA is in maintenance, do not capture these errors in Sentry.

### Note
Unfortunately, Sentry `excluded_exceptions` doesn't provide support for regular expressions so I created our own  class to exclude certain exceptions. 
See here what Raven does: https://github.com/getsentry/raven-ruby/blob/00c572b281b0862e2fbb7872b28c95e7c2578949/lib/raven/configuration.rb#L331