### PR TITLE
Mutex manifest download job and package files job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,7 @@ gem "zaru"
 gem "active_model_serializers"
 
 gem "redis-namespace"
+gem "redis-semaphore"
 
 gem "request_store"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -317,6 +317,8 @@ GEM
       redis-actionpack (>= 5.0, < 6)
       redis-activesupport (>= 5.0, < 6)
       redis-store (>= 1.2, < 2)
+    redis-semaphore (0.3.1)
+      redis
     redis-store (1.4.1)
       redis (>= 2.2, < 5)
     ref (2.0.0)
@@ -500,6 +502,7 @@ DEPENDENCIES
   rb-readline
   redis-namespace
   redis-rails (~> 5.0.2)
+  redis-semaphore
   request_store
   rspec
   rspec-rails

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -241,6 +241,11 @@ module ApplicationHelper
     "#{format('%.2f', seconds / 60)} <span class=\"ee-stat-unit\">min</span>".html_safe
   end
 
+  def ui_user?
+    return false unless RequestStore[:current_user]
+    (RequestStore[:current_user].roles || []).include?("Download eFolder")
+  end
+
   def current_ga_path
     full_path = request.env["PATH_INFO"]
 

--- a/app/jobs/v2/download_manifest_job.rb
+++ b/app/jobs/v2/download_manifest_job.rb
@@ -1,14 +1,23 @@
 class V2::DownloadManifestJob < ActiveJob::Base
   queue_as :default
 
-  def perform(manifest_source)
-    ManifestFetcher.new(manifest_source: manifest_source).process
-  # Start downloading files if it is not eX user
-  # V2::SaveFilesInS3Job.perform_later(manifest_source)
-  # Catch StandardError in case there is an error to avoid manifests being stuck in pending state
+  SECONDS_TO_AUTO_UNLOCK = 180
+
+  def perform(manifest_source, ui_user)
+    s = Redis::Semaphore.new("download_manifest_source_#{manifest_source.id}".to_s,
+                             connection: Rails.application.secrets.redis_url_sidekiq)
+
+    s.lock(SECONDS_TO_AUTO_UNLOCK)
+    return if manifest_source.current?
+
+    documents = ManifestFetcher.new(manifest_source: manifest_source).process
+
+    V2::SaveFilesInS3Job.perform_later(manifest_source) if documents.present? && !ui_user
   rescue StandardError => e
     manifest_source.update!(status: :failed)
     raise e
+  ensure
+    s.unlock
   end
 
   def max_attempts

--- a/app/jobs/v2/package_files_job.rb
+++ b/app/jobs/v2/package_files_job.rb
@@ -1,12 +1,23 @@
 class V2::PackageFilesJob < ActiveJob::Base
   queue_as :default
 
+  SECONDS_TO_AUTO_UNLOCK = 43_200
+
   def perform(manifest)
+    s = Redis::Semaphore.new("package_files_#{manifest.id}".to_s,
+                             connection: Rails.application.secrets.redis_url_sidekiq)
+
+    s.lock(SECONDS_TO_AUTO_UNLOCK)
+
+    return if manifest.recently_downloaded_files?
+
     ZipfileCreator.new(manifest: manifest).process
   # Catch StandardError in case there is an error to avoid files downloads being stuck in pending state
   rescue StandardError => e
     manifest.update!(fetched_files_status: :failed)
     raise e
+  ensure
+    s.unlock
   end
 
   def max_attempts

--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -27,8 +27,12 @@ class Manifest < ActiveRecord::Base
     V2::PackageFilesJob.perform_later(self)
   end
 
+  def recently_downloaded_files?
+    finished? && fetched_files_at && fetched_files_at > 3.days.ago
+  end
+
   def reset_records
-    records.where.not(status: 1).update_all(status: 0)
+    records.update_all(status: 0)
   end
 
   def vbms_source
@@ -85,10 +89,6 @@ class Manifest < ActiveRecord::Base
   end
 
   private
-
-  def recently_downloaded_files?
-    finished? && fetched_files_at && fetched_files_at > 3.days.ago
-  end
 
   def update_veteran_info
     return unless veteran

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -8,9 +8,8 @@ class Record < ActiveRecord::Base
 
   enum status: {
     initialized: 0,
-    pending: 1,
-    success: 2,
-    failed: 3
+    success: 1,
+    failed: 2
   }
 
   enum conversion_status: {

--- a/app/services/zipfile_creator.rb
+++ b/app/services/zipfile_creator.rb
@@ -10,29 +10,36 @@ class ZipfileCreator
     return if records.empty?
 
     t = Tempfile.new
-    index = 0
+    write_to_tempfile(t, records)
 
-    Zip::OutputStream.open(t.path) do |z|
-      records.each do |record|
-        content = record.fetch!
-        next unless content
-        z.put_next_entry(unique_filename(record, index))
-        z.print(content) && (index += 1)
-      end
-    end
     S3Service.store_file(manifest.s3_filename, t.path, :filepath)
-
     manifest.update(
       zipfile_size: File.size(t.path),
       fetched_files_status: :finished,
       fetched_files_at: Time.zone.now
     )
-
     t.close
     t.unlink
   end
 
   private
+
+  def write_to_tempfile(t, records)
+    index = 0
+    Zip::OutputStream.open(t.path) do |z|
+      records.each do |record|
+        content = record.fetch!
+        unless content
+          record.update(status: :failed)
+          next
+        end
+        z.put_next_entry(unique_filename(record, index))
+        z.print(content)
+        record.update(status: :success)
+        index += 1
+      end
+    end
+  end
 
   def unique_filename(record, index)
     "#{format('%04d', index + 1)}0-#{record.filename}"

--- a/lib/fakes/document_service.rb
+++ b/lib/fakes/document_service.rb
@@ -56,6 +56,8 @@ class Fakes::DocumentService
 
     sleep_and_check_for_error(demo, source.name)
 
+    return [] if source.records.count == demo[:num_docs]
+
     (1..(demo[:num_docs] || 0)).to_a.map do |i|
       create_document(i)
     end

--- a/spec/jobs/v2/download_manifest_job_spec.rb
+++ b/spec/jobs/v2/download_manifest_job_spec.rb
@@ -2,6 +2,7 @@ describe V2::DownloadManifestJob do
   context "#perform" do
     let(:manifest) { Manifest.create(file_number: "1234") }
     let(:source) { ManifestSource.create(name: %w[VBMS VVA].sample, manifest: manifest) }
+    let(:ui_user) { false }
 
     let(:documents) do
       [
@@ -10,7 +11,7 @@ describe V2::DownloadManifestJob do
       ]
     end
 
-    subject { V2::DownloadManifestJob.perform_now(source) }
+    subject { V2::DownloadManifestJob.perform_now(source, ui_user) }
 
     before do
       allow(V2::SaveFilesInS3Job).to receive(:perform_later)
@@ -44,11 +45,24 @@ describe V2::DownloadManifestJob do
         allow(Fakes::DocumentService).to receive(:v2_fetch_documents_for).and_return(documents)
       end
 
-      it "creates document records and starts caching files in s3" do
-        subject
-        expect(manifest.records.size).to eq 2
-        # TODO: uncomment this line
-        # expect(V2::SaveFilesInS3Job).to have_received(:perform_later)
+      context "when user is not a UI user" do
+        let(:ui_user) { false }
+
+        it "creates document records and starts caching files in s3" do
+          subject
+          expect(manifest.records.size).to eq 2
+          expect(V2::SaveFilesInS3Job).to have_received(:perform_later)
+        end
+      end
+
+      context "when user is a UI user" do
+        let(:ui_user) { true }
+
+        it "creates document records and does not start caching files in s3" do
+          subject
+          expect(manifest.records.size).to eq 2
+          expect(V2::SaveFilesInS3Job).to_not have_received(:perform_later)
+        end
       end
     end
   end

--- a/spec/services/record_fetcher_spec.rb
+++ b/spec/services/record_fetcher_spec.rb
@@ -26,7 +26,7 @@ describe RecordFetcher do
         allow(S3Service).to receive(:fetch_content).with(record.s3_filename).and_return("hello there")
       end
 
-      it "should return the content from S3 and should not update the DB" do
+      it "should return the content from S3" do
         expect(subject).to eq "hello there"
       end
     end
@@ -37,20 +37,8 @@ describe RecordFetcher do
         allow(Fakes::DocumentService).to receive(:v2_fetch_document_file).and_raise([VBMS::ClientError, VVA::ClientError].sample)
       end
 
-      it "should return nil and update status" do
+      it "should return nil" do
         expect(subject).to eq nil
-        expect(record.status).to eq "failed"
-      end
-    end
-
-    context "when application error" do
-      before do
-        allow(S3Service).to receive(:fetch_content).and_raise("application error")
-      end
-
-      it "should return raise error and update status" do
-        expect { subject }.to raise_error("application error")
-        expect(record.status).to eq "failed"
       end
     end
 
@@ -62,11 +50,6 @@ describe RecordFetcher do
 
       it "should return the content from VBMS" do
         expect(subject).to eq fake_pdf_content
-      end
-
-      it "should update document DB fields" do
-        subject
-        expect(record.reload.status).to eq "success"
       end
 
       context "when VBMS returns a tiff file" do

--- a/spec/services/zipfile_creator_spec.rb
+++ b/spec/services/zipfile_creator_spec.rb
@@ -46,6 +46,8 @@ describe ZipfileCreator do
       it "should create a zip file with all files" do
         subject
         expect(manifest.zipfile_size).to_not eq nil
+        expect(manifest.number_successful_documents).to eq 3
+        expect(manifest.number_failed_documents).to eq 0
         S3Service.fetch_file(manifest.s3_filename, zip_path)
         Zip::File.open(zip_path) do |zip_file|
           expect(zip_file.size).to eq 3
@@ -86,6 +88,8 @@ describe ZipfileCreator do
 
       it "should create a zip file with VBMS documents only" do
         subject
+        expect(manifest.number_successful_documents).to eq 2
+        expect(manifest.number_failed_documents).to eq 1
         S3Service.fetch_file(manifest.s3_filename, zip_path)
         Zip::File.open(zip_path) do |zip_file|
           expect(zip_file.size).to eq 2
@@ -126,6 +130,8 @@ describe ZipfileCreator do
 
       it "should create a zip file with VVA documents only" do
         subject
+        expect(manifest.number_successful_documents).to eq 1
+        expect(manifest.number_failed_documents).to eq 2
         S3Service.fetch_file(manifest.s3_filename, zip_path)
         Zip::File.open(zip_path) do |zip_file|
           expect(zip_file.size).to eq 1


### PR DESCRIPTION
1. Handle edge case: when two users might start the same job for the same manifest/source at the same time. 
2. Add additional logic if a current user doesn't have eX role, start saving files in s3 job