### PR TITLE
Catching timeout exceptions

### DIFF
--- a/app/services/image_converter_service.rb
+++ b/app/services/image_converter_service.rb
@@ -30,6 +30,8 @@ class ImageConverterService
 
   private
 
+  EXCEPTIONS = [Errno::ECONNREFUSED, HTTPClient::ReceiveTimeoutError].freeze
+
   # :nocov:
   def convert_tiff_to_pdf
     url = "http://localhost:5000/tiff-convert"
@@ -53,7 +55,7 @@ class ImageConverterService
     end
 
     response.body
-  rescue Errno::ECONNREFUSED
+  rescue *EXCEPTIONS
     raise ImageConverterError
   end
   # :nocov:


### PR DESCRIPTION
Looks like there's a second exception that can be raised from our service. Catching it here to handle gracefully.

**Test Plan**
- [ ] Manually change conversion service to sleep 61 seconds before returning.
   - [ ] Send request and ensure catching this error is successful.