### PR TITLE
Removing documents from eFolder when no longer in VBMS

### DIFF
--- a/app/services/download_documents.rb
+++ b/app/services/download_documents.rb
@@ -38,7 +38,7 @@ class DownloadDocuments
 
   def create_documents
     Download.transaction do
-      @external_documents.each do |external_document|
+      current_documents = @external_documents.map do |external_document|
         # JRO and SSN are required when searching for a document in VVA
         type_id = external_document.try(:doc_type) || external_document.type_id
         @download.documents.find_or_initialize_by(document_id: external_document.document_id).tap do |t|
@@ -56,6 +56,7 @@ class DownloadDocuments
           t.save!
         end
       end
+      (@download.documents - current_documents).each(&:destroy)
 
       # TODO(alex): do we still need this field? why are we setting it here?
       @download.update_attributes!(manifest_fetched_at: Time.zone.now)

--- a/app/services/download_documents.rb
+++ b/app/services/download_documents.rb
@@ -36,6 +36,7 @@ class DownloadDocuments
     @external_documents = DownloadDocuments.filter_documents(opts[:external_documents] || [])
   end
 
+  # rubocop:disable Metrics/MethodLength
   def create_documents
     Download.transaction do
       current_documents = @external_documents.map do |external_document|
@@ -62,6 +63,7 @@ class DownloadDocuments
       @download.update_attributes!(manifest_fetched_at: Time.zone.now)
     end
   end
+  # rubocop:enable Metrics/MethodLength
 
   def download_contents(save_locally: true)
     begin

--- a/client/src/apiActions.jsx
+++ b/client/src/apiActions.jsx
@@ -12,7 +12,12 @@ import {
   setVeteranId,
   setVeteranName
 } from './actions';
-import { SUCCESS_TAB } from './Constants';
+import {
+  MANIFEST_DOWNLOAD_STATE,
+  ERRORS_TAB,
+  IN_PROGRESS_TAB,
+  SUCCESS_TAB
+} from './Constants';
 import { documentDownloadComplete, documentDownloadStarted, manifestFetchComplete } from './Utils';
 
 const setStateFromResponse = (dispatch, resp) => {
@@ -25,9 +30,20 @@ const setStateFromResponse = (dispatch, resp) => {
   dispatch(setVeteranId(respAttrs.file_number));
   dispatch(setVeteranName(`${respAttrs.veteran_first_name} ${respAttrs.veteran_last_name}`));
 
-  if (documentDownloadComplete(respAttrs.fetched_files_status)) {
-    dispatch(setActiveDownloadProgressTab(SUCCESS_TAB));
+  let activeTab = IN_PROGRESS_TAB;
+
+  switch (respAttrs.fetched_files_status) {
+  case MANIFEST_DOWNLOAD_STATE.SUCCEEDED:
+    activeTab = SUCCESS_TAB;
+    break;
+  case MANIFEST_DOWNLOAD_STATE.FAILED:
+    activeTab = ERRORS_TAB;
+    break;
+  default:
+    activeTab = IN_PROGRESS_TAB;
+    break;
   }
+  dispatch(setActiveDownloadProgressTab(activeTab));
 };
 
 const baseRequest = (endpoint, csrfToken, method, options = {}) => {

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -469,7 +469,6 @@ RSpec.feature "Downloads" do
     end
 
     download_documents = DownloadDocuments.new(download: @download, vbms_service: FakeVBMSService)
-    download_documents.create_documents
     download_documents.download_and_package
 
     visit download_path(@download)

--- a/spec/requests/api/v1/file_spec.rb
+++ b/spec/requests/api/v1/file_spec.rb
@@ -299,12 +299,6 @@ describe "File API v1", type: :request do
                   type_id: "123",
                   received_at: "2017-02-01T00:00:00.000Z",
                   external_document_id: "1"
-                },
-                {
-                  id: download.documents[2].id,
-                  type_id: "825",
-                  received_at: "2015-09-06T01:00:00.000Z",
-                  external_document_id: document.document_id
                 }
               ]
             }
@@ -312,7 +306,7 @@ describe "File API v1", type: :request do
         }.to_json
       end
 
-      it "returns existing and new files" do
+      it "returns new files" do
         get "/api/v1/files", nil, headers
         expect(response.code).to eq("200")
         expect(response.body).to eq(response_body)

--- a/spec/services/download_documents_spec.rb
+++ b/spec/services/download_documents_spec.rb
@@ -76,9 +76,24 @@ describe DownloadDocuments do
         updated_download_documents.create_documents
       end
 
-      it "updates the metadata of old documents and adds any new documents" do
-        expect(Document.count).to eq(5)
+      it "updates the metadata of old documents, adds any new documents, removes any old" do
+        expect(Document.count).to eq(2)
         expect(Document.first.type_id).to eq("124")
+      end
+    end
+
+    context "when a document was saved before, but has been removed" do
+      let(:external_documents_updated) do
+        [
+          OpenStruct.new(document_id: generate_id, received_at: 3.hours.ago, downloaded_from: "VVA")
+        ]
+      end
+
+      it "removes the extra documents" do
+        expect(Document.count).to eq(4)
+
+        DownloadDocuments.new(download: download, external_documents: external_documents_updated).create_documents
+        expect(Document.count).to eq(1)
       end
     end
   end
@@ -169,7 +184,7 @@ describe DownloadDocuments do
 
         download.documents.each_with_index do |document, _i|
           document.save!
-          expect(document).to be_success
+          expect(document.reload).to be_success
           expect(document.path).to eq((Rails.root + "tmp/files/#{download.id}/#{document.id}").to_s)
           expect(File.exist?(document.path)).to be_truthy
         end


### PR DESCRIPTION
A number of documents were uploaded to a veteran's file that were intended for another veteran. When those files were removed from VBMS, we never remove them in eFolder. Therefore you can still view them in Reader. This isn't a problem in the new eFolder API, but we're back-porting the change to v1.

**Test Plan**
- [ ] Run automated tests to ensure documents that are not returned from VBMS are not returned by eFolder.