### PR TITLE
Adding feature toggle to disable conversion of tiff's to pdfs

### DIFF
--- a/app/services/image_converter_service.rb
+++ b/app/services/image_converter_service.rb
@@ -13,7 +13,9 @@ class ImageConverterService
   # If the converter converts this mime_type then this returns the converted type
   # otherwise it just returns the original type.
   def self.converted_mime_type(mime_type)
-    return "application/pdf" if mime_type == "image/tiff"
+    if FeatureToggle.enabled?(:convert_tiff_images)
+      return "application/pdf" if mime_type == "image/tiff"
+    end
 
     mime_type
   end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -247,9 +247,26 @@ describe Document do
     end
 
     context "when passed image/tiff" do
-      let(:mime_type) { "image/tiff" }
-      it "returns pdf" do
-        expect(document.preferred_extension).to eq("pdf")
+      context "when convert_tiff_images feature toggle is on" do
+        before do
+          FeatureToggle.enable!(:convert_tiff_images)
+        end
+
+        let(:mime_type) { "image/tiff" }
+        it "returns pdf" do
+          expect(document.preferred_extension).to eq("pdf")
+        end
+      end
+
+      context "when convert_tiff_images feature toggle is off" do
+        before do
+          FeatureToggle.disable!(:convert_tiff_images)
+        end
+
+        let(:mime_type) { "image/tiff" }
+        it "returns tiff" do
+          expect(document.preferred_extension).to eq("tiff")
+        end
       end
     end
 

--- a/spec/models/fetcher_spec.rb
+++ b/spec/models/fetcher_spec.rb
@@ -54,6 +54,10 @@ describe Fetcher do
       end
 
       context "when VBMS returns a tiff file" do
+        before do
+          FeatureToggle.enable!(:convert_tiff_images)
+        end
+
         let(:document) do
           download.documents.build(
             id: "1234",

--- a/spec/models/record_spec.rb
+++ b/spec/models/record_spec.rb
@@ -71,6 +71,10 @@ describe Record do
     end
 
     context "when passed image/tiff" do
+      before do
+        FeatureToggle.enable!(:convert_tiff_images)
+      end
+
       let(:mime_type) { "image/tiff" }
       it "returns pdf" do
         expect(record.preferred_extension).to eq("pdf")

--- a/spec/services/image_converter_service_spec.rb
+++ b/spec/services/image_converter_service_spec.rb
@@ -9,6 +9,10 @@ describe ImageConverterService do
   let(:image_converter) { ImageConverterService.new(image: tiff_content, mime_type: mime_type) }
 
   context "#process" do
+    before do
+      FeatureToggle.enable!(:convert_tiff_images)
+    end
+
     context "when image is a tiff" do
       it "converts it" do
         expect(valid_pdf?(image_converter.process)).to be_truthy


### PR DESCRIPTION
We only convert an image if `converted_mime_type` returns a new mime_type. This adds a feature toggle to force `converted_mime_type` to return the original mime_type and therefore not convert the image.