### PR TITLE
Switch DataDog to use dogstatsd

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,11 +37,8 @@ gem "sentry-raven"
 
 gem 'newrelic_rpm'
 
-<<<<<<< HEAD
 gem "dogstatsd-ruby" 
 
-=======
->>>>>>> master
 # SSOI
 gem 'omniauth-saml-va', git: 'https://github.com/department-of-veterans-affairs/omniauth-saml-va', branch: 'paultag/css'
 

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem "sentry-raven"
 
 gem 'newrelic_rpm'
 
-gem "dogapi" 
+gem "dogstatsd-ruby" 
 
 # SSOI
 gem 'omniauth-saml-va', git: 'https://github.com/department-of-veterans-affairs/omniauth-saml-va', branch: 'paultag/css'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,10 +173,7 @@ GEM
     database_cleaner (1.5.3)
     diff-lcs (1.2.5)
     docile (1.1.5)
-<<<<<<< HEAD
     dogstatsd-ruby (3.1.0)
-=======
->>>>>>> master
     dotenv (2.2.1)
     dotenv-rails (2.2.1)
       dotenv (= 2.2.1)
@@ -473,10 +470,7 @@ DEPENDENCIES
   connect_vbms!
   connect_vva!
   database_cleaner
-<<<<<<< HEAD
   dogstatsd-ruby
-=======
->>>>>>> master
   dotenv-rails
   jbuilder (~> 2.0)
   jquery-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,8 +173,7 @@ GEM
     database_cleaner (1.5.3)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    dogapi (1.28.0)
-      multi_json
+    dogstatsd-ruby (3.1.0)
     dotenv (2.2.1)
     dotenv-rails (2.2.1)
       dotenv (= 2.2.1)
@@ -471,7 +470,7 @@ DEPENDENCIES
   connect_vbms!
   connect_vva!
   database_cleaner
-  dogapi
+  dogstatsd-ruby
   dotenv-rails
   jbuilder (~> 2.0)
   jquery-rails

--- a/app/services/data_dog_service.rb
+++ b/app/services/data_dog_service.rb
@@ -22,7 +22,7 @@ class DataDogService
 
   private_class_method def self.get_tags(app_name, attrs)
     extra_tags = attrs.reduce([]) do |tags, (key, val)|
-      tags + "#{key}:#{val}"
+      tags + ["#{key}:#{val}"]
     end
     [
       "app:#{app_name}",

--- a/app/services/data_dog_service.rb
+++ b/app/services/data_dog_service.rb
@@ -1,40 +1,35 @@
-require "dogapi"
+require "datadog/statsd"
 
 class DataDogService
-  datadog_api_key = ENV["DATADOG_API_KEY"]
-  if datadog_api_key.nil?
-    Rails.logger.warn "Env var DATADOG_API_KEY is not set, so DataDog metrics will not be tracked."
-    # Setting the API key to an empty string will make tracking requests silently fail, which is what we want.
-    datadog_api_key = ""
-  end
-
-  @dog = Dogapi::Client.new(datadog_api_key)
+  @statsd = Datadog::Statsd.new
   @host = `curl http://instance-data/latest/meta-data/instance-id --silent || echo "not-ec2"`.strip
 
   def self.increment_counter(metric_group:, metric_name:, app_name:, attrs: {})
-    emit_datadog_point(
-      metric_group: metric_group, metric_name: metric_name, app_name: app_name,
-      attrs: attrs, metric_type: "counter", metric_value: 1)
+    tags = get_tags(app_name, attrs)
+    stat_name = get_stat_name(metric_group, metric_name)
+    @statsd.increment(stat_name, tags: tags)
   end
 
   def self.emit_gauge(metric_group:, metric_name:, metric_value:, app_name:, attrs: {})
-    emit_datadog_point(
-      metric_group: metric_group, metric_name: metric_name, metric_value: metric_value, app_name: app_name,
-      attrs: attrs, metric_type: "gauge")
+    tags = get_tags(app_name, attrs)
+    stat_name = get_stat_name(metric_group, metric_name)
+    @statsd.gauge(stat_name, metric_value, tags: tags)
   end
 
-  # rubocop:disable Metrics/ParameterLists
-  private_class_method def self.emit_datadog_point(
-    metric_group:, metric_name:, metric_value:, app_name:, attrs:, metric_type:
-  )
+  private_class_method def self.get_stat_name(metric_group, metric_name)
+    "dsva-appeals.#{metric_group}.#{metric_name}"
+  end
+
+  private_class_method def self.get_tags(app_name, attrs)
     extra_tags = attrs.reduce([]) do |tags, (key, val)|
-      tags << "#{key}:#{val}"
+      tags + "#{key}:#{val}"
     end
-    @dog.emit_point("dsva-appeals.#{metric_group}.#{metric_name}", metric_value,
-                    host: @host, type: metric_type,
-                    tags: [
-                      "app:#{app_name}",
-                      "env:#{Rails.env}"
-                    ] + extra_tags)
+    [
+      "app:#{app_name}",
+      "env:#{Rails.env}",
+      # I am not sure that dogstatsd lets us set the hostname.
+      # https://github.com/DataDog/dogstatsd-ruby/issues/66
+      "hostname:#{@host}"
+    ] + extra_tags
   end
 end

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -3,9 +3,9 @@ require "benchmark"
 # see https://dropwizard.github.io/metrics/3.1.0/getting-started/ for abstractions on metric types
 class MetricsService
   # rubocop:disable Metrics/MethodLength
+  @app = "eFolder"
   def self.record(description, service: nil, name: "unknown")
     return_value = nil
-    app = "eFolder"
 
     Rails.logger.info("STARTED #{description}")
     stopwatch = Benchmark.measure do
@@ -15,8 +15,18 @@ class MetricsService
     if service
       metric = PrometheusService.send("#{service}_request_latency".to_sym)
 
-      metric.set({ app: app, name: name }, stopwatch.real)
-
+      latency = stopwatch.real
+      metric.set({ app: @app, name: name }, latency)
+      DataDogService.emit_gauge(
+        metric_group: "service",
+        metric_name: "request_latency",
+        metric_value: latency,
+        app_name: @app,
+        attrs: {
+          service: service,
+          endpoint: name
+        }
+      )
     end
 
     Rails.logger.info("FINISHED #{description}: #{stopwatch}")
@@ -24,16 +34,30 @@ class MetricsService
   rescue
     if service
       metric = PrometheusService.send("#{service}_request_error_counter".to_sym)
-      metric.increment(app: app, name: name)
+      metric.increment(app: @app, name: name)
+      increment_datadog_counter("request_error", service, name)
     end
 
-    # Reraise the same error. We don't want to interfere at all in normal error handling
-    # this is just to capture the metric
+    # Re-raise the same error. We don't want to interfere at all in normal error handling.
+    # This is just to capture the metric.
     raise
   ensure
     if service
       metric = PrometheusService.send("#{service}_request_attempt_counter".to_sym)
-      metric.increment(app: app, name: name)
+      metric.increment(app: @app, name: name)
+      increment_datadog_counter("request_attempt", service, name)
     end
+  end
+
+  private_class_method def self.increment_datadog_counter(metric_name, service, endpoint_name)
+    DataDogService.increment_counter(
+      metric_group: "service",
+      metric_name: metric_name,
+      app_name: @app,
+      attrs: {
+        service: service,
+        endpoint: endpoint_name
+      }
+    )
   end
 end

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -1,5 +1,4 @@
 require "benchmark"
-require "dogapi"
 
 # see https://dropwizard.github.io/metrics/3.1.0/getting-started/ for abstractions on metric types
 class MetricsService


### PR DESCRIPTION
I used the same testing process as https://github.com/department-of-veterans-affairs/caseflow-efolder/pull/776. I installed the macOS DataDog agent so this new approach could work.

In the screenshot below, you can see the data showing up ([sample notebook](https://app.datadoghq.com/notebook/23056/Delete%20this%20after%20caseflow-efolder%23789%20is%20merged)):

![image](https://user-images.githubusercontent.com/25331532/34117865-fa7c04d6-e3ea-11e7-9012-37fd1291777f.png)

Here is the data from UAT:

![image](https://user-images.githubusercontent.com/25331532/34133764-a1d1a1ee-e424-11e7-9d83-1666f6ddd6e6.png)


