### PR TITLE
When VBMS is down, do not send error to Sentry

### DIFF
--- a/app/services/exception_logger.rb
+++ b/app/services/exception_logger.rb
@@ -1,5 +1,8 @@
 class ExceptionLogger
-  DEPENDENCY_MAINTENANCE = [/Could not get JDBC Connection/, /Maintenance.+VBMS/, /upstream connect error or disconnect/].freeze
+  DEPENDENCY_MAINTENANCE = [/Could not get JDBC Connection/,
+                            /Maintenance.+VBMS/,
+                            /upstream connect error or disconnect/,
+                            /A system error occurred/].freeze
 
   def self.capture(e)
     Rails.logger.error "#{e.message}\n#{e.backtrace.join("\n")}"


### PR DESCRIPTION
This fixes sentry error: https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/612/