### PR TITLE
Namespace rake tasks

### DIFF
--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -1,4 +1,4 @@
 desc "Runs the continuous integration scripts"
-task ci: ["efolder:lint", "efolder:security", "efolder:spec", "efolder:sauceci"]
+task ci: ["efolder:lint", "efolder:security", "spec", "efolder:sauceci"]
 
 task default: :ci

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -1,4 +1,4 @@
 desc "Runs the continuous integration scripts"
-task ci: [:lint, :security, :spec, :sauceci]
+task ci: ["efolder:lint", "efolder:security", "efolder:spec", "efolder:sauceci"]
 
 task default: :ci

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,24 +1,26 @@
 require "open3"
 require "rainbow"
 
-desc "shortcut to run all linting tools, at the same time."
-task :lint do
-  puts "running scss-lint..."
-  scss_result = ShellCommand.run("scss-lint --color")
+namespace :efolder do
+  desc "shortcut to run all linting tools, at the same time."
+  task :lint do
+    puts "running scss-lint..."
+    scss_result = ShellCommand.run("scss-lint --color")
 
-  opts = ENV["CI"] ? "" : "--auto-correct"
-  puts "running rubocop..."
-  rubocop_result = ShellCommand.run("rubocop #{opts} --color")
+    opts = ENV["CI"] ? "" : "--auto-correct"
+    puts "running rubocop..."
+    rubocop_result = ShellCommand.run("rubocop #{opts} --color")
 
-  eslint_cmd = ENV["CI"] ? "lint" : "lint:fix"
-  puts "\nrunning eslint..."
-  eslint_result = ShellCommand.run("cd ./client && yarn run #{eslint_cmd}")
+    eslint_cmd = ENV["CI"] ? "lint" : "lint:fix"
+    puts "\nrunning eslint..."
+    eslint_result = ShellCommand.run("cd ./client && yarn run #{eslint_cmd}")
 
-  puts "\n"
-  if scss_result && rubocop_result && eslint_result
-    puts Rainbow("Passed. Everything looks stylish!").green
-  else
-    puts Rainbow("Failed. Linting issues were found.").red
-    exit!(1)
+    puts "\n"
+    if scss_result && rubocop_result && eslint_result
+      puts Rainbow("Passed. Everything looks stylish!").green
+    else
+      puts Rainbow("Failed. Linting issues were found.").red
+      exit!(1)
+    end
   end
 end

--- a/lib/tasks/sauceci.rake
+++ b/lib/tasks/sauceci.rake
@@ -1,11 +1,13 @@
-desc "convenience task used to run sauce browser tests only on the master travis branch"
-task :sauceci do
-  sauce_result = true
+namespace :efolder do
+  desc "convenience task used to run sauce browser tests only on the master travis branch"
+  task :sauceci do
+    sauce_result = true
 
-  if ENV["TRAVIS_BRANCH"] == "master" && !ENV["TRAVIS_PULL_REQUEST"]
-    puts "running feature tests on Sauce browsers..."
-    sauce_result = ShellCommand.run("rake spec:browsers")
+    if ENV["TRAVIS_BRANCH"] == "master" && !ENV["TRAVIS_PULL_REQUEST"]
+      puts "running feature tests on Sauce browsers..."
+      sauce_result = ShellCommand.run("rake spec:browsers")
+    end
+
+    exit!(1) unless sauce_result
   end
-
-  exit!(1) unless sauce_result
 end

--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -1,22 +1,24 @@
 require "open3"
 require "rainbow"
 
-desc "shortcut to run all linting tools, at the same time."
-task :security do
-  puts "running Brakeman security scan..."
-  brakeman_result = ShellCommand.run(
-    "brakeman --exit-on-warn --run-all-checks --confidence-level=2"
-  )
+namespace :efolder do
+  desc "shortcut to run all linting tools, at the same time."
+  task :security do
+    puts "running Brakeman security scan..."
+    brakeman_result = ShellCommand.run(
+      "brakeman --exit-on-warn --run-all-checks --confidence-level=2"
+    )
 
-  puts "running bundle-audit to check for insecure dependencies..."
-  exit!(1) unless ShellCommand.run("bundle-audit update")
-  audit_result = ShellCommand.run("bundle-audit check")
+    puts "running bundle-audit to check for insecure dependencies..."
+    exit!(1) unless ShellCommand.run("bundle-audit update")
+    audit_result = ShellCommand.run("bundle-audit check")
 
-  puts "\n"
-  if brakeman_result && audit_result
-    puts Rainbow("Passed. No obvious security vulnerabilities.").green
-  else
-    puts Rainbow("Failed. Security vulnerabilities were found.").red
-    exit!(1)
+    puts "\n"
+    if brakeman_result && audit_result
+      puts Rainbow("Passed. No obvious security vulnerabilities.").green
+    else
+      puts Rainbow("Failed. Security vulnerabilities were found.").red
+      exit!(1)
+    end
   end
 end

--- a/lib/tasks/spec_browsers.rake
+++ b/lib/tasks/spec_browsers.rake
@@ -1,12 +1,14 @@
 begin
   require "rspec"
 
-  namespace :spec do
-    desc "Run the feature specs with sauce labs on supported browsers"
+  namespace :efolder do
+    namespace :spec do
+      desc "Run the feature specs with sauce labs on supported browsers"
 
-    RSpec::Core::RakeTask.new(:browsers) do |t|
-      ENV["SAUCE_SPECS"] = "true"
-      t.pattern = "spec/feature/**/*_spec.rb"
+      RSpec::Core::RakeTask.new(:browsers) do |t|
+        ENV["SAUCE_SPECS"] = "true"
+        t.pattern = "spec/feature/**/*_spec.rb"
+      end
     end
   end
   # rubocop:disable Lint/HandleExceptions

--- a/lib/tasks/spec_browsers.rake
+++ b/lib/tasks/spec_browsers.rake
@@ -1,14 +1,12 @@
 begin
   require "rspec"
 
-  namespace :efolder do
-    namespace :spec do
-      desc "Run the feature specs with sauce labs on supported browsers"
+  namespace :spec do
+    desc "Run the feature specs with sauce labs on supported browsers"
 
-      RSpec::Core::RakeTask.new(:browsers) do |t|
-        ENV["SAUCE_SPECS"] = "true"
-        t.pattern = "spec/feature/**/*_spec.rb"
-      end
+    RSpec::Core::RakeTask.new(:browsers) do |t|
+      ENV["SAUCE_SPECS"] = "true"
+      t.pattern = "spec/feature/**/*_spec.rb"
     end
   end
   # rubocop:disable Lint/HandleExceptions


### PR DESCRIPTION
When we run rake tasks for efolder we end up running [caseflow commons' rake tasks](https://github.com/department-of-veterans-affairs/caseflow-commons/blob/6be9e1e95b1a012af1fb5b7aa292ec7123281dc2/lib/tasks/ci.rake) with the same name. One way to avoid this is to namespace the rake tasks so they don't have the same name. This should speed up efolder builds because the CI server isn't running caseflow commons tasks when all we care about is efolder express. Once consequence of this change is that in order to run any of the tasks, we need to add the namespace (e.g. `bundle exec efolder:lint`).