### PR TITLE
Default userDisplayName to Menu

### DIFF
--- a/app/controllers/gui_controller.rb
+++ b/app/controllers/gui_controller.rb
@@ -17,7 +17,7 @@ class GuiController < ApplicationController
       feedbackUrl: feedback_url,
       referenceGuidePath: ActionController::Base.helpers.asset_path("reference_guide.pdf"),
       trainingGuidePath: ActionController::Base.helpers.asset_path("training_guide.pdf"),
-      userDisplayName: current_user.display_name
+      userDisplayName: current_user.try(:display_name) || "Menu"
     }.to_json
   end
   helper_method :initial_react_data


### PR DESCRIPTION
Set the userDisplayName that will display as the text on the dropdown menu to "Menu" if current_user is not set. Such a case can occur on the unauthorized and out-of-service pages. This behaviour mirrors [what we do](https://github.com/department-of-veterans-affairs/caseflow/search?utf8=%E2%9C%93&q=userDisplayName%3D%22Menu%22) in the main caseflow repo.