### PR TITLE
Replace homespun document ID generator with SecureRandom version

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -81,11 +81,7 @@ User.prepend(StubbableUser)
 
 module RandomHelper
   def self.valid_document_id
-    "{#{hex_str_of_length(8).upcase}-#{hex_str_of_length(4).upcase}-#{hex_str_of_length(4).upcase}-#{hex_str_of_length(4).upcase}-#{hex_str_of_length(12).upcase}}".upcase
-  end
-
-  def self.hex_str_of_length(len = 8)
-    SecureRandom.hex[0..len].to_s
+    "{#{SecureRandom.uuid.upcase}}"
   end
 end
 


### PR DESCRIPTION
Improvement upon the [initial version](https://github.com/department-of-veterans-affairs/caseflow-efolder/pull/794/commits/cd9f31b4d4cbc917c2fdca2e4597990d3ddabae3?diff=unified#diff-e11bdaf9116be3911e9557b69e242370R82) using `SecureRandom.uuid()` instead of the homespun version I hacked together (h/t Alan).