### PR TITLE
Rename manifest source - source column

### DIFF
--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -32,11 +32,11 @@ class Manifest < ActiveRecord::Base
   end
 
   def vbms_source
-    sources.find_or_create_by(source: "VBMS")
+    sources.find_or_create_by(name: "VBMS")
   end
 
   def vva_source
-    sources.find_or_create_by(source: "VVA")
+    sources.find_or_create_by(name: "VVA")
   end
 
   def number_successful_documents

--- a/app/models/manifest_source.rb
+++ b/app/models/manifest_source.rb
@@ -9,9 +9,9 @@ class ManifestSource < ActiveRecord::Base
   belongs_to :manifest
   has_many :records, dependent: :destroy
 
-  validates :manifest, :source, presence: true
-  validates :manifest, uniqueness: { scope: :source }
-  validates :source, inclusion: { in: %w[VBMS VVA] }
+  validates :manifest, :name, presence: true
+  validates :manifest, uniqueness: { scope: :name }
+  validates :name, inclusion: { in: %w[VBMS VVA] }
 
   delegate :file_number, to: :manifest
 
@@ -22,7 +22,7 @@ class ManifestSource < ActiveRecord::Base
   end
 
   def service
-    case source
+    case name
     when "VBMS"
       VBMSService
     when "VVA"

--- a/app/models/serializers/v2/manifest_serializer.rb
+++ b/app/models/serializers/v2/manifest_serializer.rb
@@ -9,7 +9,7 @@ class Serializers::V2::ManifestSerializer < ActiveModel::Serializer
   attribute :sources do
     object.sources.map do |source|
       {
-        source: source.source,
+        source: source.name,
         status: source.status,
         fetched_at: source.fetched_at,
         number_of_documents: source.records.count

--- a/db/migrate/20180123192853_rename_source_to_name_in_sources.rb
+++ b/db/migrate/20180123192853_rename_source_to_name_in_sources.rb
@@ -1,0 +1,5 @@
+class RenameSourceToNameInSources < ActiveRecord::Migration
+  def change
+    rename_column :manifest_sources, :source, :name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180117181843) do
+ActiveRecord::Schema.define(version: 20180123192853) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -97,7 +97,7 @@ ActiveRecord::Schema.define(version: 20180117181843) do
   create_table "manifest_sources", force: :cascade do |t|
     t.integer  "manifest_id"
     t.integer  "status",      default: 0
-    t.string   "source"
+    t.string   "name"
     t.datetime "fetched_at"
     t.datetime "created_at",              null: false
     t.datetime "updated_at",              null: false
@@ -109,9 +109,9 @@ ActiveRecord::Schema.define(version: 20180117181843) do
     t.string   "veteran_first_name"
     t.string   "veteran_last_four_ssn"
     t.integer  "zipfile_size",          limit: 8
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
-    t.integer  "fetched_files_status",  default: 0
+    t.datetime "created_at",                                  null: false
+    t.datetime "updated_at",                                  null: false
+    t.integer  "fetched_files_status",            default: 0
     t.datetime "fetched_files_at"
   end
 
@@ -128,11 +128,11 @@ ActiveRecord::Schema.define(version: 20180117181843) do
     t.integer  "size"
     t.string   "jro"
     t.string   "source"
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
     t.integer  "conversion_status",  default: 0
     t.string   "series_id"
     t.integer  "version"
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
   end
 
   add_index "records", ["manifest_source_id", "series_id"], name: "index_records_on_manifest_source_id_and_series_id", using: :btree

--- a/lib/fakes/document_service.rb
+++ b/lib/fakes/document_service.rb
@@ -54,7 +54,7 @@ class Fakes::DocumentService
     demo = DEMOS[source.file_number] || DEMOS["DEMODEFAULT"]
     return [] if !demo || demo[:num_docs] <= 0
 
-    sleep_and_check_for_error(demo, source.source)
+    sleep_and_check_for_error(demo, source.name)
 
     (1..(demo[:num_docs] || 0)).to_a.map do |i|
       create_document(i)

--- a/spec/jobs/v2/download_manifest_job_spec.rb
+++ b/spec/jobs/v2/download_manifest_job_spec.rb
@@ -1,7 +1,7 @@
 describe V2::DownloadManifestJob do
   context "#perform" do
     let(:manifest) { Manifest.create(file_number: "1234") }
-    let(:source) { ManifestSource.create(source: %w[VBMS VVA].sample, manifest: manifest) }
+    let(:source) { ManifestSource.create(name: %w[VBMS VVA].sample, manifest: manifest) }
 
     let(:documents) do
       [

--- a/spec/jobs/v2/package_files_job_spec.rb
+++ b/spec/jobs/v2/package_files_job_spec.rb
@@ -2,7 +2,7 @@ describe V2::PackageFilesJob do
   context "#perform" do
     let(:user) { User.create(css_id: "Foo", station_id: "112") }
     let(:manifest) { Manifest.find_or_create_by_user(user: user, file_number: "1234") }
-    let(:source) { ManifestSource.create(source: %w[VBMS VVA].sample, manifest: manifest) }
+    let(:source) { ManifestSource.create(name: %w[VBMS VVA].sample, manifest: manifest) }
 
     let!(:records) do
       [

--- a/spec/jobs/v2/save_files_in_s3_job_spec.rb
+++ b/spec/jobs/v2/save_files_in_s3_job_spec.rb
@@ -1,7 +1,7 @@
 describe V2::SaveFilesInS3Job do
   context "#perform" do
     let(:manifest) { Manifest.create(file_number: "1234") }
-    let(:source) { ManifestSource.create(source: %w[VBMS VVA].sample, manifest: manifest) }
+    let(:source) { ManifestSource.create(name: %w[VBMS VVA].sample, manifest: manifest) }
 
     let!(:records) do
       [

--- a/spec/models/manifest_source_spec.rb
+++ b/spec/models/manifest_source_spec.rb
@@ -1,7 +1,7 @@
 describe ManifestSource do
   context "#source" do
     let(:manifest) { Manifest.create(file_number: "1234") }
-    let(:source) { ManifestSource.create(source: name, manifest: manifest) }
+    let(:source) { ManifestSource.create(name: name, manifest: manifest) }
 
     subject { source.service }
 
@@ -27,7 +27,7 @@ describe ManifestSource do
     end
 
     let(:manifest) { Manifest.create(file_number: "1234") }
-    let(:source) { ManifestSource.create(source: %w[VBMS VVA].sample, manifest: manifest) }
+    let(:source) { ManifestSource.create(name: %w[VBMS VVA].sample, manifest: manifest) }
 
     subject { source.start! }
 

--- a/spec/models/manifest_spec.rb
+++ b/spec/models/manifest_spec.rb
@@ -20,8 +20,8 @@ describe Manifest do
 
     context "when all manifests are current" do
       it "does not start any jobs" do
-        manifest.sources.create(source: "VVA", status: :success, fetched_at: 2.hours.ago)
-        manifest.sources.create(source: "VBMS", status: :success, fetched_at: 2.hours.ago)
+        manifest.sources.create(name: "VVA", status: :success, fetched_at: 2.hours.ago)
+        manifest.sources.create(name: "VBMS", status: :success, fetched_at: 2.hours.ago)
         subject
         expect(V2::DownloadManifestJob).to_not have_received(:perform_later)
       end
@@ -29,8 +29,8 @@ describe Manifest do
 
     context "when one manifest is expired" do
       it "starts one job" do
-        manifest.sources.create(source: "VVA", status: :success, fetched_at: 2.hours.ago)
-        manifest.sources.create(source: "VBMS", status: :success, fetched_at: 5.hours.ago)
+        manifest.sources.create(name: "VVA", status: :success, fetched_at: 2.hours.ago)
+        manifest.sources.create(name: "VBMS", status: :success, fetched_at: 5.hours.ago)
         subject
         expect(V2::DownloadManifestJob).to have_received(:perform_later).once
       end

--- a/spec/models/record_spec.rb
+++ b/spec/models/record_spec.rb
@@ -3,7 +3,7 @@ describe Record do
     Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
   end
   let(:manifest) { Manifest.create(file_number: "1234") }
-  let(:source) { ManifestSource.create(source: %w[VBMS VVA].sample, manifest: manifest) }
+  let(:source) { ManifestSource.create(name: %w[VBMS VVA].sample, manifest: manifest) }
 
   context ".create_from_external_document" do
     subject { Record.create_from_external_document(source, external_document) }

--- a/spec/requests/api/v2/files_downloads_spec.rb
+++ b/spec/requests/api/v2/files_downloads_spec.rb
@@ -7,7 +7,7 @@ describe "Files Downloads API v2", type: :request do
     end
 
     let(:manifest) { Manifest.create(file_number: "1234") }
-    let(:source) { ManifestSource.create(source: %w[VBMS VVA].sample, manifest: manifest) }
+    let(:source) { ManifestSource.create(name: %w[VBMS VVA].sample, manifest: manifest) }
 
     let!(:records) do
       [Record.create(

--- a/spec/requests/api/v2/records_spec.rb
+++ b/spec/requests/api/v2/records_spec.rb
@@ -7,7 +7,7 @@ describe "Records API v2", type: :request do
     end
 
     let(:manifest) { Manifest.create(file_number: "1234") }
-    let(:source) { ManifestSource.create(source: %w[VBMS VVA].sample, manifest: manifest) }
+    let(:source) { ManifestSource.create(name: %w[VBMS VVA].sample, manifest: manifest) }
 
     let(:record) do
       Record.create(

--- a/spec/services/document_creator_spec.rb
+++ b/spec/services/document_creator_spec.rb
@@ -1,6 +1,6 @@
 describe DocumentCreator do
   let(:manifest) { Manifest.create(file_number: "1234") }
-  let(:source) { ManifestSource.create(source: %w[VVA VBMS].sample, manifest: manifest) }
+  let(:source) { ManifestSource.create(name: %w[VVA VBMS].sample, manifest: manifest) }
 
   context "#create" do
     subject { DocumentCreator.new(manifest_source: source, external_documents: documents).create }

--- a/spec/services/image_converter_service_spec.rb
+++ b/spec/services/image_converter_service_spec.rb
@@ -6,7 +6,7 @@ describe ImageConverterService do
   let(:pdf_content) { File.open(tiff_file, "r", &:read) }
 
   let(:manifest) { Manifest.create(file_number: "1234") }
-  let(:source) { ManifestSource.create(source: %w[VBMS VVA].sample, manifest: manifest) }
+  let(:source) { ManifestSource.create(name: %w[VBMS VVA].sample, manifest: manifest) }
   let(:record) { Record.create(version_id: "TEST", series_id: "5555", manifest_source: source, mime_type: "image/tiff") }
   let(:image_converter) { ImageConverterService.new(image: tiff_content, record: record) }
 

--- a/spec/services/manifest_fetcher_spec.rb
+++ b/spec/services/manifest_fetcher_spec.rb
@@ -1,6 +1,6 @@
 describe ManifestFetcher do
   let(:manifest) { Manifest.create(file_number: "1234") }
-  let(:source) { ManifestSource.create(source: name, manifest: manifest) }
+  let(:source) { ManifestSource.create(name: name, manifest: manifest) }
 
   let(:documents) do
     [

--- a/spec/services/record_fetcher_spec.rb
+++ b/spec/services/record_fetcher_spec.rb
@@ -1,6 +1,6 @@
 describe RecordFetcher do
   let(:manifest) { Manifest.create(file_number: "1234") }
-  let(:source) { ManifestSource.create(source: %w[VBMS VVA].sample, manifest: manifest) }
+  let(:source) { ManifestSource.create(name: %w[VBMS VVA].sample, manifest: manifest) }
 
   let(:record) do
     Record.create(


### PR DESCRIPTION
Rename `manifest_source.source` to `manifest_source.name` as it is a better name for the column.