### PR TITLE
Redis::Semaphore Changing `connection` to `url`

### DIFF
--- a/app/jobs/v2/download_manifest_job.rb
+++ b/app/jobs/v2/download_manifest_job.rb
@@ -5,7 +5,7 @@ class V2::DownloadManifestJob < ActiveJob::Base
 
   def perform(manifest_source, ui_user)
     s = Redis::Semaphore.new("download_manifest_source_#{manifest_source.id}".to_s,
-                             connection: Rails.application.secrets.redis_url_sidekiq)
+                             url: Rails.application.secrets.redis_url_sidekiq)
 
     s.lock(SECONDS_TO_AUTO_UNLOCK)
     return if manifest_source.current?

--- a/app/jobs/v2/package_files_job.rb
+++ b/app/jobs/v2/package_files_job.rb
@@ -5,7 +5,7 @@ class V2::PackageFilesJob < ActiveJob::Base
 
   def perform(manifest)
     s = Redis::Semaphore.new("package_files_#{manifest.id}".to_s,
-                             connection: Rails.application.secrets.redis_url_sidekiq)
+                             url: Rails.application.secrets.redis_url_sidekiq)
 
     s.lock(SECONDS_TO_AUTO_UNLOCK)
 

--- a/app/services/record_fetcher.rb
+++ b/app/services/record_fetcher.rb
@@ -8,7 +8,7 @@ class RecordFetcher
 
   def process
     s = Redis::Semaphore.new("record_#{record.id}".to_s,
-                             connection: Rails.application.secrets.redis_url_sidekiq)
+                             url: Rails.application.secrets.redis_url_sidekiq)
     s.lock(SECONDS_TO_AUTO_UNLOCK)
     content_from_s3 || content_from_vbms
   rescue *EXCEPTIONS


### PR DESCRIPTION
Currently in UAT eFolder errors whenever grabbing the mutex. It appears to be because we're trying to connect to redis using connection rather than url, and so are trying to connect to localhost. Trying to connect a semaphore using url works in the rails console on UAT.

**Test Plan**
- [ ] Run the following in the Rails console:
```
s = Redis::Semaphore.new("TEST LOCK", url: Rails.application.secrets.redis_url_sidekiq)
s.lock(1)
s.unlock
```