### PR TITLE
Upgrade downstream dependency on omniauth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,10 @@ gem "dogstatsd-ruby"
 # SSOI
 gem "omniauth-saml-va", git: "https://github.com/department-of-veterans-affairs/omniauth-saml-va", branch: "paultag/css"
 
+# Required until downstream dependency upgrades omniauth to 1.3.2 or greater.
+# https://github.com/omniauth/omniauth-saml/blob/89eeb83517b2333666c4cb627d416cef63ac041d/omniauth-saml.gemspec#L16
+gem "omniauth", "~> 1.3.2"
+
 gem "puma"
 
 gem "rack-cors", require: "rack/cors"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,7 +195,7 @@ GEM
       builder (>= 2.1.2)
     haml (4.0.7)
       tilt
-    hashie (3.4.6)
+    hashie (3.5.7)
     highline (1.7.8)
     httpclient (2.8.3)
     httpi (2.4.2)
@@ -238,7 +238,7 @@ GEM
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
     nori (2.6.0)
-    omniauth (1.3.1)
+    omniauth (1.3.2)
       hashie (>= 1.2, < 4)
       rack (>= 1.0, < 3)
     omniauth-saml (1.6.0)
@@ -265,7 +265,7 @@ GEM
     public_suffix (2.0.5)
     puma (3.6.2)
     quantile (0.2.0)
-    rack (1.6.5)
+    rack (1.6.8)
     rack-cors (1.0.1)
     rack-protection (1.5.3)
       rack
@@ -490,6 +490,7 @@ DEPENDENCIES
   mini_magick
   moment_timezone-rails
   newrelic_rpm
+  omniauth (~> 1.3.2)
   omniauth-saml-va!
   pg
   prometheus-client (~> 0.7.1)


### PR DESCRIPTION
Upgrade `omniauth` dependency to version 1.3.2 or greater to satisfy vulnerability described in https://nvd.nist.gov/vuln/detail/CVE-2017-18076. We depend on `omniauth` by way of `omniauth-saml-va` by way of `omniauth-saml`. I have created a [PR in omniauth-saml](https://github.com/omniauth/omniauth-saml/pull/148) to upgrade the version that package depends on.