### PR TITLE
V2 api - use VBMS ListDocuments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,7 @@ gem 'request_store'
 
 gem "mini_magick"
 
-gem 'connect_vbms', git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "5dda05573d424d557be7a09052ab24b0dc6a5c5f"
+gem 'connect_vbms', git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "e7fc3e6825f45176950c0b7ce37b38068ec5aea8"
 gem 'connect_vva', git: "https://github.com/department-of-veterans-affairs/connect_vva.git", ref: "f7036e7d3c17aae6e66e345051ea61c6badc5de2"
 gem 'bgs', git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", :branch => '9266698668bf361bf5df06990d06da59abb7c608'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,8 +21,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vbms.git
-  revision: 5dda05573d424d557be7a09052ab24b0dc6a5c5f
-  ref: 5dda05573d424d557be7a09052ab24b0dc6a5c5f
+  revision: e7fc3e6825f45176950c0b7ce37b38068ec5aea8
+  ref: e7fc3e6825f45176950c0b7ce37b38068ec5aea8
   specs:
     connect_vbms (1.0.0)
       httpclient (~> 2.8.0)

--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::ApplicationController < BaseController
   before_action :authenticate_or_authorize
 
   rescue_from StandardError do |error|
-    capture_error(error)
+    ExceptionLogger.capture(error)
 
     render json: {
       "errors": [
@@ -61,10 +61,5 @@ class Api::V1::ApplicationController < BaseController
 
   def css_id
     request.headers["HTTP_CSS_ID"]
-  end
-
-  def capture_error(e)
-    Rails.logger.error "#{e.message}\n#{e.backtrace.join("\n")}"
-    Raven.capture_exception(e)
   end
 end

--- a/app/jobs/v2/download_manifest_job.rb
+++ b/app/jobs/v2/download_manifest_job.rb
@@ -1,23 +1,12 @@
 class V2::DownloadManifestJob < ActiveJob::Base
   queue_as :default
 
-  around_perform :set_vbms_version
-
   def perform(manifest_source)
     documents = ManifestFetcher.new(manifest_source: manifest_source).process
     return if documents.blank?
     DocumentCreator.new(manifest_source: manifest_source, external_documents: documents).create
     # start caching files in s3 when manifest is fetched succesfully
     V2::SaveFilesInS3Job.perform_later(manifest_source)
-  end
-
-  private
-
-  # Use VBMS efolder new API - remove it when switched to the new API
-  def set_vbms_version
-    FeatureToggle.enable!(:vbms_efolder_service_v1)
-    yield
-    FeatureToggle.disable!(:vbms_efolder_service_v1)
   end
 
   def max_attempts

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -51,10 +51,10 @@ class Record < ActiveRecord::Base
     find_or_initialize_by(manifest_source: manifest_source, external_document_id: document.document_id).tap do |t|
       t.assign_attributes(
         type_id: document.type_id,
-        type_description: document.type_description,
+        type_description: document.try(:type_description),
         mime_type: document.mime_type,
         received_at: document.received_at,
-        jro: document.jro,
+        jro: document.try(:jro),
         source: document.source
       )
       t.save!

--- a/app/services/document_creator.rb
+++ b/app/services/document_creator.rb
@@ -39,6 +39,6 @@ class DocumentCreator
 
   # Override the getter to return only non-restricted documents
   def external_documents
-    @external_documents.reject { |document| RESTRICTED_TYPES.include?(document.type_id) || document.restricted? }
+    @external_documents.reject { |document| RESTRICTED_TYPES.include?(document.type_id) || document.try(:restricted?) }
   end
 end


### PR DESCRIPTION
Since we can't turn on VBMS eFolder V1 yet, we need to continue using the old eDocument service for the v2 api. 

Tested using VBMS and VVA file numbers pointed to UAT env. 