### PR TITLE
Remove unneeded documents

### DIFF
--- a/app/services/document_creator.rb
+++ b/app/services/document_creator.rb
@@ -34,10 +34,16 @@ class DocumentCreator
 
   def create
     ManifestSource.transaction do
+      valid_records = []
       external_documents.each do |document|
-        Record.create_from_external_document(manifest_source, document)
+        valid_records << Record.create_from_external_document(manifest_source, document)
       end
+      remove_deleted_records(valid_records)
     end
+  end
+
+  def remove_deleted_records(valid_records)
+    (manifest_source.records - valid_records).each(&:delete)
   end
 
   # Override the getter to return only non-restricted documents

--- a/app/services/document_creator.rb
+++ b/app/services/document_creator.rb
@@ -34,9 +34,8 @@ class DocumentCreator
 
   def create
     ManifestSource.transaction do
-      valid_records = []
-      external_documents.each do |document|
-        valid_records << Record.create_from_external_document(manifest_source, document)
+      valid_records = external_documents.map do |document|
+        Record.create_from_external_document(manifest_source, document)
       end
       # User can delete documents from VBMS so clean up these records if they were previously created
       remove_deleted_records(valid_records)
@@ -44,7 +43,7 @@ class DocumentCreator
   end
 
   def remove_deleted_records(valid_records)
-    (manifest_source.records - valid_records).each(&:delete)
+    (manifest_source.records - valid_records).each(&:destroy)
   end
 
   # Override the getter to return only non-restricted documents

--- a/app/services/document_creator.rb
+++ b/app/services/document_creator.rb
@@ -38,6 +38,7 @@ class DocumentCreator
       external_documents.each do |document|
         valid_records << Record.create_from_external_document(manifest_source, document)
       end
+      # User can delete documents from VBMS so clean up these records if they were previously created
       remove_deleted_records(valid_records)
     end
   end

--- a/spec/services/document_creator_spec.rb
+++ b/spec/services/document_creator_spec.rb
@@ -55,5 +55,22 @@ describe DocumentCreator do
         expect(source.reload.records.first.series_id).to eq "4"
       end
     end
+
+    context "documents have been deleted from VBMS but still present in the DB" do
+      let(:documents) do
+        [
+          OpenStruct.new(document_id: "1", series_id: "3"),
+          OpenStruct.new(document_id: "2", series_id: "4")
+        ]
+      end
+
+      it "removes deleted documents from the DB" do
+        source.records.create(version_id: "3", series_id: "5")
+        subject
+        expect(source.reload.records.size).to eq 2
+        expect(source.reload.records.first.series_id).to eq "3"
+        expect(source.reload.records.second.series_id).to eq "4"
+      end
+    end
   end
 end


### PR DESCRIPTION
Delete records if there were perviously created in Caseflow DB but no longer exist in VBMS.