### PR TITLE
Call new Image Magick Service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,8 @@ gem 'request_store'
 
 gem "mini_magick"
 
+gem 'curb'
+
 gem 'connect_vbms', git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "e7fc3e6825f45176950c0b7ce37b38068ec5aea8"
 gem 'connect_vva', git: "https://github.com/department-of-veterans-affairs/connect_vva.git", ref: "f7036e7d3c17aae6e66e345051ea61c6badc5de2"
 gem 'bgs', git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", :branch => '9266698668bf361bf5df06990d06da59abb7c608'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,7 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.4)
     connection_pool (2.2.1)
+    curb (0.9.4)
     d3-rails (4.10.2)
       railties (>= 3.1)
     database_cleaner (1.5.3)
@@ -469,6 +470,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   connect_vbms!
   connect_vva!
+  curb
   database_cleaner
   dogstatsd-ruby
   dotenv-rails

--- a/README.md
+++ b/README.md
@@ -9,15 +9,13 @@ FOIA Requests that give veterans access to their own VA files take **way** too l
 
 ## First Time Development Setup
 
-You'll need Ruby 2.3.0, Postgres, Redis and ImageMagick if you don't have them.
+You'll need Ruby 2.3.0, Postgres and Redis if you don't have them.
 
 > $ rbenv install 2.3.0
 
 > $ brew install postgresql
 
 > $ brew install redis
-
-> $ brew install imagemagick
 
 You may want to have Redis and Postgres run on startup. Let brew tell you how to do that:
 
@@ -44,6 +42,10 @@ Now start both the rails server,
 And in a seperate terminal, start a jobs worker
 
 > $ bundle exec sidekiq
+
+If you want to convert TIFF files to PDFs then you also need to run the image converter service. You can
+do this by cloning the appeals-deployment repo, navigating to `ansible/utility-roles/imagemagick/files`
+and running `docker-compose up`. By default if this is not running, TIFFs will gracefully not convert.
 
 If you want to test out the DEMO flow (without VBMS connection),
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -33,9 +33,16 @@ class Document < ActiveRecord::Base
     @path ||= File.join(download.download_dir, id.to_s)
   end
 
+  def converted_mime_type
+    @converted_mime_type || mime_type
+  end
+  attr_writer :converted_mime_type
+
   def fetch_content!(save_document_metadata:)
+    image = fetcher.content(save_document_metadata: save_document_metadata)
+
     return {
-      content: fetcher.content(save_document_metadata: save_document_metadata),
+      content: image,
       error_kind: nil
     }
   rescue VBMS::ClientError => e
@@ -127,7 +134,7 @@ class Document < ActiveRecord::Base
   end
 
   def preferred_extension
-    mime = MIME::Types[ImageConverterService.converted_mime_type(mime_type)].first
+    mime = MIME::Types[converted_mime_type].first
     mime ? mime.preferred_extension : ""
   end
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -12,7 +12,7 @@ class Document < ActiveRecord::Base
   enum download_status: { pending: 0, success: 1, failed: 2 }
 
   enum conversion_status: {
-    not_converted: 0,
+    not_converted: nil,
     conversion_success: 1,
     conversion_failed: 2
   }

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -39,10 +39,8 @@ class Document < ActiveRecord::Base
   attr_writer :converted_mime_type
 
   def fetch_content!(save_document_metadata:)
-    image = fetcher.content(save_document_metadata: save_document_metadata)
-
     return {
-      content: image,
+      content: fetcher.content(save_document_metadata: save_document_metadata),
       error_kind: nil
     }
   rescue VBMS::ClientError => e

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -33,10 +33,10 @@ class Document < ActiveRecord::Base
     @path ||= File.join(download.download_dir, id.to_s)
   end
 
-  def converted_mime_type
-    @converted_mime_type || mime_type
+  def s3_stored_file_mime_type
+    @s3_stored_file_mime_type || mime_type
   end
-  attr_writer :converted_mime_type
+  attr_writer :s3_stored_file_mime_type
 
   def fetch_content!(save_document_metadata:)
     return {
@@ -132,7 +132,7 @@ class Document < ActiveRecord::Base
   end
 
   def preferred_extension
-    mime = MIME::Types[converted_mime_type].first
+    mime = MIME::Types[s3_stored_file_mime_type].first
     mime ? mime.preferred_extension : ""
   end
 

--- a/app/models/fetcher.rb
+++ b/app/models/fetcher.rb
@@ -16,26 +16,26 @@ class Fetcher
     ImageConverterService.converted_mime_type(document.mime_type)
   end
 
-  def converted_content
+  def cached_converted_content
     document.converted_mime_type = converted_mime_type
-    @converted_content ||= MetricsService.record("S3: fetch content for: #{document.s3_filename}",
-                                                 service: :s3,
-                                                 name: "fetch_content") do
+    @cached_converted_content ||= MetricsService.record("S3: fetch content for: #{document.s3_filename}",
+                                                        service: :s3,
+                                                        name: "fetch_content") do
       S3Service.fetch_content(document.s3_filename)
     end
   end
 
-  def original_content
+  def cached_original_content
     document.converted_mime_type = document.mime_type
-    @original_content ||= MetricsService.record("S3: fetch content for: #{document.s3_filename}",
-                                                service: :s3,
-                                                name: "fetch_content") do
+    @cached_original_content ||= MetricsService.record("S3: fetch content for: #{document.s3_filename}",
+                                                       service: :s3,
+                                                       name: "fetch_content") do
       S3Service.fetch_content(document.s3_filename)
     end
   end
 
   def cached_content
-    converted_content || original_content
+    cached_converted_content || cached_original_content
   end
 
   def download_from_service

--- a/app/models/fetcher.rb
+++ b/app/models/fetcher.rb
@@ -12,19 +12,45 @@ class Fetcher
 
   private
 
-  def cached_content
-    @cached_content ||= MetricsService.record("S3: fetch content for: #{document.s3_filename}",
-                                              service: :s3,
-                                              name: "fetch_content") do
+  def converted_mime_type
+    ImageConverterService.converted_mime_type(document.mime_type)
+  end
+
+  def converted_content
+    document.converted_mime_type = converted_mime_type
+    @converted_content ||= MetricsService.record("S3: fetch content for: #{document.s3_filename}",
+                                                 service: :s3,
+                                                 name: "fetch_content") do
       S3Service.fetch_content(document.s3_filename)
     end
+  end
+
+  def original_content
+    document.converted_mime_type = document.mime_type
+    @original_content ||= MetricsService.record("S3: fetch content for: #{document.s3_filename}",
+                                                service: :s3,
+                                                name: "fetch_content") do
+      S3Service.fetch_content(document.s3_filename)
+    end
+  end
+
+  def cached_content
+    converted_content || original_content
   end
 
   def download_from_service
     return cached_content if cached_content
 
-    converted_image = ImageConverterService.new(
-      image: external_service.fetch_document_file(document), mime_type: document.mime_type).process
+    content_from_service = external_service.fetch_document_file(document)
+
+    begin
+      document.converted_mime_type = converted_mime_type
+      converted_image = ImageConverterService.new(
+        image: content_from_service, mime_type: document.mime_type).process
+    rescue ImageConverterService::ImageConverterError
+      document.converted_mime_type = document.mime_type
+      converted_image = content_from_service
+    end
     S3Service.store_file(document.s3_filename, converted_image)
 
     converted_image

--- a/app/models/fetcher.rb
+++ b/app/models/fetcher.rb
@@ -14,8 +14,8 @@ class Fetcher
 
   def cached_content
     @cached_content ||= MetricsService.record("S3: fetch content for: #{document.s3_filename}",
-                          service: :s3,
-                          name: "fetch_content") do
+                                              service: :s3,
+                                              name: "fetch_content") do
       S3Service.fetch_content(document.s3_filename)
     end
   end

--- a/app/models/fetcher.rb
+++ b/app/models/fetcher.rb
@@ -12,48 +12,19 @@ class Fetcher
 
   private
 
-  def converted_mime_type
-    ImageConverterService.converted_mime_type(document.mime_type)
-  end
-
   def cached_content
-    MetricsService.record("S3: fetch content for: #{document.s3_filename}",
+    @cached_content ||= MetricsService.record("S3: fetch content for: #{document.s3_filename}",
                           service: :s3,
                           name: "fetch_content") do
       S3Service.fetch_content(document.s3_filename)
     end
   end
 
-  def cached_converted_content
-    # Don't need to do anything if the mime_type is not converted.
-    return if converted_mime_type == document.mime_type
-
-    document.s3_stored_file_mime_type = converted_mime_type
-    @cached_converted_content ||= cached_content
-  end
-
-  def cached_original_content
-    document.s3_stored_file_mime_type = document.mime_type
-    @cached_original_content ||= cached_content
-  end
-
-  def cached_converted_or_original_content
-    @cached_converted_or_original_content ||= (cached_converted_content || cached_original_content)
-  end
-
   def download_from_service
-    return cached_converted_or_original_content if cached_converted_or_original_content
+    return cached_content if cached_content
 
-    content_from_service = external_service.fetch_document_file(document)
-
-    begin
-      document.s3_stored_file_mime_type = converted_mime_type
-      converted_image = ImageConverterService.new(
-        image: content_from_service, mime_type: document.mime_type).process
-    rescue ImageConverterService::ImageConverterError
-      document.s3_stored_file_mime_type = document.mime_type
-      converted_image = content_from_service
-    end
+    converted_image = ImageConverterService.new(
+      image: external_service.fetch_document_file(document), record: document).process
     S3Service.store_file(document.s3_filename, converted_image)
 
     converted_image

--- a/app/models/fetcher.rb
+++ b/app/models/fetcher.rb
@@ -16,39 +16,42 @@ class Fetcher
     ImageConverterService.converted_mime_type(document.mime_type)
   end
 
-  def cached_converted_content
-    document.converted_mime_type = converted_mime_type
-    @cached_converted_content ||= MetricsService.record("S3: fetch content for: #{document.s3_filename}",
-                                                        service: :s3,
-                                                        name: "fetch_content") do
+  def cached_content
+    MetricsService.record("S3: fetch content for: #{document.s3_filename}",
+                          service: :s3,
+                          name: "fetch_content") do
       S3Service.fetch_content(document.s3_filename)
     end
+  end
+
+  def cached_converted_content
+    # Don't need to do anything if the mime_type is not converted.
+    return if converted_mime_type == document.mime_type
+
+    document.s3_stored_file_mime_type = converted_mime_type
+    @cached_converted_content ||= cached_content
   end
 
   def cached_original_content
-    document.converted_mime_type = document.mime_type
-    @cached_original_content ||= MetricsService.record("S3: fetch content for: #{document.s3_filename}",
-                                                       service: :s3,
-                                                       name: "fetch_content") do
-      S3Service.fetch_content(document.s3_filename)
-    end
+    document.s3_stored_file_mime_type = document.mime_type
+    @cached_original_content ||= cached_content
   end
 
-  def cached_content
-    cached_converted_content || cached_original_content
+  def cached_converted_or_original_content
+    @cached_converted_or_original_content ||= (cached_converted_content || cached_original_content)
   end
 
   def download_from_service
-    return cached_content if cached_content
+    return cached_converted_or_original_content if cached_converted_or_original_content
 
     content_from_service = external_service.fetch_document_file(document)
 
     begin
-      document.converted_mime_type = converted_mime_type
+      document.s3_stored_file_mime_type = converted_mime_type
       converted_image = ImageConverterService.new(
         image: content_from_service, mime_type: document.mime_type).process
     rescue ImageConverterService::ImageConverterError
-      document.converted_mime_type = document.mime_type
+      document.s3_stored_file_mime_type = document.mime_type
       converted_image = content_from_service
     end
     S3Service.store_file(document.s3_filename, converted_image)

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -21,6 +21,11 @@ class Record < ActiveRecord::Base
   delegate :manifest, :service, to: :manifest_source
   delegate :file_number, to: :manifest
 
+  def converted_mime_type
+    @converted_mime_type || mime_type
+  end
+  attr_writer :converted_mime_type
+
   def fetch!
     fetcher.process
   end
@@ -68,7 +73,7 @@ class Record < ActiveRecord::Base
   end
 
   def mime
-    MIME::Types[mime_type].first
+    MIME::Types[converted_mime_type].first
   end
 
   def adjust_mime_type

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -11,7 +11,7 @@ class Record < ActiveRecord::Base
   }
 
   enum conversion_status: {
-    not_converted: nil,
+    not_converted: 0,
     conversion_success: 1,
     conversion_failed: 2
   }

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -35,8 +35,8 @@ class Record < ActiveRecord::Base
     external_document_id
   end
 
-  def s3_filename
-    "#{external_document_id}.#{preferred_extension}"
+  def s3_filename(extension: preferred_extension)
+    "#{external_document_id}.#{extension}"
   end
 
   def preferred_extension
@@ -68,7 +68,7 @@ class Record < ActiveRecord::Base
   end
 
   def mime
-    MIME::Types[ImageConverterService.converted_mime_type(mime_type)].first
+    MIME::Types[mime_type].first
   end
 
   def adjust_mime_type

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -11,7 +11,7 @@ class Record < ActiveRecord::Base
   }
 
   enum conversion_status: {
-    not_converted: 0,
+    not_converted: nil,
     conversion_success: 1,
     conversion_failed: 2
   }

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -21,10 +21,10 @@ class Record < ActiveRecord::Base
   delegate :manifest, :service, to: :manifest_source
   delegate :file_number, to: :manifest
 
-  def converted_mime_type
-    @converted_mime_type || mime_type
+  def s3_stored_file_mime_type
+    @s3_stored_file_mime_type || mime_type
   end
-  attr_writer :converted_mime_type
+  attr_writer :s3_stored_file_mime_type
 
   def fetch!
     fetcher.process
@@ -73,7 +73,7 @@ class Record < ActiveRecord::Base
   end
 
   def mime
-    MIME::Types[converted_mime_type].first
+    MIME::Types[s3_stored_file_mime_type].first
   end
 
   def adjust_mime_type

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -40,8 +40,8 @@ class Record < ActiveRecord::Base
     external_document_id
   end
 
-  def s3_filename(extension: preferred_extension)
-    "#{external_document_id}.#{extension}"
+  def s3_filename
+    "#{external_document_id}.#{preferred_extension}"
   end
 
   def preferred_extension

--- a/app/services/download_documents.rb
+++ b/app/services/download_documents.rb
@@ -79,9 +79,10 @@ class DownloadDocuments
   end
 
   def fetch_from_s3(document)
-    # All the content should already be in S3.
-    fetch_result = document.fetch_content!(save_document_metadata: true)
-    document.save_locally(fetch_result[:content])
+    # if the file exists on the filesystem, skip
+    return if File.exist?(document.path)
+
+    S3Service.fetch_file(document.s3_filename, document.path)
   end
 
   def zip_exists_locally?

--- a/app/services/download_documents.rb
+++ b/app/services/download_documents.rb
@@ -79,9 +79,6 @@ class DownloadDocuments
   end
 
   def fetch_from_s3(document)
-    # if the file exists on the filesystem, skip
-    # return if File.exist?(document.path)
-
     # All the content should already be in S3.
     fetch_result = document.fetch_content!(save_document_metadata: true)
     document.save_locally(fetch_result[:content])

--- a/app/services/download_documents.rb
+++ b/app/services/download_documents.rb
@@ -80,9 +80,11 @@ class DownloadDocuments
 
   def fetch_from_s3(document)
     # if the file exists on the filesystem, skip
-    return if File.exist?(document.path)
+    # return if File.exist?(document.path)
 
-    S3Service.fetch_file(document.s3_filename, document.path)
+    # All the content should already be in S3.
+    fetch_result = document.fetch_content!(save_document_metadata: true)
+    document.save_locally(fetch_result[:content])
   end
 
   def zip_exists_locally?

--- a/app/services/image_converter_service.rb
+++ b/app/services/image_converter_service.rb
@@ -22,8 +22,7 @@ class ImageConverterService
     mime_type
   end
 
-  private
-
+  # :nocov:
   def convert_tiff_to_pdf
     url = "http://localhost:5000/tiff-convert"
 
@@ -39,9 +38,10 @@ class ImageConverterService
         curl.http_post(Curl::PostField.file("file", file.path))
       end
 
-      fail ImageConverterError if true # curl.status != "200 OK"
+      fail ImageConverterError if curl.status != "200 OK"
     end
 
     curl.body
   end
+  # :nocov:
 end

--- a/app/services/image_converter_service.rb
+++ b/app/services/image_converter_service.rb
@@ -42,6 +42,8 @@ class ImageConverterService
     end
 
     curl.body
+  rescue Curl::Err::ConnectionFailedError
+    raise ImageConverterError
   end
   # :nocov:
 end

--- a/app/services/image_converter_service.rb
+++ b/app/services/image_converter_service.rb
@@ -1,5 +1,7 @@
 # Converts images to PDFs
 class ImageConverterService
+  class ImageConverterError < StandardError; end
+
   include ActiveModel::Model
   attr_accessor :image, :mime_type
 
@@ -7,7 +9,7 @@ class ImageConverterService
     # If we do not handle converting this mime_type, don't do any processing.
     return image if self.class.converted_mime_type(mime_type) == mime_type
 
-    convert_tiff_to_pdf if mime_type == "image/tiff" && tiff?
+    convert_tiff_to_pdf if mime_type == "image/tiff"
   end
 
   # If the converter converts this mime_type then this returns the converted type
@@ -22,34 +24,24 @@ class ImageConverterService
 
   private
 
-  # Adding a magic number check based on this recommendation: https://imagetragick.com/
-  def tiff?
-    "MM\u0000*" == image[0..3] || "II*\u0000" == image[0..3]
-  end
-
   def convert_tiff_to_pdf
+    url = "http://localhost:5000/tiff-convert"
+
+    curl = Curl::Easy.new(url)
+    curl.multipart_form_post = true
+
     MetricsService.record("Image Magick: Convert tiff to pdf",
                           service: :image_magick,
                           name: "image_magick_convert_tiff_to_pdf") do
-      base_path = File.join(Rails.application.config.download_filepath, "tiff_convert")
-      FileUtils.mkdir_p(base_path) unless File.exist?(base_path)
-
-      filename = SecureRandom.hex[0..16].to_s
-
-      tiff_name = File.join(base_path, "#{filename}.tiff")
-
-      File.open(tiff_name, "wb") do |f|
-        f.write(image)
+      Tempfile.open(["tiff_to_convert", ".tiff"]) do |file|
+        file.binmode
+        file.write(image)
+        curl.http_post(Curl::PostField.file("file", file.path))
       end
 
-      pdf_name = File.join(base_path, "#{filename}.pdf")
-
-      MiniMagick::Tool::Convert.new do |convert|
-        convert << tiff_name
-        convert << pdf_name
-      end
-
-      File.open(pdf_name, "r", &:read)
+      fail ImageConverterError if true # curl.status != "200 OK"
     end
+
+    curl.body
   end
 end

--- a/app/services/image_converter_service.rb
+++ b/app/services/image_converter_service.rb
@@ -30,6 +30,7 @@ class ImageConverterService
 
   private
 
+  # :nocov:
   def convert_tiff_to_pdf
     url = "http://localhost:5000/tiff-convert"
 
@@ -52,6 +53,7 @@ class ImageConverterService
   rescue Curl::Err::ConnectionFailedError
     raise ImageConverterError
   end
+  # :nocov:
 
   def convert
     case record.mime_type

--- a/app/services/image_converter_service.rb
+++ b/app/services/image_converter_service.rb
@@ -46,7 +46,7 @@ class ImageConverterService
         curl.http_post(Curl::PostField.file("file", file.path))
       end
 
-      fail ImageConverterError if curl.status != "200 OK"
+      raise ImageConverterError if curl.status != "200 OK"
     end
 
     curl.body
@@ -58,9 +58,9 @@ class ImageConverterService
   def convert
     case record.mime_type
     when "image/tiff"
-      return convert_tiff_to_pdf
+      convert_tiff_to_pdf
     else
-      return image
+      image
     end
   end
 end

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -38,6 +38,8 @@ class MetricsService
       increment_datadog_counter("request_error", service, name)
     end
 
+    Rails.logger.info("RESCUED #{description}")
+
     # Re-raise the same error. We don't want to interfere at all in normal error handling.
     # This is just to capture the metric.
     raise

--- a/app/services/record_fetcher.rb
+++ b/app/services/record_fetcher.rb
@@ -21,7 +21,7 @@ class RecordFetcher
 
   def convert_to_pdf(content)
     # Every time we can't find the file in S3 and are asked to convert the version from
-    # VBMS, we try to do the conversion, even if it failed last time in case some change
+    # VBMS, we try to do the conversion, even if it failed last time. In case some change
     # has enabled it to be converted this time.
     converted_content = ImageConverterService.new(image: content, mime_type: record.mime_type).process
     record.update_attributes!(conversion_status: :conversion_success)

--- a/app/services/record_fetcher.rb
+++ b/app/services/record_fetcher.rb
@@ -8,7 +8,7 @@ class RecordFetcher
   def process
     return cached_content if cached_content
     content = record.service.fetch_document_file(record)
-    content = convert_to_pdf(content)
+    content = ImageConverterService.new(image: content, record: record).process
     S3Service.store_file(record.s3_filename, content)
     record.update(status: :success)
     content
@@ -18,18 +18,6 @@ class RecordFetcher
   end
 
   private
-
-  def convert_to_pdf(content)
-    # Every time we can't find the file in S3 and are asked to convert the version from
-    # VBMS, we try to do the conversion, even if it failed last time. In case some change
-    # has enabled it to be converted this time.
-    converted_content = ImageConverterService.new(image: content, mime_type: record.mime_type).process
-    record.update_attributes!(conversion_status: :conversion_success)
-    converted_content
-  rescue ImageConverterService::ImageConverterError
-    record.update_attributes!(conversion_status: :conversion_failed)
-    content
-  end
 
   def cached_content
     @cached_content ||= MetricsService.record("S3: fetch content for: #{record.s3_filename}",

--- a/app/services/record_fetcher.rb
+++ b/app/services/record_fetcher.rb
@@ -8,7 +8,7 @@ class RecordFetcher
   def process
     return cached_content if cached_content
     content = record.service.fetch_document_file(record)
-    content = ImageConverterService.new(image: content, mime_type: record.mime_type).process
+    content = convert_to_pdf(content)
     S3Service.store_file(record.s3_filename, content)
     record.update(status: :success)
     content
@@ -19,11 +19,37 @@ class RecordFetcher
 
   private
 
-  def cached_content
-    @cached_content ||= MetricsService.record("S3: fetch content for: #{record.s3_filename}",
-                                              service: :s3,
-                                              name: "fetch_content") do
+  def convert_to_pdf(content)
+    record.converted_mime_type = converted_mime_type
+    ImageConverterService.new(image: content, mime_type: record.mime_type).process
+  rescue ImageConverterService::ImageConverterError
+    record.converted_mime_type = record.mime_type
+    content
+  end
+
+  def converted_mime_type
+    ImageConverterService.converted_mime_type(record.mime_type)
+  end
+
+  def cached_converted_content
+    record.converted_mime_type = converted_mime_type
+    @cached_converted_content ||= MetricsService.record("S3: fetch content for: #{record.s3_filename}",
+                                                        service: :s3,
+                                                        name: "fetch_content") do
       S3Service.fetch_content(record.s3_filename)
     end
+  end
+
+  def cached_original_content
+    record.converted_mime_type = record.mime_type
+    @cached_original_content ||= MetricsService.record("S3: fetch content for: #{record.s3_filename}",
+                                                       service: :s3,
+                                                       name: "fetch_content") do
+      S3Service.fetch_content(record.s3_filename)
+    end
+  end
+
+  def cached_content
+    cached_converted_content || cached_original_content
   end
 end

--- a/app/services/record_fetcher.rb
+++ b/app/services/record_fetcher.rb
@@ -6,7 +6,7 @@ class RecordFetcher
   EXCEPTIONS = [VBMS::ClientError, VVA::ClientError].freeze
 
   def process
-    return cached_content if cached_content
+    return cached_converted_or_original_content if cached_converted_or_original_content
     content = record.service.fetch_document_file(record)
     content = convert_to_pdf(content)
     S3Service.store_file(record.s3_filename, content)
@@ -20,10 +20,10 @@ class RecordFetcher
   private
 
   def convert_to_pdf(content)
-    record.converted_mime_type = converted_mime_type
+    record.s3_stored_file_mime_type = converted_mime_type
     ImageConverterService.new(image: content, mime_type: record.mime_type).process
   rescue ImageConverterService::ImageConverterError
-    record.converted_mime_type = record.mime_type
+    record.s3_stored_file_mime_type = record.mime_type
     content
   end
 
@@ -31,25 +31,28 @@ class RecordFetcher
     ImageConverterService.converted_mime_type(record.mime_type)
   end
 
-  def cached_converted_content
-    record.converted_mime_type = converted_mime_type
-    @cached_converted_content ||= MetricsService.record("S3: fetch content for: #{record.s3_filename}",
-                                                        service: :s3,
-                                                        name: "fetch_content") do
+  def cached_content
+    MetricsService.record("S3: fetch content for: #{record.s3_filename}",
+                          service: :s3,
+                          name: "fetch_content") do
       S3Service.fetch_content(record.s3_filename)
     end
+  end
+
+  def cached_converted_content
+    # Don't need to do anything if the mime_type is not converted.
+    return if converted_mime_type == record.mime_type
+
+    record.s3_stored_file_mime_type = converted_mime_type
+    @cached_converted_content ||= cached_content
   end
 
   def cached_original_content
-    record.converted_mime_type = record.mime_type
-    @cached_original_content ||= MetricsService.record("S3: fetch content for: #{record.s3_filename}",
-                                                       service: :s3,
-                                                       name: "fetch_content") do
-      S3Service.fetch_content(record.s3_filename)
-    end
+    record.s3_stored_file_mime_type = record.mime_type
+    @cached_original_content ||= cached_content
   end
 
-  def cached_content
-    cached_converted_content || cached_original_content
+  def cached_converted_or_original_content
+    @cached_converted_or_original_content ||= (cached_converted_content || cached_original_content)
   end
 end

--- a/db/migrate/20180106211625_add_conversion_status_to_records.rb
+++ b/db/migrate/20180106211625_add_conversion_status_to_records.rb
@@ -1,0 +1,5 @@
+class AddConversionStatusToRecords < ActiveRecord::Migration
+  def change
+    add_column :records, :conversion_status, :integer
+  end
+end

--- a/db/migrate/20180106211625_add_conversion_status_to_records.rb
+++ b/db/migrate/20180106211625_add_conversion_status_to_records.rb
@@ -1,5 +1,5 @@
 class AddConversionStatusToRecords < ActiveRecord::Migration
   def change
-    add_column :records, :conversion_status, :integer
+    safety_assured { add_column :records, :conversion_status, :integer, default: 0 }
   end
 end

--- a/db/migrate/20180108170052_add_conversion_status_to_documents.rb
+++ b/db/migrate/20180108170052_add_conversion_status_to_documents.rb
@@ -1,0 +1,5 @@
+class AddConversionStatusToDocuments < ActiveRecord::Migration
+  def change
+    add_column :documents, :conversion_status, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -92,6 +92,15 @@ ActiveRecord::Schema.define(version: 20171221184002) do
     t.datetime "updated_at",              null: false
   end
 
+  create_table "manifest_statuses", force: :cascade do |t|
+    t.integer  "manifest_id"
+    t.integer  "status",      default: 0
+    t.string   "source"
+    t.datetime "fetched_at"
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+  end
+
   create_table "manifests", force: :cascade do |t|
     t.string   "file_number"
     t.string   "veteran_last_name"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171221184002) do
+ActiveRecord::Schema.define(version: 20180106211625) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,6 +92,15 @@ ActiveRecord::Schema.define(version: 20171221184002) do
     t.datetime "updated_at",              null: false
   end
 
+  create_table "manifest_statuses", force: :cascade do |t|
+    t.integer  "manifest_id"
+    t.integer  "status",      default: 0
+    t.string   "source"
+    t.datetime "fetched_at"
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+  end
+
   create_table "manifests", force: :cascade do |t|
     t.string   "file_number"
     t.string   "veteran_last_name"
@@ -117,6 +126,7 @@ ActiveRecord::Schema.define(version: 20171221184002) do
     t.string   "source"
     t.datetime "created_at",                       null: false
     t.datetime "updated_at",                       null: false
+    t.integer  "conversion_status"
   end
 
   add_index "records", ["manifest_source_id", "external_document_id"], name: "index_records_on_manifest_source_id_and_external_document_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -92,15 +92,6 @@ ActiveRecord::Schema.define(version: 20171221184002) do
     t.datetime "updated_at",              null: false
   end
 
-  create_table "manifest_statuses", force: :cascade do |t|
-    t.integer  "manifest_id"
-    t.integer  "status",      default: 0
-    t.string   "source"
-    t.datetime "fetched_at"
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
-  end
-
   create_table "manifests", force: :cascade do |t|
     t.string   "file_number"
     t.string   "veteran_last_name"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -92,15 +92,6 @@ ActiveRecord::Schema.define(version: 20180106211625) do
     t.datetime "updated_at",              null: false
   end
 
-  create_table "manifest_statuses", force: :cascade do |t|
-    t.integer  "manifest_id"
-    t.integer  "status",      default: 0
-    t.string   "source"
-    t.datetime "fetched_at"
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
-  end
-
   create_table "manifests", force: :cascade do |t|
     t.string   "file_number"
     t.string   "veteran_last_name"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180106211625) do
+ActiveRecord::Schema.define(version: 20180108170052) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,24 +34,25 @@ ActiveRecord::Schema.define(version: 20180106211625) do
 
   create_table "documents", force: :cascade do |t|
     t.integer  "download_id"
-    t.integer  "download_status",  default: 0
+    t.integer  "download_status",   default: 0
     t.string   "document_id"
     t.string   "vbms_filename"
     t.string   "source"
     t.string   "mime_type"
     t.datetime "received_at"
-    t.datetime "created_at",                        null: false
-    t.datetime "updated_at",                        null: false
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
     t.datetime "started_at"
     t.datetime "completed_at"
     t.integer  "lock_version"
     t.string   "type_description"
     t.string   "type_id"
     t.text     "error_message"
-    t.string   "downloaded_from",  default: "VBMS"
+    t.string   "downloaded_from",   default: "VBMS"
     t.string   "jro"
     t.string   "ssn"
     t.integer  "size"
+    t.integer  "conversion_status"
   end
 
   add_index "documents", ["completed_at"], name: "index_documents_on_completed_at", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -118,7 +118,7 @@ ActiveRecord::Schema.define(version: 20180108170052) do
     t.string   "source"
     t.datetime "created_at",                       null: false
     t.datetime "updated_at",                       null: false
-    t.integer  "conversion_status"
+    t.integer  "conversion_status",    default: 0
   end
 
   add_index "records", ["manifest_source_id", "external_document_id"], name: "index_records_on_manifest_source_id_and_external_document_id", using: :btree

--- a/lib/fakes/document_service.rb
+++ b/lib/fakes/document_service.rb
@@ -44,7 +44,7 @@ class Fakes::DocumentService
     },
     "DEMODEFAULT" => {
       manifest_load: 4,
-      num_docs: 10,
+      num_docs: 1,
       max_file_load: 3
     }
   }.freeze
@@ -61,7 +61,7 @@ class Fakes::DocumentService
     sleep(rand(max_time))
     fail VBMS::ClientError if errors && rand(5) == 3
     fail VVA::ClientError if errors && rand(5) == 2
-
+    # binding.pry
     if document.mime_type == "application/pdf"
       IO.binread(Rails.root + "lib/pdfs/#{document.id % 5}.pdf")
     else
@@ -85,7 +85,7 @@ class Fakes::DocumentService
 
   # Randomly send a pdf or tiff
   def self.document_type
-    return { ext: "pdf", mime_type: "application/pdf" } if rand(2)
+    # return { ext: "pdf", mime_type: "application/pdf" } if rand(2)
     { ext: "tiff", mime_type: "image/tiff" }
   end
 

--- a/lib/fakes/document_service.rb
+++ b/lib/fakes/document_service.rb
@@ -44,7 +44,7 @@ class Fakes::DocumentService
     },
     "DEMODEFAULT" => {
       manifest_load: 4,
-      num_docs: 1,
+      num_docs: 10,
       max_file_load: 3
     }
   }.freeze
@@ -61,7 +61,7 @@ class Fakes::DocumentService
     sleep(rand(max_time))
     fail VBMS::ClientError if errors && rand(5) == 3
     fail VVA::ClientError if errors && rand(5) == 2
-    # binding.pry
+
     if document.mime_type == "application/pdf"
       IO.binread(Rails.root + "lib/pdfs/#{document.id % 5}.pdf")
     else
@@ -85,7 +85,7 @@ class Fakes::DocumentService
 
   # Randomly send a pdf or tiff
   def self.document_type
-    # return { ext: "pdf", mime_type: "application/pdf" } if rand(2)
+    return { ext: "pdf", mime_type: "application/pdf" } if rand(2)
     { ext: "tiff", mime_type: "image/tiff" }
   end
 

--- a/lib/fakes/document_service.rb
+++ b/lib/fakes/document_service.rb
@@ -85,7 +85,7 @@ class Fakes::DocumentService
 
   # Randomly send a pdf or tiff
   def self.document_type
-    return { ext: "pdf", mime_type: "application/pdf" } if rand(2)
+    return { ext: "pdf", mime_type: "application/pdf" } if rand(2) == 1
     { ext: "tiff", mime_type: "image/tiff" }
   end
 

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -7,13 +7,15 @@ describe Document do
   end
 
   let(:mime_type) { "application/pdf" }
+  let(:conversion_status) { :not_converted }
   let(:download) { Download.create(file_number: "21012") }
   let(:document) do
     download.documents.build(
       document_id: "{3333-3333}",
       received_at: Time.utc(2015, 9, 6, 1, 0, 0),
       type_id: "825",
-      mime_type: mime_type
+      mime_type: mime_type,
+      conversion_status: conversion_status
     )
   end
 
@@ -253,8 +255,16 @@ describe Document do
         end
 
         let(:mime_type) { "image/tiff" }
-        it "returns pdf" do
-          expect(document.preferred_extension).to eq("pdf")
+        it "returns tiff when conversion_status is not_converted" do
+          expect(document.preferred_extension).to eq("tiff")
+        end
+
+        context "when conversion_status is conversion_success" do
+          let(:conversion_status) { :conversion_success }
+
+          it "returns tiff when not_converted? is true" do
+            expect(document.preferred_extension).to eq("pdf")
+          end
         end
       end
 

--- a/spec/models/fetcher_spec.rb
+++ b/spec/models/fetcher_spec.rb
@@ -66,23 +66,12 @@ describe Fetcher do
 
         before do
           allow(Fakes::DocumentService).to receive(:fetch_document_file).and_return(tiff_content)
-          allow_any_instance_of(ImageConverterService).to receive(:convert).and_return(fake_pdf_content)
+          allow_any_instance_of(ImageConverterService).to receive(:convert_tiff_to_pdf).and_return(fake_pdf_content)
           FeatureToggle.enable!(:convert_tiff_images)
         end
 
-        it "should ask the ImageConverterService to convert the image" do
+        it "should convert the tiff to pdf and return it" do
           expect(subject).to eq fake_pdf_content
-        end
-
-        context "when the tiff file cannot be converted" do
-          before do
-            allow_any_instance_of(ImageConverterService).to receive(:convert)
-              .and_raise(ImageConverterService::ImageConverterError)
-          end
-
-          it "should return the tiff" do
-            expect(subject).to eq tiff_content
-          end
         end
       end
     end

--- a/spec/models/fetcher_spec.rb
+++ b/spec/models/fetcher_spec.rb
@@ -54,10 +54,6 @@ describe Fetcher do
       end
 
       context "when VBMS returns a tiff file" do
-        before do
-          FeatureToggle.enable!(:convert_tiff_images)
-        end
-
         let(:document) do
           download.documents.build(
             id: "1234",
@@ -70,10 +66,23 @@ describe Fetcher do
 
         before do
           allow(Fakes::DocumentService).to receive(:fetch_document_file).and_return(tiff_content)
+          allow_any_instance_of(ImageConverterService).to receive(:convert_tiff_to_pdf).and_return(fake_pdf_content)
+          FeatureToggle.enable!(:convert_tiff_images)
         end
 
-        it "should convert the tiff to pdf and return it" do
-          expect(valid_pdf?(subject)).to be_truthy
+        it "should ask the ImageConverterService to convert the image" do
+          expect(subject).to eq fake_pdf_content
+        end
+
+        context "when the tiff file cannot be converted" do
+          before do
+            allow_any_instance_of(ImageConverterService).to receive(:convert_tiff_to_pdf)
+              .and_raise(ImageConverterService::ImageConverterError)
+          end
+
+          it "should return the tiff" do
+            expect(subject).to eq tiff_content
+          end
         end
       end
     end

--- a/spec/models/fetcher_spec.rb
+++ b/spec/models/fetcher_spec.rb
@@ -66,7 +66,7 @@ describe Fetcher do
 
         before do
           allow(Fakes::DocumentService).to receive(:fetch_document_file).and_return(tiff_content)
-          allow_any_instance_of(ImageConverterService).to receive(:convert_tiff_to_pdf).and_return(fake_pdf_content)
+          allow_any_instance_of(ImageConverterService).to receive(:convert).and_return(fake_pdf_content)
           FeatureToggle.enable!(:convert_tiff_images)
         end
 
@@ -76,7 +76,7 @@ describe Fetcher do
 
         context "when the tiff file cannot be converted" do
           before do
-            allow_any_instance_of(ImageConverterService).to receive(:convert_tiff_to_pdf)
+            allow_any_instance_of(ImageConverterService).to receive(:convert)
               .and_raise(ImageConverterService::ImageConverterError)
           end
 

--- a/spec/models/record_spec.rb
+++ b/spec/models/record_spec.rb
@@ -76,8 +76,18 @@ describe Record do
       end
 
       let(:mime_type) { "image/tiff" }
-      it "returns pdf" do
-        expect(record.preferred_extension).to eq("pdf")
+      it "returns tiff" do
+        expect(record.preferred_extension).to eq("tiff")
+      end
+
+      context "and conversion_status is :conversion_success" do
+        let(:record) do
+          Record.new(external_document_id: "{TEST}", mime_type: mime_type, conversion_status: :conversion_success)
+        end
+
+        it "returns pdf" do
+          expect(record.preferred_extension).to eq("pdf")
+        end
       end
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,7 +4,6 @@ require File.expand_path("../../config/environment", __FILE__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "spec_helper"
-require "utility_functions"
 require "rspec/rails"
 require_relative "support/database_cleaner"
 # Add additional requires below this line. Rails is not loaded until this point!

--- a/spec/services/image_converter_service_spec.rb
+++ b/spec/services/image_converter_service_spec.rb
@@ -1,4 +1,4 @@
-describe ImageConverterService, focus: true do
+describe ImageConverterService do
   let(:tiff_file) { Rails.root + "lib/tiffs/0.tiff" }
   let(:tiff_content) { File.open(tiff_file, "r", &:read) }
 

--- a/spec/services/image_converter_service_spec.rb
+++ b/spec/services/image_converter_service_spec.rb
@@ -1,4 +1,4 @@
-describe ImageConverterService do
+describe ImageConverterService, focus: true do
   let(:tiff_file) { Rails.root + "lib/tiffs/0.tiff" }
   let(:tiff_content) { File.open(tiff_file, "r", &:read) }
 
@@ -7,7 +7,7 @@ describe ImageConverterService do
 
   let(:manifest) { Manifest.create(file_number: "1234") }
   let(:source) { ManifestSource.create(source: %w(VBMS VVA).sample, manifest: manifest) }
-  let(:record) { Record.new(external_document_id: "TEST", manifest_source: source, mime_type: "image/tiff") }
+  let(:record) { Record.create(external_document_id: "TEST", manifest_source: source, mime_type: "image/tiff") }
   let(:image_converter) { ImageConverterService.new(image: tiff_content, record: record) }
 
   before { FeatureToggle.enable!(:convert_tiff_images) }
@@ -32,7 +32,7 @@ describe ImageConverterService do
     end
 
     context "when image is a pdf" do
-      let(:record) { Record.new(mime_type: "application/pdf") }
+      let(:record) { Record.create(external_document_id: "TEST", manifest_source: source, mime_type: "application/pdf") }
       let(:image_converter) { ImageConverterService.new(image: pdf_content, record: record) }
 
       it "doesn't change it and marks record as not_converted" do

--- a/spec/services/image_converter_service_spec.rb
+++ b/spec/services/image_converter_service_spec.rb
@@ -13,8 +13,9 @@ describe ImageConverterService do
 
   context "#process" do
     context "when image is a tiff" do
-      it "converts it" do
-        expect(valid_pdf?(image_converter.process)).to be_truthy
+      it "calls service" do
+        allow_any_instance_of(ImageConverterService).to receive(:convert_tiff_to_pdf).and_return(pdf_content)
+        expect(image_converter.process).to eq(pdf_content)
       end
     end
 

--- a/spec/services/image_converter_service_spec.rb
+++ b/spec/services/image_converter_service_spec.rb
@@ -6,7 +6,7 @@ describe ImageConverterService do
   let(:pdf_content) { File.open(tiff_file, "r", &:read) }
 
   let(:manifest) { Manifest.create(file_number: "1234") }
-  let(:source) { ManifestSource.create(source: %w(VBMS VVA).sample, manifest: manifest) }
+  let(:source) { ManifestSource.create(source: %w[VBMS VVA].sample, manifest: manifest) }
   let(:record) { Record.create(external_document_id: "TEST", manifest_source: source, mime_type: "image/tiff") }
   let(:image_converter) { ImageConverterService.new(image: tiff_content, record: record) }
 

--- a/spec/services/image_converter_service_spec.rb
+++ b/spec/services/image_converter_service_spec.rb
@@ -5,26 +5,39 @@ describe ImageConverterService do
   let(:pdf_file) { Rails.root + "lib/pdfs/0.pdf" }
   let(:pdf_content) { File.open(tiff_file, "r", &:read) }
 
-  let(:mime_type) { "image/tiff" }
-  let(:image_converter) { ImageConverterService.new(image: tiff_content, mime_type: mime_type) }
+  let(:manifest) { Manifest.create(file_number: "1234") }
+  let(:source) { ManifestSource.create(source: %w(VBMS VVA).sample, manifest: manifest) }
+  let(:record) { Record.new(external_document_id: "TEST", manifest_source: source, mime_type: "image/tiff") }
+  let(:image_converter) { ImageConverterService.new(image: tiff_content, record: record) }
 
   before { FeatureToggle.enable!(:convert_tiff_images) }
   after { FeatureToggle.disable!(:convert_tiff_images) }
 
   context "#process" do
     context "when image is a tiff" do
-      it "calls service" do
+      it "returns pdf image and marks record as conversion_success" do
         allow_any_instance_of(ImageConverterService).to receive(:convert_tiff_to_pdf).and_return(pdf_content)
         expect(image_converter.process).to eq(pdf_content)
+        expect(record.conversion_success?).to eq(true)
+      end
+
+      context "when service returns an error" do
+        it "returns tiff image and marks record as conversion_failed" do
+          allow(image_converter).to receive(:convert_tiff_to_pdf)
+            .and_raise(ImageConverterService::ImageConverterError)
+          expect(image_converter.process).to eq(tiff_content)
+          expect(record.conversion_failed?).to eq(true)
+        end
       end
     end
 
     context "when image is a pdf" do
-      let(:mime_type) { "application/pdf" }
-      let(:image_converter) { ImageConverterService.new(image: pdf_content, mime_type: mime_type) }
+      let(:record) { Record.new(mime_type: "application/pdf") }
+      let(:image_converter) { ImageConverterService.new(image: pdf_content, record: record) }
 
-      it "doesn't change it" do
+      it "doesn't change it and marks record as not_converted" do
         expect(image_converter.process).to eq(pdf_content)
+        expect(record.not_converted?).to eq(true)
       end
     end
   end

--- a/spec/services/record_fetcher_spec.rb
+++ b/spec/services/record_fetcher_spec.rb
@@ -63,7 +63,7 @@ describe RecordFetcher do
         before do
           FeatureToggle.enable!(:convert_tiff_images)
           allow(Fakes::DocumentService).to receive(:fetch_document_file).and_return(tiff_content)
-          allow_any_instance_of(ImageConverterService).to receive(:convert_tiff_to_pdf).and_return(fake_pdf_content)
+          allow_any_instance_of(ImageConverterService).to receive(:convert).and_return(fake_pdf_content)
         end
         after { FeatureToggle.disable!(:convert_tiff_images) }
 
@@ -74,7 +74,7 @@ describe RecordFetcher do
 
         context "when the tiff file cannot be converted" do
           before do
-            allow_any_instance_of(ImageConverterService).to receive(:convert_tiff_to_pdf)
+            allow_any_instance_of(ImageConverterService).to receive(:convert)
               .and_raise(ImageConverterService::ImageConverterError)
           end
 

--- a/spec/services/record_fetcher_spec.rb
+++ b/spec/services/record_fetcher_spec.rb
@@ -63,25 +63,12 @@ describe RecordFetcher do
         before do
           FeatureToggle.enable!(:convert_tiff_images)
           allow(Fakes::DocumentService).to receive(:fetch_document_file).and_return(tiff_content)
-          allow_any_instance_of(ImageConverterService).to receive(:convert).and_return(fake_pdf_content)
+          allow_any_instance_of(ImageConverterService).to receive(:convert_tiff_to_pdf).and_return(fake_pdf_content)
         end
         after { FeatureToggle.disable!(:convert_tiff_images) }
 
-        it "should convert the tiff to pdf, return it, and mark conversion as success" do
+        it "should convert the tiff to pdf and return it" do
           expect(subject).to eq fake_pdf_content
-          expect(record.conversion_success?).to be true
-        end
-
-        context "when the tiff file cannot be converted" do
-          before do
-            allow_any_instance_of(ImageConverterService).to receive(:convert)
-              .and_raise(ImageConverterService::ImageConverterError)
-          end
-
-          it "should return the tiff and mark conversion as failed" do
-            expect(subject).to eq tiff_content
-            expect(record.conversion_failed?).to be true
-          end
         end
       end
     end

--- a/spec/services/record_fetcher_spec.rb
+++ b/spec/services/record_fetcher_spec.rb
@@ -67,8 +67,9 @@ describe RecordFetcher do
         end
         after { FeatureToggle.disable!(:convert_tiff_images) }
 
-        it "should convert the tiff to pdf and return it" do
+        it "should convert the tiff to pdf, return it, and mark conversion as success" do
           expect(subject).to eq fake_pdf_content
+          expect(record.conversion_success?).to be true
         end
 
         context "when the tiff file cannot be converted" do
@@ -77,8 +78,9 @@ describe RecordFetcher do
               .and_raise(ImageConverterService::ImageConverterError)
           end
 
-          it "should return the tiff" do
+          it "should return the tiff and mark conversion as failed" do
             expect(subject).to eq tiff_content
+            expect(record.conversion_failed?).to be true
           end
         end
       end

--- a/spec/services/record_fetcher_spec.rb
+++ b/spec/services/record_fetcher_spec.rb
@@ -63,11 +63,23 @@ describe RecordFetcher do
         before do
           FeatureToggle.enable!(:convert_tiff_images)
           allow(Fakes::DocumentService).to receive(:fetch_document_file).and_return(tiff_content)
+          allow_any_instance_of(ImageConverterService).to receive(:convert_tiff_to_pdf).and_return(fake_pdf_content)
         end
         after { FeatureToggle.disable!(:convert_tiff_images) }
 
         it "should convert the tiff to pdf and return it" do
-          expect(valid_pdf?(subject)).to be_truthy
+          expect(subject).to eq fake_pdf_content
+        end
+
+        context "when the tiff file cannot be converted" do
+          before do
+            allow_any_instance_of(ImageConverterService).to receive(:convert_tiff_to_pdf)
+              .and_raise(ImageConverterService::ImageConverterError)
+          end
+
+          it "should return the tiff" do
+            expect(subject).to eq tiff_content
+          end
         end
       end
     end

--- a/spec/utility_functions.rb
+++ b/spec/utility_functions.rb
@@ -1,7 +1,0 @@
-# Checks for a valid PDF as based on this stack overflow response
-# https://stackoverflow.com/questions/28156467/fastest-way-to-check-that-a-pdf-
-# is-corrupted-or-just-missing-eof-in-ruby
-def valid_pdf?(data)
-  pattern = /^startxref\n\d+\n%%EOF\n\z/m
-  data.scrub =~ pattern
-end


### PR DESCRIPTION
This PR does two things:

1) Removes code calling Image Magick directly and instead calls our new image conversion service.
2) Changes both the v1 and v2 APIs to fail gracefully if conversion fails. If it fails we now return the original file (i.e. TIFF image) instead of failing.

**Test Plan**
- Ensure the `:convert_tiff_images` feature flag is turned on.
- Testing locally by commenting out this line: https://github.com/department-of-veterans-affairs/caseflow-efolder/blob/mdbenjam-call-convert-service/lib/fakes/document_service.rb#L88 so that we only return TIFFs then going through the UI, new and old document APIs to ensure the following:
   - If the conversion service is running (see new readme instructions), then the images are converted from TIFF to PDF
   - If the conversion service is not running or throws an error, then the TIFF images are returned.
- Once someone takes an initial look and thinks this is the right direction, I'll do more testing in UAT to ensure this works on real cases.
  