### PR TITLE
Set manifest pending status synchronously

### DIFF
--- a/app/models/manifest_source.rb
+++ b/app/models/manifest_source.rb
@@ -15,6 +15,7 @@ class ManifestSource < ActiveRecord::Base
 
   def start!
     return if current? || pending?
+    update(status: :pending)
     V2::DownloadManifestJob.perform_later(self)
   end
 

--- a/app/models/serializers/v2/manifest_serializer.rb
+++ b/app/models/serializers/v2/manifest_serializer.rb
@@ -22,7 +22,9 @@ class Serializers::V2::ManifestSerializer < ActiveModel::Serializer
         id: document.id,
         type_id: document.type_id,
         received_at: document.received_at,
-        external_document_id: document.external_document_id
+        external_document_id: document.external_document_id,
+        created_at: document.created_at,
+        updated_at: document.updated_at
       }
     end
   end

--- a/app/services/manifest_fetcher.rb
+++ b/app/services/manifest_fetcher.rb
@@ -3,10 +3,10 @@ class ManifestFetcher
 
   attr_accessor :manifest_source
 
-  EXCEPTIONS = [VBMS::ClientError, VVA::ClientError].freeze
+  # Catch StandardError in case there is an error to avoid manifests being stuck in pending state
+  EXCEPTIONS = [VBMS::ClientError, VVA::ClientError, StandardError].freeze
 
   def process
-    manifest_source.update(status: :pending)
     documents = manifest_source.service.fetch_documents_for(manifest_source.manifest)
     manifest_source.update(status: :success, fetched_at: Time.zone.now)
     documents


### PR DESCRIPTION
1. Set manifest status to pending before starting asynchronous job
2. Catch StandardError while fetching manifest to change the status from pending to failed. 