### PR TITLE
Change file header

### DIFF
--- a/client/src/apiActions.jsx
+++ b/client/src/apiActions.jsx
@@ -123,7 +123,7 @@ export const startDocumentDownload = (manifestId, csrfToken) => (dispatch) => {
 };
 
 export const startManifestFetch = (veteranId, csrfToken, redirectFunction) => (dispatch) => {
-  postRequest('/api/v2/manifests/', csrfToken, { FILE_NUMBER: veteranId }).
+  postRequest('/api/v2/manifests/', csrfToken, { 'FILE-NUMBER': veteranId }).
     then(
       (resp) => {
         setStateFromResponse(dispatch, resp);


### PR DESCRIPTION
The `FILE_NUMBER` header works locally but does not work in UAT (returns a "missing header: File Number" 400 error). Changed the header to `FILE-NUMBER` to match caseflow, tested locally and it works. Fingers crossed that this will work in UAT as well.