### PR TITLE
Update BGS dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,7 @@ gem "mini_magick"
 
 gem "httpclient"
 
-gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", branch: "416f7a4ee49c7c80160e97416e7c7b0a7bd20a4a"
+gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", branch: "e30db7fdf6f5c28c09d6081d062cad80820240a0"
 gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "f014b4772385814cd510712c46698653866f99dd"
 gem "connect_vva", git: "https://github.com/department-of-veterans-affairs/connect_vva.git", ref: "5af0ad0e2538c1039bce75dbc6c4019b3e0c3312"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,8 +51,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/ruby-bgs.git
-  revision: 416f7a4ee49c7c80160e97416e7c7b0a7bd20a4a
-  branch: 416f7a4ee49c7c80160e97416e7c7b0a7bd20a4a
+  revision: e30db7fdf6f5c28c09d6081d062cad80820240a0
+  branch: e30db7fdf6f5c28c09d6081d062cad80820240a0
   specs:
     bgs (0.1)
       nokogiri (~> 1.8.2)
@@ -144,7 +144,7 @@ GEM
       sass (~> 3.0)
       slim (>= 1.3.6, < 4.0)
       terminal-table (~> 1.4)
-    builder (3.2.2)
+    builder (3.2.3)
     bundler-audit (0.5.0)
       bundler (~> 1.2)
       thor (~> 0.18)
@@ -198,7 +198,7 @@ GEM
     hashie (3.5.7)
     highline (1.7.8)
     httpclient (2.8.3)
-    httpi (2.4.2)
+    httpi (2.4.3)
       rack
       socksify
     i18n (0.7.0)
@@ -370,12 +370,12 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    savon (2.11.2)
+    savon (2.12.0)
       akami (~> 1.2)
       builder (>= 2.1.2)
       gyoku (~> 1.2)
       httpi (~> 2.3)
-      nokogiri (>= 1.4.0)
+      nokogiri (>= 1.8.1)
       nori (~> 2.4)
       wasabi (~> 3.4)
     scss_lint (0.52.0)
@@ -409,7 +409,7 @@ GEM
       temple (~> 0.7.6)
       tilt (>= 1.3.3, < 2.1)
     slop (3.6.0)
-    socksify (1.7.0)
+    socksify (1.7.1)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)


### PR DESCRIPTION
A [recent change](https://github.com/department-of-veterans-affairs/ruby-bgs/pull/50) to the ruby-bgs gem resolves an issue that was resulting in an uncaught NoMethodError. This change incorporates those changes from the latest version of the ruby-bgs gem.