### PR TITLE
Upgrade connect_vbms version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,7 @@ gem "mini_magick"
 gem "httpclient"
 
 gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", branch: "416f7a4ee49c7c80160e97416e7c7b0a7bd20a4a"
-gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "7b3da0fa5ee6732d3c8ad2f557e425e770b1f435"
+gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "f014b4772385814cd510712c46698653866f99dd"
 gem "connect_vva", git: "https://github.com/department-of-veterans-affairs/connect_vva.git", ref: "5af0ad0e2538c1039bce75dbc6c4019b3e0c3312"
 
 # catch problematic migrations

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,10 +21,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vbms.git
-  revision: 7b3da0fa5ee6732d3c8ad2f557e425e770b1f435
-  ref: 7b3da0fa5ee6732d3c8ad2f557e425e770b1f435
+  revision: f014b4772385814cd510712c46698653866f99dd
+  ref: f014b4772385814cd510712c46698653866f99dd
   specs:
-    connect_vbms (1.0.0)
+    connect_vbms (1.0.1)
       httpclient (~> 2.8.0)
       httpi (~> 2.4)
       mail


### PR DESCRIPTION
Upgrade to the [most recent commit of connect_vbms](https://github.com/department-of-veterans-affairs/connect_vbms/commit/f014b4772385814cd510712c46698653866f99dd) which upgrades version of Nokogiri to mitigate a [known vulnerability](https://github.com/sparklemotion/nokogiri/issues/1714) with that package.

This change does not change the version of Nokogiri efolder depends on because the [similar change for ruby-bgs](https://github.com/department-of-veterans-affairs/caseflow-efolder/pull/862) was merged into master prior to this one and affected the change in Gemfile.lock.