### PR TITLE
Remove references to Document.filepath from app logic

### DIFF
--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -164,7 +164,7 @@ class Download < ActiveRecord::Base
   def reset!
     Download.transaction do
       update_attributes!(status: :pending_documents)
-      documents.update_all(filepath: nil, download_status: 0, completed_at: nil)
+      documents.update_all(download_status: 0, completed_at: nil)
     end
   end
 

--- a/spec/models/download_spec.rb
+++ b/spec/models/download_spec.rb
@@ -168,11 +168,9 @@ describe "Download" do
 
       expect(download.reload).to be_pending_documents
       expect(@documents.first.reload).to be_pending
-      expect(@documents.first.filepath).to be_nil
       expect(@documents.first.completed_at).to eq nil
       expect(@documents.first.pending?).to eq true
       expect(@documents.last.reload).to be_pending
-      expect(@documents.last.filepath).to be_nil
       expect(@documents.last.completed_at).to eq nil
       expect(@documents.last.pending?).to eq true
     end


### PR DESCRIPTION
Connects #778.

This piece will need to be deployed before [the other PR](https://github.com/department-of-veterans-affairs/caseflow-efolder/pull/797) associated with #778 in order to avoid issues where the code executes expecting the `filepath` column and it is not there.