### PR TITLE
Upgrade omniauth-saml-va to incorporate upstream changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,11 +44,7 @@ gem "newrelic_rpm"
 gem "dogstatsd-ruby"
 
 # SSOI
-gem "omniauth-saml-va", git: "https://github.com/department-of-veterans-affairs/omniauth-saml-va", branch: "paultag/css"
-
-# Required until downstream dependency upgrades omniauth to 1.3.2 or greater.
-# https://github.com/omniauth/omniauth-saml/blob/89eeb83517b2333666c4cb627d416cef63ac041d/omniauth-saml.gemspec#L16
-gem "omniauth", "~> 1.3.2"
+gem "omniauth-saml-va", git: "https://github.com/department-of-veterans-affairs/omniauth-saml-va", ref: "06fdb4d33b49d57efadbf827a09ab4c66dd54e12"
 
 gem "puma"
 

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem "newrelic_rpm"
 gem "dogstatsd-ruby"
 
 # SSOI
-gem "omniauth-saml-va", git: "https://github.com/department-of-veterans-affairs/omniauth-saml-va", ref: "06fdb4d33b49d57efadbf827a09ab4c66dd54e12"
+gem "omniauth-saml-va", git: "https://github.com/department-of-veterans-affairs/omniauth-saml-va", ref: "fc5d4132c150add221a79bf06b71d8dafefc3ca6"
 
 gem "puma"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,11 +43,11 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/omniauth-saml-va
-  revision: 24a515b3cbaf17e543e1351c2846001cc2b40c09
-  branch: paultag/css
+  revision: 06fdb4d33b49d57efadbf827a09ab4c66dd54e12
+  ref: 06fdb4d33b49d57efadbf827a09ab4c66dd54e12
   specs:
     omniauth-saml-va (0.1)
-      omniauth-saml (~> 1.6.0)
+      omniauth-saml (~> 1.8)
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/ruby-bgs.git
@@ -108,6 +108,11 @@ GEM
       activemodel (= 4.2.7.1)
       activesupport (= 4.2.7.1)
       arel (~> 6.0)
+    activerecord-jdbc-adapter (50.0)
+      activerecord (>= 2.2)
+    activerecord-jdbcpostgresql-adapter (50.0)
+      activerecord-jdbc-adapter (~> 50.0)
+      jdbc-postgres (>= 9.4, < 43)
     activesupport (4.2.7.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
@@ -170,6 +175,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.4)
+    concurrent-ruby (1.0.4-java)
     connection_pool (2.2.1)
     d3-rails (4.10.2)
       railties (>= 3.1)
@@ -189,6 +195,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     fastercsv (1.5.5)
     ffi (1.9.14)
+    ffi (1.9.14-java)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     gyoku (1.3.1)
@@ -205,15 +212,20 @@ GEM
     jbuilder (2.6.1)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
+    jdbc-postgres (42.1.4)
     jmespath (1.3.1)
     jquery-rails (4.2.2)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
+    json (1.8.3-java)
     jsonapi-renderer (0.1.2)
     launchy (2.4.3)
       addressable (~> 2.3)
+    launchy (2.4.3-java)
+      addressable (~> 2.3)
+      spoon (~> 0.0.1)
     libv8 (3.16.14.17)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
@@ -237,13 +249,14 @@ GEM
     newrelic_rpm (4.5.0.337)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
+    nokogiri (1.8.1-java)
     nori (2.6.0)
-    omniauth (1.3.2)
-      hashie (>= 1.2, < 4)
-      rack (>= 1.0, < 3)
-    omniauth-saml (1.6.0)
+    omniauth (1.8.1)
+      hashie (>= 3.4.6, < 3.6.0)
+      rack (>= 1.6.2, < 3)
+    omniauth-saml (1.8.1)
       omniauth (~> 1.3)
-      ruby-saml (~> 1.3)
+      ruby-saml (~> 1.4, >= 1.4.3)
     parallel (1.12.1)
     parser (2.4.0.2)
       ast (~> 2.3)
@@ -259,11 +272,17 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry (0.10.4-java)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+      spoon (~> 0.0)
     pry-byebug (3.4.3)
       byebug (>= 9.0, < 9.1)
       pry (~> 0.10)
     public_suffix (2.0.5)
     puma (3.6.2)
+    puma (3.6.2-java)
     quantile (0.2.0)
     rack (1.6.8)
     rack-cors (1.0.1)
@@ -352,7 +371,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
-    ruby-saml (1.4.1)
+    ruby-saml (1.6.1)
       nokogiri (>= 1.5.10)
     ruby2ruby (2.2.0)
       ruby_parser (~> 3.1)
@@ -410,6 +429,8 @@ GEM
       tilt (>= 1.3.3, < 2.1)
     slop (3.6.0)
     socksify (1.7.0)
+    spoon (0.0.6)
+      ffi
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -426,8 +447,12 @@ GEM
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
       ref
+    therubyrhino (2.0.4)
+      therubyrhino_jar (>= 1.7.3)
+    therubyrhino_jar (1.7.6)
     thor (0.19.4)
     thread_safe (0.3.5)
+    thread_safe (0.3.5-java)
     tilt (2.0.5)
     timecop (0.8.1)
     turbolinks (5.0.1)
@@ -447,6 +472,8 @@ GEM
     websocket (1.2.3)
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
+    websocket-driver (0.6.4-java)
+      websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
     xmldsig (0.3.2)
       nokogiri
@@ -464,6 +491,7 @@ GEM
       activerecord
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES
@@ -490,7 +518,6 @@ DEPENDENCIES
   mini_magick
   moment_timezone-rails
   newrelic_rpm
-  omniauth (~> 1.3.2)
   omniauth-saml-va!
   pg
   prometheus-client (~> 0.7.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,11 +43,11 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/omniauth-saml-va
-  revision: 06fdb4d33b49d57efadbf827a09ab4c66dd54e12
-  ref: 06fdb4d33b49d57efadbf827a09ab4c66dd54e12
+  revision: fc5d4132c150add221a79bf06b71d8dafefc3ca6
+  ref: fc5d4132c150add221a79bf06b71d8dafefc3ca6
   specs:
     omniauth-saml-va (0.1)
-      omniauth-saml (~> 1.8)
+      omniauth-saml (~> 1.9)
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/ruby-bgs.git
@@ -254,8 +254,8 @@ GEM
     omniauth (1.8.1)
       hashie (>= 3.4.6, < 3.6.0)
       rack (>= 1.6.2, < 3)
-    omniauth-saml (1.8.1)
-      omniauth (~> 1.3)
+    omniauth-saml (1.9.0)
+      omniauth (~> 1.3, >= 1.3.2)
       ruby-saml (~> 1.4, >= 1.4.3)
     parallel (1.12.1)
     parser (2.4.0.2)


### PR DESCRIPTION
`omniauth-saml` has upgraded the version of `omniauth` ([PR here](https://github.com/omniauth/omniauth-saml/pull/148)) to mitigate the vulnerability we avoided by making the changes in #846, so we can remove the explicit dependency on `omniauth`. PR to point `omniauth-saml-va` to the correct version of `omniauth-saml` [here](https://github.com/department-of-veterans-affairs/omniauth-saml-va/pull/11#pullrequestreview-93040187).

Additionally, we merged the `omniauth-saml-va` branch we were referencing the gemfile into the master branch of that repo so that change is reflected here as well.