### PR TITLE
Stop caching when sending errors

### DIFF
--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -2,11 +2,12 @@ class Api::V1::DocumentsController < Api::V1::ApplicationController
   before_action :can_access?
 
   def show
+    fetch_result = document.fetch_content!(save_document_metadata: false)
+    return document_download_failed(fetch_result[:error_kind]) if fetch_result[:error_kind]
+
     # Enable document caching for a month.
     expires_in 30.days, public: true
 
-    fetch_result = document.fetch_content!(save_document_metadata: false)
-    return document_download_failed(fetch_result[:error_kind]) if fetch_result[:error_kind]
     send_data(
       fetch_result[:content],
       type: document.mime_type,

--- a/app/controllers/api/v2/records_controller.rb
+++ b/app/controllers/api/v2/records_controller.rb
@@ -1,10 +1,12 @@
 class Api::V2::RecordsController < Api::V1::ApplicationController
   before_action :validate_access
-  before_action :enable_caching
 
   def show
     result = record.fetch!
     return document_failed if record.failed?
+
+    # Only cache if we're not returning an error
+    enable_caching
 
     send_data(
       result,


### PR DESCRIPTION
Connects: #814 

Currently eFolder caches error responses. This can cause Reader users to get error versions of our pages because they retrieved a document during an outage, and cached the response.

**Test Plan**
- [ ] locally connect reader to eFolder and verify that before the change, if errors are returned from the documents_controller, that those values were cached. i.e. once the endpoint stops sending errors, going back to the error-ed documents should still return errors.
- [ ] locally connect reader to eFolder and verify that after the change, if errors are returned from the documents_controller, that those values are not cached. i.e. once the endpoint stops sending errors, going back to the error-ed documents should now resolve.
- [ ] Curl the records_controller before and after the change and ensure that the cache-control header is no longer present when throwing errors.