### PR TITLE
Make copy to clipboard function work

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
     "history": "^4.7.2",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
+    "react-copy-to-clipboard": "^5.0.1",
     "react-dom": "^16.2.0",
     "react-redux": "^5.0.6",
     "react-router-dom": "^4.2.2",

--- a/client/src/components/DownloadPageHeader.jsx
+++ b/client/src/components/DownloadPageHeader.jsx
@@ -1,23 +1,20 @@
 import React from 'react';
+import CopyToClipboard from 'react-copy-to-clipboard';
 
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
 
 import CopyIcon from '../components/CopyIcon';
 
-// TODO: Get copy-paste feature working.
 export default class DownloadPageHeader extends React.PureComponent {
   render() {
     return <AppSegment extraClassNames="cf-efolder-header">
       <h3 className="cf-push-left cf-name-header cf-efolder-name">{this.props.veteranName}</h3>
       <div className="cf-txt-uc cf-efolder-id-control cf-push-right">Veteran ID &nbsp;
-        <button
-          type="submit"
-          title="Copy to clipboard"
-          className="cf-apppeal-id ee-copy-button"
-          data-clipboard-text={this.props.veteranId}
-        >
-          {this.props.veteranId} <CopyIcon />
-        </button>
+        <CopyToClipboard text={this.props.veteranId}>
+          <button type="submit" title="Copy to clipboard" className="cf-apppeal-id ee-copy-button">
+            {this.props.veteranId} <CopyIcon />
+          </button>
+        </CopyToClipboard>
       </div>
     </AppSegment>;
   }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1352,6 +1352,12 @@ cookiejar@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.1.tgz#41ad57b1b555951ec171412a81942b1e8200d34a"
 
+copy-to-clipboard@^3:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.0.8.tgz#f4e82f4a8830dce4666b7eb8ded0c9bcc313aba9"
+  dependencies:
+    toggle-selection "^1.0.3"
+
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
@@ -3097,7 +3103,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.6.0:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -3179,6 +3185,13 @@ rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-copy-to-clipboard@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.1.tgz#8eae107bb400be73132ed3b6a7b4fb156090208e"
+  dependencies:
+    copy-to-clipboard "^3"
+    prop-types "^15.5.8"
 
 react-dom@^16.2.0:
   version "16.2.0"
@@ -3722,6 +3735,10 @@ to-fast-properties@^1.0.3:
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
+
+toggle-selection@^1.0.3:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
 
 tough-cookie@~2.3.0:
   version "2.3.3"


### PR DESCRIPTION
Connects #874.

Makes the copy to clipboard button work after breaking that functionality in the move to react.