### PR TITLE
Lowell test fixes 1

### DIFF
--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -1,9 +1,6 @@
 class Fakes::BGSService
   include ActiveModel::Model
 
-  cattr_accessor :veteran_info
-  cattr_accessor :sensitive_files
-
   def demo?(file_number)
     !!(file_number =~ /^DEMO/)
   end
@@ -40,4 +37,9 @@ class Fakes::BGSService
   def check_sensitivity(file_number)
     !(sensitive_files || {})[file_number]
   end
+
+  # Methods to be stubbed out in tests:
+  def veteran_info; end
+
+  def sensitive_files; end
 end

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -56,13 +56,14 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Creating a download" do
-    Fakes::BGSService.veteran_info = {
+    veteran_info = {
       "12341234" => {
         "veteran_first_name" => "Stan",
         "veteran_last_name" => "Lee",
         "veteran_last_four_ssn" => "2222"
       }
     }
+    allow_any_instance_of(Fakes::BGSService).to receive(:veteran_info).and_return(veteran_info)
 
     visit "/"
     expect(page).to_not have_content "Recent Searches"
@@ -71,7 +72,7 @@ RSpec.feature "Downloads" do
     click_button "Search"
 
     # Test that Caseflow caches veteran name for a download
-    Fakes::BGSService.veteran_info = {}
+    allow_any_instance_of(Fakes::BGSService).to receive(:veteran_info).and_return(nil)
 
     @download = @user_download.last
     expect(@download).to_not be_nil
@@ -91,13 +92,14 @@ RSpec.feature "Downloads" do
   end
 
   scenario ": initial wait" do
-    Fakes::BGSService.veteran_info = {
+    veteran_info = {
       "1234" => {
         "veteran_first_name" => "Stan",
         "veteran_last_name" => "Lee",
         "veteran_last_four_ssn" => "2222"
       }
     }
+    allow_any_instance_of(Fakes::BGSService).to receive(:veteran_info).and_return(veteran_info)
 
     visit "/"
 
@@ -110,13 +112,14 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Searching for an errored download tries again" do
-    Fakes::BGSService.veteran_info = {
+    veteran_info = {
       "55555555" => {
         "veteran_first_name" => "Stan",
         "veteran_last_name" => "Lee",
         "veteran_last_four_ssn" => "2222"
       }
     }
+    allow_any_instance_of(Fakes::BGSService).to receive(:veteran_info).and_return(veteran_info)
 
     @user_download.create!(
       file_number: "55555555",
@@ -147,13 +150,14 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Extraneous spaces in search input" do
-    Fakes::BGSService.veteran_info = {
+    veteran_info = {
       "12341234" => {
         "veteran_first_name" => "Stan",
         "veteran_last_name" => "Lee",
         "veteran_last_four_ssn" => "2222"
       }
     }
+    allow_any_instance_of(Fakes::BGSService).to receive(:veteran_info).and_return(veteran_info)
 
     visit "/"
     expect(page).to_not have_content "Recent Searches"
@@ -203,8 +207,11 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Sensitive download error" do
-    Fakes::BGSService.veteran_info = { "88888888" => { "veteran_first_name" => "Nick", "veteran_last_name" => "Saban" } }
-    Fakes::BGSService.sensitive_files = { "88888888" => true }
+    veteran_info = { "88888888" => { "veteran_first_name" => "Nick", "veteran_last_name" => "Saban" } }
+    sensitive_files = { "88888888" => true }
+
+    allow_any_instance_of(Fakes::BGSService).to receive(:veteran_info).and_return(veteran_info)
+    allow_any_instance_of(Fakes::BGSService).to receive(:sensitive_files).and_return(sensitive_files)
 
     visit "/"
     fill_in "Search for a Veteran ID number below to get started.", with: "88888888"
@@ -214,9 +221,6 @@ RSpec.feature "Downloads" do
 
     search = Search.where(user: @user).first
     expect(search).to be_access_denied
-
-    Fakes::BGSService.sensitive_files = nil
-    Fakes::BGSService.veteran_info = nil
   end
 
   scenario "Attempting to view download created by another user" do
@@ -278,13 +282,14 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Confirming download" do
-    Fakes::BGSService.veteran_info = {
+    veteran_info = {
       "3456" => {
         "veteran_first_name" => "Steph",
         "veteran_last_name" => "Curry",
         "veteran_last_four_ssn" => "2345"
       }
     }
+    allow_any_instance_of(Fakes::BGSService).to receive(:veteran_info).and_return(veteran_info)
     download = @user_download.create(file_number: "3456", status: :fetching_manifest)
 
     visit download_path(download)
@@ -439,13 +444,14 @@ RSpec.feature "Downloads" do
   end
 
   scenario "Completed download" do
-    Fakes::BGSService.veteran_info = {
+    veteran_info = {
       "12" => {
         "veteran_first_name" => "Stan",
         "veteran_last_name" => "Lee",
         "veteran_last_four_ssn" => "2222"
       }
     }
+    allow_any_instance_of(Fakes::BGSService).to receive(:veteran_info).and_return(veteran_info)
     # clean files
     FileUtils.rm_rf(Rails.application.config.download_filepath)
 

--- a/spec/jobs/save_files_in_s3_spec.rb
+++ b/spec/jobs/save_files_in_s3_spec.rb
@@ -14,9 +14,7 @@ describe SaveFilesInS3Job do
         veteran_last_name: "Washington"
       )
     end
-    let(:document_id) do
-      "{#{random_int_of_length(4)}-#{random_int_of_length(4)}}"
-    end
+    let(:document_id) { RandomHelper.valid_document_id }
     let!(:document) do
       download.documents.create(
         id: 34,
@@ -45,8 +43,4 @@ describe SaveFilesInS3Job do
       expect(S3Service).to have_received(:store_file).with(document.s3_filename, anything)
     end
   end
-end
-
-def random_int_of_length(len = 8)
-  (Array.new(len) { ("0".."9").to_a.sample }).join
 end

--- a/spec/jobs/save_files_in_s3_spec.rb
+++ b/spec/jobs/save_files_in_s3_spec.rb
@@ -14,10 +14,13 @@ describe SaveFilesInS3Job do
         veteran_last_name: "Washington"
       )
     end
+    let(:document_id) do
+      "{#{random_int_of_length(4)}-#{random_int_of_length(4)}}"
+    end
     let!(:document) do
       download.documents.create(
         id: 34,
-        document_id: "{3333-3333}",
+        document_id: document_id,
         received_at: Time.utc(2015, 9, 6, 1, 0, 0),
         type_id: "825",
         mime_type: "application/pdf"
@@ -41,4 +44,8 @@ describe SaveFilesInS3Job do
       expect(S3Service).to have_received(:store_file).with(document.s3_filename, anything)
     end
   end
+end
+
+def random_int_of_length(len = 8)
+  (Array.new(len) { ("0".."9").to_a.sample }).join
 end

--- a/spec/jobs/save_files_in_s3_spec.rb
+++ b/spec/jobs/save_files_in_s3_spec.rb
@@ -26,9 +26,8 @@ describe SaveFilesInS3Job do
         mime_type: "application/pdf"
       )
     end
-
-    before do
-      Fakes::BGSService.veteran_info = {
+    let(:veteran_info) do
+      {
         "21011" => {
           "veteran_first_name" => "Stan",
           "veteran_last_name" => "Lee",
@@ -36,6 +35,8 @@ describe SaveFilesInS3Job do
         }
       }
     end
+
+    before { allow_any_instance_of(Fakes::BGSService).to receive(:veteran_info).and_return(veteran_info) }
 
     it "saves files in S3" do
       allow(S3Service).to receive(:store_file).and_return(nil)

--- a/spec/models/download_spec.rb
+++ b/spec/models/download_spec.rb
@@ -6,16 +6,19 @@ describe "Download" do
   let(:veteran_last_four_ssn) { "0987" }
   let(:file_number) { "1234" }
 
-  before do
-    Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
-
-    Fakes::BGSService.veteran_info = {
+  let(:veteran_info) do
+    {
       file_number => {
         "veteran_first_name" => veteran_first_name,
         "veteran_last_name" => veteran_last_name,
         "veteran_last_four_ssn" => veteran_last_four_ssn
       }
     }
+  end
+
+  before do
+    Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
+    allow_any_instance_of(Fakes::BGSService).to receive(:veteran_info).and_return(veteran_info)
     FeatureToggle.enable!(:vva_service)
   end
   after { Timecop.return }
@@ -26,16 +29,6 @@ describe "Download" do
     subject { Download.new(file_number: file_number) }
 
     context "when file number is set" do
-      before do
-        Fakes::BGSService.veteran_info = {
-          file_number => {
-            "veteran_first_name" => veteran_first_name,
-            "veteran_last_name" => veteran_last_name,
-            "veteran_last_four_ssn" => veteran_last_four_ssn
-          }
-        }
-      end
-
       it "indicates that veteran info is missing if it is" do
         # veteran names & ssn are fetched right before persistance
         # to the db, so before save is called, that info won't be

--- a/spec/models/manifest_spec.rb
+++ b/spec/models/manifest_spec.rb
@@ -69,7 +69,7 @@ describe Manifest do
     end
 
     before do
-      Fakes::BGSService.veteran_info = { "445566" => veteran_record }
+      allow_any_instance_of(Fakes::BGSService).to receive(:veteran_info).and_return("445566" => veteran_record)
     end
 
     subject { manifest.veteran_first_name }

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -46,14 +46,13 @@ describe Search do
     subject { search.perform! }
 
     before do
-      Fakes::BGSService.veteran_info =
-        { "22223333" =>
+      veteran_info = { "22223333" =>
           {
             "veteran_first_name" => "John",
             "veteran_last_name" => "McJohn"
           }
         }
-      Fakes::BGSService.sensitive_files = {}
+      allow_any_instance_of(Fakes::BGSService).to receive(:veteran_info).and_return(veteran_info)
       allow(DownloadAllManifestJob).to receive(:perform_later)
 
       Download.delete_all
@@ -136,7 +135,7 @@ describe Search do
 
     context "when user cannot access file with that file_number" do
       before do
-        Fakes::BGSService.sensitive_files = { "22223333" => true }
+        allow_any_instance_of(Fakes::BGSService).to receive(:sensitive_files).and_return("22223333" => true)
       end
 
       it "sets search to access_denied and returns false" do

--- a/spec/models/veteran_spec.rb
+++ b/spec/models/veteran_spec.rb
@@ -15,7 +15,7 @@ describe Veteran do
     end
 
     before do
-      Fakes::BGSService.veteran_info = { "445566" => veteran_record }
+      allow_any_instance_of(Fakes::BGSService).to receive(:veteran_info).and_return("445566" => veteran_record)
     end
 
     context "when veteran does not exist in BGS" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -85,6 +85,10 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = false
 
+  config.before(:all) do
+    User.unauthenticate!
+  end
+
   config.after(:each) do
     Rails.cache.clear
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -79,6 +79,16 @@ module StubbableUser
 end
 User.prepend(StubbableUser)
 
+module RandomHelper
+  def self.valid_document_id
+    "{#{hex_str_of_length(8).upcase}-#{hex_str_of_length(4).upcase}-#{hex_str_of_length(4).upcase}-#{hex_str_of_length(4).upcase}-#{hex_str_of_length(12).upcase}}".upcase
+  end
+
+  def self.hex_str_of_length(len = 8)
+    SecureRandom.hex[0..len].to_s
+  end
+end
+
 RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/spec/requests/api/v1/file_spec.rb
+++ b/spec/requests/api/v1/file_spec.rb
@@ -40,7 +40,7 @@ describe "File API v1", type: :request do
   end
 
   before do
-    Fakes::BGSService.sensitive_files = { veteran_id.to_s => false }
+    allow_any_instance_of(Fakes::BGSService).to receive(:sensitive_files).and_return(veteran_id.to_s => false)
     FeatureToggle.enable!(:reader_api)
     FeatureToggle.enable!(:vva_service)
   end
@@ -227,7 +227,7 @@ describe "File API v1", type: :request do
 
   context "When sensitivity is higher than permissions" do
     before do
-      Fakes::BGSService.sensitive_files = { veteran_id.to_s => true }
+      allow_any_instance_of(Fakes::BGSService).to receive(:sensitive_files).and_return(veteran_id.to_s => true)
     end
 
     it "returns 403" do

--- a/spec/requests/api/v1/file_spec.rb
+++ b/spec/requests/api/v1/file_spec.rb
@@ -40,6 +40,7 @@ describe "File API v1", type: :request do
   end
 
   before do
+    User.unauthenticate!
     Fakes::BGSService.sensitive_files = { veteran_id.to_s => false }
     FeatureToggle.enable!(:reader_api)
     FeatureToggle.enable!(:vva_service)

--- a/spec/requests/api/v1/file_spec.rb
+++ b/spec/requests/api/v1/file_spec.rb
@@ -40,7 +40,6 @@ describe "File API v1", type: :request do
   end
 
   before do
-    User.unauthenticate!
     Fakes::BGSService.sensitive_files = { veteran_id.to_s => false }
     FeatureToggle.enable!(:reader_api)
     FeatureToggle.enable!(:vva_service)

--- a/spec/requests/api/v2/manifests_spec.rb
+++ b/spec/requests/api/v2/manifests_spec.rb
@@ -31,6 +31,7 @@ describe "Manifests API v2", type: :request do
   end
 
   before do
+    User.unauthenticate!
     Fakes::BGSService.sensitive_files = { veteran_id.to_s => false }
     Timecop.freeze(Time.utc(2015, 1, 1, 17, 0, 0))
   end

--- a/spec/requests/api/v2/manifests_spec.rb
+++ b/spec/requests/api/v2/manifests_spec.rb
@@ -31,8 +31,7 @@ describe "Manifests API v2", type: :request do
   end
 
   before do
-    User.unauthenticate!
-    Fakes::BGSService.sensitive_files = { veteran_id.to_s => false }
+    allow_any_instance_of(Fakes::BGSService).to receive(:sensitive_files).and_return(veteran_id.to_s => false)
     Timecop.freeze(Time.utc(2015, 1, 1, 17, 0, 0))
   end
 
@@ -161,7 +160,7 @@ describe "Manifests API v2", type: :request do
 
   context "When sensitivity is higher than permissions" do
     before do
-      Fakes::BGSService.sensitive_files = { veteran_id.to_s => true }
+      allow_any_instance_of(Fakes::BGSService).to receive(:sensitive_files).and_return(veteran_id.to_s => true)
     end
 
     it "returns 403" do

--- a/spec/services/image_converter_service_spec.rb
+++ b/spec/services/image_converter_service_spec.rb
@@ -8,11 +8,10 @@ describe ImageConverterService do
   let(:mime_type) { "image/tiff" }
   let(:image_converter) { ImageConverterService.new(image: tiff_content, mime_type: mime_type) }
 
-  context "#process" do
-    before do
-      FeatureToggle.enable!(:convert_tiff_images)
-    end
+  before { FeatureToggle.enable!(:convert_tiff_images) }
+  after { FeatureToggle.disable!(:convert_tiff_images) }
 
+  context "#process" do
     context "when image is a tiff" do
       it "converts it" do
         expect(valid_pdf?(image_converter.process)).to be_truthy

--- a/spec/services/record_fetcher_spec.rb
+++ b/spec/services/record_fetcher_spec.rb
@@ -61,8 +61,10 @@ describe RecordFetcher do
         let(:mime_type) { "image/tiff" }
 
         before do
+          FeatureToggle.enable!(:convert_tiff_images)
           allow(Fakes::DocumentService).to receive(:fetch_document_file).and_return(tiff_content)
         end
+        after { FeatureToggle.disable!(:convert_tiff_images) }
 
         it "should convert the tiff to pdf and return it" do
           expect(valid_pdf?(subject)).to be_truthy


### PR DESCRIPTION
The [pull request to run efolder tests in a random order](https://github.com/department-of-veterans-affairs/caseflow-efolder/pull/761) has been revealing a lot of tests that should fail but pass due to the order in which they are run. I had initially planned to fix all of those cases (thinking there would be few) in the same PR that randomizes the test order in Travis, however due to the large number of falsely passing tests, I think it best to incorporate in distinct PRs so they can be merged to master as soon as possible. This is the first batch of those test fixes.