### PR TITLE
Add unauthorized alert to react app

### DIFF
--- a/client/src/containers/UnauthorizedContainer.jsx
+++ b/client/src/containers/UnauthorizedContainer.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 
+import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
 import StatusMessage from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/StatusMessage';
 
 export default class UnauthorizedContainer extends React.PureComponent {

--- a/client/src/containers/UnauthorizedContainer.jsx
+++ b/client/src/containers/UnauthorizedContainer.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import AppSegment from '@department-of-veterans-affairs/appeals-frontend-toolkit/components/AppSegment';
+
+export default class UnauthorizedContainer extends React.PureComponent {
+  render() {
+    return <main className="usa-grid">
+      <AppSegment extraClassNames="cf-app-msg-screen" filledBackground>
+        <h1 class="cf-msg-screen-heading">Drat!</h1>
+        <h2 class="cf-msg-screen-deck">You aren't authorized to use eFolder Express yet.</h2>
+        <p class="cf-msg-screen-text">
+          <Link to="/help">Click here</Link> to find out how you can request access to eFolder Express.
+        </p>
+      </AppSegment>
+    </main>;
+  }
+}

--- a/client/src/containers/UnauthorizedContainer.jsx
+++ b/client/src/containers/UnauthorizedContainer.jsx
@@ -1,18 +1,16 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-import AppSegment from '@department-of-veterans-affairs/appeals-frontend-toolkit/components/AppSegment';
+import StatusMessage from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/StatusMessage';
 
 export default class UnauthorizedContainer extends React.PureComponent {
   render() {
     return <main className="usa-grid">
-      <AppSegment extraClassNames="cf-app-msg-screen" filledBackground>
-        <h1 className="cf-msg-screen-heading">Drat!</h1>
-        <h2 className="cf-msg-screen-deck">You aren't authorized to use eFolder Express yet.</h2>
-        <p className="cf-msg-screen-text">
-          <Link to="/help">Click here</Link> to find out how you can request access to eFolder Express.
-        </p>
-      </AppSegment>
+      <StatusMessage title="Drat!">
+        You aren't authorized to use eFolder Express yet.
+        <br />
+        <Link to="/help">Click here</Link> to find out how you can request access to eFolder Express.
+      </StatusMessage>
     </main>;
   }
 }

--- a/client/src/containers/UnauthorizedContainer.jsx
+++ b/client/src/containers/UnauthorizedContainer.jsx
@@ -7,9 +7,9 @@ export default class UnauthorizedContainer extends React.PureComponent {
   render() {
     return <main className="usa-grid">
       <AppSegment extraClassNames="cf-app-msg-screen" filledBackground>
-        <h1 class="cf-msg-screen-heading">Drat!</h1>
-        <h2 class="cf-msg-screen-deck">You aren't authorized to use eFolder Express yet.</h2>
-        <p class="cf-msg-screen-text">
+        <h1 className="cf-msg-screen-heading">Drat!</h1>
+        <h2 className="cf-msg-screen-deck">You aren't authorized to use eFolder Express yet.</h2>
+        <p className="cf-msg-screen-text">
           <Link to="/help">Click here</Link> to find out how you can request access to eFolder Express.
         </p>
       </AppSegment>


### PR DESCRIPTION
Once the frontend toolkit [PR to add the StatusMessage](https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit/pull/11) is merged I will move this over to use that shared StatusMessage component instead of `<AppSegment>`.

Tested that this displays correctly by adding a route in `InitContainer` and navigating to that route. Since I think this will more usually be used as an alert (and not a page to which folks are redirected), I did not include that route in this PR. I imagine this alert will probably respond to some global state in `InitContainer` that we set off an action based on an API response.