### PR TITLE
Enable CORS for v2

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -39,14 +39,7 @@ module CaseflowEfolder
     config.middleware.insert_before 0, "Rack::Cors" do
         allow do
           origins cors_origins
-          resource '/api/v1/*',
-            headers:     :any, # Headers to allow in the request
-            methods:     :get,
-            # when making a cross-origin request, only Cache-Control, Content-Language, 
-            # Content-Type, Expires, Last-Modified, Pragma are exposed. PDF.js requires some additional headers to be sent as well
-            expose:      ['content-range, content-length, accept-ranges'], # Headers to send in response
-            credentials: true
-          resource '/api/v2/*',
+          resource /\/api\/v(1|2)\/.*/,
             headers:     :any, # Headers to allow in the request
             methods:     :get,
             # when making a cross-origin request, only Cache-Control, Content-Language, 

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,6 +46,13 @@ module CaseflowEfolder
             # Content-Type, Expires, Last-Modified, Pragma are exposed. PDF.js requires some additional headers to be sent as well
             expose:      ['content-range, content-length, accept-ranges'], # Headers to send in response
             credentials: true
+          resource '/api/v2/*',
+            headers:     :any, # Headers to allow in the request
+            methods:     :get,
+            # when making a cross-origin request, only Cache-Control, Content-Language, 
+            # Content-Type, Expires, Last-Modified, Pragma are exposed. PDF.js requires some additional headers to be sent as well
+            expose:      ['content-range, content-length, accept-ranges'], # Headers to send in response
+            credentials: true
         end
     end
 


### PR DESCRIPTION
The new eFolder API (v2) needs CORS enabled to service requests from other domains. We've already enabled v1, so we updated the allowed URLs to include v2.

**Test Plan**
- [ ] Change the `config.use_efolder_locally = true` in Caseflow's `development.rb`
- [ ] Run eFolder on port 4000, and Caseflow on port 3000
- [ ] Ensure FeatureToggle `:efolder_api_v2` is disabled, then go to the document list page and click on documents. Ensure they load.
- [ ] Turn on FeatureToggle `:efolder_api_v2`, then go to the document list page and click on documents. Ensure they load. Open up the network tab and ensure they are coming from the v2 version of the API.