### PR TITLE
Fix deprecation warning

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,8 +34,8 @@ Rails.application.routes.draw do
 
     namespace :v2 do
       namespace :manifests, only: [] do
-        post "/", to: :start
-        get "/", to: :progress
+        post "/", action: :start
+        get "/", action: :progress
         get :history
       end
       resources :manifests, only: [] do


### PR DESCRIPTION
Resolves the two following deprecation warnings when starting the rails server:
```
DEPRECATION WARNING: Defining a route where `to` is a symbol is deprecated. Please change `to: :start` to `action: :start`. (called from block (4 levels) in <top (required)> at /Users/lowell/Projects/efolder/config/routes.rb:37)
DEPRECATION WARNING: Defining a route where `to` is a symbol is deprecated. Please change `to: :progress` to `action: :progress`. (called from block (4 levels) in <top (required)> at /Users/lowell/Projects/efolder/config/routes.rb:38)
```