### PR TITLE
Anya/818 add series id and version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,8 +80,8 @@ gem "mini_magick"
 gem "httpclient"
 
 gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", branch: "9266698668bf361bf5df06990d06da59abb7c608"
-gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "e7fc3e6825f45176950c0b7ce37b38068ec5aea8"
-gem "connect_vva", git: "https://github.com/department-of-veterans-affairs/connect_vva.git", ref: "f7036e7d3c17aae6e66e345051ea61c6badc5de2"
+gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "7b3da0fa5ee6732d3c8ad2f557e425e770b1f435"
+gem "connect_vva", git: "https://github.com/department-of-veterans-affairs/connect_vva.git", ref: "5af0ad0e2538c1039bce75dbc6c4019b3e0c3312"
 
 # catch problematic migrations
 gem "zero_downtime_migrations"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,8 +21,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vbms.git
-  revision: e7fc3e6825f45176950c0b7ce37b38068ec5aea8
-  ref: e7fc3e6825f45176950c0b7ce37b38068ec5aea8
+  revision: 7b3da0fa5ee6732d3c8ad2f557e425e770b1f435
+  ref: 7b3da0fa5ee6732d3c8ad2f557e425e770b1f435
   specs:
     connect_vbms (1.0.0)
       httpclient (~> 2.8.0)
@@ -35,8 +35,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vva.git
-  revision: f7036e7d3c17aae6e66e345051ea61c6badc5de2
-  ref: f7036e7d3c17aae6e66e345051ea61c6badc5de2
+  revision: 5af0ad0e2538c1039bce75dbc6c4019b3e0c3312
+  ref: 5af0ad0e2538c1039bce75dbc6c4019b3e0c3312
   specs:
     connect_vva (0.1)
       savon (~> 2.11, >= 2.11.0)

--- a/app/models/serializers/v2/manifest_serializer.rb
+++ b/app/models/serializers/v2/manifest_serializer.rb
@@ -22,7 +22,8 @@ class Serializers::V2::ManifestSerializer < ActiveModel::Serializer
         id: document.id,
         type_id: document.type_id,
         received_at: document.received_at,
-        external_document_id: document.external_document_id,
+        version_id: document.version_id,
+        series_id: document.series_id,
         created_at: document.created_at,
         updated_at: document.updated_at
       }

--- a/app/services/external_api/vva_service.rb
+++ b/app/services/external_api/vva_service.rb
@@ -13,6 +13,11 @@ class ExternalApi::VVAService
     documents
   end
 
+  # TODO: remove when switched to VBMS eFolder API
+  def self.v2_fetch_documents_for(download)
+    fetch_documents_for(download)
+  end
+
   def self.fetch_document_file(document)
     @vva_client ||= init_client
     result ||= MetricsService.record("VVA: fetch document content for: #{document.document_id}",
@@ -27,6 +32,11 @@ class ExternalApi::VVAService
       )
     end
     result&.content
+  end
+
+  # TODO: remove when switched to VBMS eFolder API
+  def self.v2_fetch_document_file(document)
+    fetch_document_file(document)
   end
 
   def self.init_client

--- a/app/services/manifest_fetcher.rb
+++ b/app/services/manifest_fetcher.rb
@@ -7,7 +7,7 @@ class ManifestFetcher
   EXCEPTIONS = [VBMS::ClientError, VVA::ClientError, StandardError].freeze
 
   def process
-    documents = manifest_source.service.fetch_documents_for(manifest_source.manifest)
+    documents = manifest_source.service.v2_fetch_documents_for(manifest_source.manifest)
     manifest_source.update(status: :success, fetched_at: Time.zone.now)
     documents
   rescue *EXCEPTIONS => e

--- a/app/services/record_fetcher.rb
+++ b/app/services/record_fetcher.rb
@@ -7,7 +7,7 @@ class RecordFetcher
 
   def process
     return cached_content if cached_content
-    content = record.service.fetch_document_file(record)
+    content = record.service.v2_fetch_document_file(record)
     content = ImageConverterService.new(image: content, record: record).process
     S3Service.store_file(record.s3_filename, content)
     record.update(status: :success)

--- a/db/migrate/20180109185340_add_series_id_version_to_records.rb
+++ b/db/migrate/20180109185340_add_series_id_version_to_records.rb
@@ -1,0 +1,6 @@
+class AddSeriesIdVersionToRecords < ActiveRecord::Migration
+  def change
+    add_column :records, :series_id, :string
+    add_column :records, :version, :integer
+  end
+end

--- a/db/migrate/20180109194733_rename_external_document_id_to_version_id_in_records.rb
+++ b/db/migrate/20180109194733_rename_external_document_id_to_version_id_in_records.rb
@@ -1,0 +1,5 @@
+class RenameExternalDocumentIdToVersionIdInRecords < ActiveRecord::Migration
+  def change
+    rename_column :records, :external_document_id, :version_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,8 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180108170052) do
-
+ActiveRecord::Schema.define(version: 20180109194733) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -107,8 +106,8 @@ ActiveRecord::Schema.define(version: 20180108170052) do
 
   create_table "records", force: :cascade do |t|
     t.integer  "manifest_source_id"
-    t.integer  "status",               default: 0
-    t.string   "external_document_id"
+    t.integer  "status",             default: 0
+    t.string   "version_id"
     t.string   "mime_type"
     t.datetime "received_at"
     t.string   "type_description"
@@ -116,12 +115,14 @@ ActiveRecord::Schema.define(version: 20180108170052) do
     t.integer  "size"
     t.string   "jro"
     t.string   "source"
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
     t.integer  "conversion_status",    default: 0
+    t.string   "series_id"
+    t.integer  "version"
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
   end
 
-  add_index "records", ["manifest_source_id", "external_document_id"], name: "index_records_on_manifest_source_id_and_external_document_id", using: :btree
+  add_index "records", ["manifest_source_id", "version_id"], name: "index_records_on_manifest_source_id_and_version_id", using: :btree
 
   create_table "searches", force: :cascade do |t|
     t.integer  "download_id"
@@ -139,9 +140,10 @@ ActiveRecord::Schema.define(version: 20180108170052) do
   create_table "user_manifests", force: :cascade do |t|
     t.integer  "manifest_id"
     t.integer  "user_id"
-    t.integer  "status",      default: 0
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+    t.integer  "status",           default: 0
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+    t.datetime "fetched_files_at"
   end
 
   add_index "user_manifests", ["manifest_id", "user_id"], name: "index_user_manifests_on_manifest_id_and_user_id", using: :btree

--- a/lib/fakes/document_service.rb
+++ b/lib/fakes/document_service.rb
@@ -97,6 +97,7 @@ class Fakes::DocumentService
     { ext: "tiff", mime_type: "image/tiff" }
   end
 
+  # rubocop:disable Metrics/AbcSize
   def self.create_document(i)
     type = document_type
 
@@ -112,6 +113,7 @@ class Fakes::DocumentService
       downloaded_from: service_type
     )
   end
+  # rubocop:enable Metrics/AbcSize
 
   def self.list_fake_documents(file_number)
     demo = DEMOS[file_number]

--- a/lib/fakes/document_service.rb
+++ b/lib/fakes/document_service.rb
@@ -57,6 +57,10 @@ class Fakes::DocumentService
     list_fake_documents(download.file_number)
   end
 
+  def self.v2_fetch_documents_for(download)
+    fetch_documents_for(download)
+  end
+
   def self.fetch_document_file(document)
     sleep(rand(max_time))
     raise VBMS::ClientError if errors && rand(5) == 3
@@ -67,6 +71,10 @@ class Fakes::DocumentService
     else
       IO.binread(Rails.root + "lib/tiffs/#{document.id % 5}.tiff")
     end
+  end
+
+  def self.v2_fetch_document_file(document)
+    fetch_document_file(document)
   end
 
   # can be overridden by child classes to provide more specific error
@@ -96,6 +104,9 @@ class Fakes::DocumentService
       vbms_filename: "happy-thursday-#{SecureRandom.hex}.#{type[:ext]}",
       type_id: Document::TYPES.keys.sample,
       document_id: "{#{SecureRandom.hex(4).upcase}-#{SecureRandom.hex(2).upcase}-#{SecureRandom.hex(2).upcase}-#{SecureRandom.hex(2).upcase}-#{SecureRandom.hex(6).upcase}}",
+      version_id: "{#{SecureRandom.hex(4).upcase}-#{SecureRandom.hex(2).upcase}-#{SecureRandom.hex(2).upcase}-#{SecureRandom.hex(2).upcase}-#{SecureRandom.hex(6).upcase}}",
+      series_id: "{#{SecureRandom.hex(4).upcase}-#{SecureRandom.hex(2).upcase}-#{SecureRandom.hex(2).upcase}-#{SecureRandom.hex(2).upcase}-#{SecureRandom.hex(6).upcase}}",
+      version: rand(10).to_s,
       mime_type: type[:mime_type],
       received_at: (i * 2).days.ago,
       downloaded_from: service_type

--- a/spec/jobs/v2/download_manifest_job_spec.rb
+++ b/spec/jobs/v2/download_manifest_job_spec.rb
@@ -5,8 +5,8 @@ describe DownloadManifestJob do
 
     let(:documents) do
       [
-        OpenStruct.new(document_id: "1"),
-        OpenStruct.new(document_id: "2")
+        OpenStruct.new(document_id: "1", series_id: "1234"),
+        OpenStruct.new(document_id: "2", series_id: "5678")
       ]
     end
 

--- a/spec/jobs/v2/save_files_in_s3_job_spec.rb
+++ b/spec/jobs/v2/save_files_in_s3_job_spec.rb
@@ -5,8 +5,8 @@ describe SaveFilesInS3Job do
 
     let!(:records) do
       [
-        source.records.create(external_document_id: "1234"),
-        source.records.create(external_document_id: "5678")
+        source.records.create(version_id: "1234", series_id: "4321"),
+        source.records.create(version_id: "5678", series_id: "8765")
       ]
     end
 

--- a/spec/models/record_spec.rb
+++ b/spec/models/record_spec.rb
@@ -11,6 +11,8 @@ describe Record do
     let(:external_document) do
       OpenStruct.new(
         document_id: "12345",
+        series_id: "6789",
+        version: "2",
         type_id: "777",
         type_description: "VA 8 Certification of Appeal",
         mime_type: "application/pdf",
@@ -22,7 +24,9 @@ describe Record do
 
     it "creates a record" do
       expect(subject.manifest_source).to eq source
-      expect(subject.external_document_id).to eq "12345"
+      expect(subject.version_id).to eq "12345"
+      expect(subject.series_id).to eq "6789"
+      expect(subject.version).to eq 2
       expect(subject.type_id).to eq "777"
       expect(subject.type_description).to eq "VA 8 Certification of Appeal"
       expect(subject.received_at).to eq 2.days.ago
@@ -35,7 +39,7 @@ describe Record do
     subject { record.s3_filename }
 
     let(:record) do
-      Record.new(external_document_id: "{TEST}", mime_type: "application/pdf")
+      Record.new(version_id: "{TEST}", mime_type: "application/pdf")
     end
 
     it { is_expected.to eq("{TEST}.pdf") }
@@ -46,7 +50,8 @@ describe Record do
       subject do
         Record.create(
           mime_type: mime_type,
-          external_document_id: "1234",
+          version_id: "1234",
+          series_id: "5678",
           manifest_source: source
         ).mime_type
       end
@@ -61,7 +66,7 @@ describe Record do
 
   context "#preferred_extension" do
     let(:record) do
-      Record.new(external_document_id: "{TEST}", mime_type: mime_type)
+      Record.new(version_id: "{TEST}", mime_type: mime_type)
     end
 
     context "when passed application/pdf" do
@@ -83,7 +88,7 @@ describe Record do
 
       context "and conversion_status is :conversion_success" do
         let(:record) do
-          Record.new(external_document_id: "{TEST}", mime_type: mime_type, conversion_status: :conversion_success)
+          Record.new(version_id: "{TEST}", mime_type: mime_type, conversion_status: :conversion_success)
         end
 
         it "returns pdf" do
@@ -102,7 +107,7 @@ describe Record do
 
   context "#accessible_by?" do
     let(:user) { User.create(css_id: "123", station_id: "456") }
-    let(:record) { Record.create(manifest_source: source) }
+    let(:record) { Record.new(manifest_source: source) }
 
     subject { record.accessible_by?(user) }
 

--- a/spec/requests/api/v2/records_spec.rb
+++ b/spec/requests/api/v2/records_spec.rb
@@ -9,7 +9,8 @@ describe "Records API v2", type: :request do
 
     let(:record) do
       Record.create(
-        external_document_id: "{3333-3333}",
+        version_id: "{3333-3333}",
+        series_id: "{4444-4444",
         manifest_source: source,
         received_at: Time.utc(2015, 9, 6, 1, 0, 0),
         type_id: "825",

--- a/spec/services/document_creator_spec.rb
+++ b/spec/services/document_creator_spec.rb
@@ -8,8 +8,8 @@ describe DocumentCreator do
     context "when there are external documents" do
       let(:documents) do
         [
-          OpenStruct.new(document_id: "1"),
-          OpenStruct.new(document_id: "2")
+          OpenStruct.new(document_id: "1", series_id: "3"),
+          OpenStruct.new(document_id: "2", series_id: "4")
         ]
       end
       it "creates the documents" do
@@ -32,8 +32,8 @@ describe DocumentCreator do
     context "when there are restricted document types" do
       let(:documents) do
         [
-          OpenStruct.new(document_id: "1", type_id: DocumentCreator::RESTRICTED_TYPES.sample),
-          OpenStruct.new(document_id: "2", type_id: "554")
+          OpenStruct.new(document_id: "1", series_id: "3", type_id: DocumentCreator::RESTRICTED_TYPES.sample),
+          OpenStruct.new(document_id: "2", series_id: "4", type_id: "554")
         ]
       end
 
@@ -41,7 +41,8 @@ describe DocumentCreator do
         expect(source.records).to eq []
         subject
         expect(source.reload.records.size).to eq 1
-        expect(source.reload.records.first.external_document_id).to eq "2"
+        expect(source.reload.records.first.version_id).to eq "2"
+        expect(source.reload.records.first.series_id).to eq "4"
       end
     end
   end

--- a/spec/services/image_converter_service_spec.rb
+++ b/spec/services/image_converter_service_spec.rb
@@ -7,7 +7,7 @@ describe ImageConverterService do
 
   let(:manifest) { Manifest.create(file_number: "1234") }
   let(:source) { ManifestSource.create(source: %w[VBMS VVA].sample, manifest: manifest) }
-  let(:record) { Record.create(external_document_id: "TEST", manifest_source: source, mime_type: "image/tiff") }
+  let(:record) { Record.create(version_id: "TEST", series_id: "5555", manifest_source: source, mime_type: "image/tiff") }
   let(:image_converter) { ImageConverterService.new(image: tiff_content, record: record) }
 
   before { FeatureToggle.enable!(:convert_tiff_images) }
@@ -32,7 +32,7 @@ describe ImageConverterService do
     end
 
     context "when image is a pdf" do
-      let(:record) { Record.create(external_document_id: "TEST", manifest_source: source, mime_type: "application/pdf") }
+      let(:record) { Record.create(version_id: "TEST", series_id: "6666", manifest_source: source, mime_type: "application/pdf") }
       let(:image_converter) { ImageConverterService.new(image: pdf_content, record: record) }
 
       it "doesn't change it and marks record as not_converted" do

--- a/spec/services/manifest_fetcher_spec.rb
+++ b/spec/services/manifest_fetcher_spec.rb
@@ -4,8 +4,8 @@ describe ManifestFetcher do
 
   let(:documents) do
     [
-      OpenStruct.new(document_id: "1"),
-      OpenStruct.new(document_id: "2")
+      OpenStruct.new(document_id: "1", series_id: "3"),
+      OpenStruct.new(document_id: "2", series_id: "4")
     ]
   end
 
@@ -17,7 +17,7 @@ describe ManifestFetcher do
 
       context "when VBMS client returns manifest" do
         before do
-          allow(VBMSService).to receive(:fetch_documents_for).and_return(documents)
+          allow(VBMSService).to receive(:v2_fetch_documents_for).and_return(documents)
         end
 
         it "saves manifest status as success and updated fetched at" do
@@ -29,7 +29,7 @@ describe ManifestFetcher do
 
       context "when VBMS client returns error" do
         before do
-          allow(VBMSService).to receive(:fetch_documents_for).and_raise(VBMS::ClientError)
+          allow(VBMSService).to receive(:v2_fetch_documents_for).and_raise(VBMS::ClientError)
         end
 
         it "saves manifest status as failed" do
@@ -45,7 +45,7 @@ describe ManifestFetcher do
 
       context "when VVA client returns manifest" do
         before do
-          allow(VVAService).to receive(:fetch_documents_for).and_return(documents)
+          allow(VVAService).to receive(:v2_fetch_documents_for).and_return(documents)
         end
 
         it "saves manifest status as success and updated fetched at" do
@@ -57,7 +57,7 @@ describe ManifestFetcher do
 
       context "when VVA client returns error" do
         before do
-          allow(VVAService).to receive(:fetch_documents_for).and_raise(VVA::ClientError)
+          allow(VVAService).to receive(:v2_fetch_documents_for).and_raise(VVA::ClientError)
         end
 
         it "saves manifest status as failed" do

--- a/spec/services/record_fetcher_spec.rb
+++ b/spec/services/record_fetcher_spec.rb
@@ -4,7 +4,8 @@ describe RecordFetcher do
 
   let(:record) do
     Record.create(
-      external_document_id: "{3333-3333}",
+      version_id: "{3333-3333}",
+      series_id: "{4444-4444}",
       manifest_source: source,
       received_at: Time.utc(2015, 9, 6, 1, 0, 0),
       type_id: "825",


### PR DESCRIPTION
connects #818 
This PR adds series_id and version. The VBMS eFolder new API will only be integrated into eX v2 code. 
Reader will need to start using series_id to identify the document. Need to think how to migrate Reader. 