### PR TITLE
Update message we send to slack on deploy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,16 +42,8 @@ node('deploy') {
       stage('deploy-message') {
         checkout scm
         DEPLOY_MESSAGE = sh (
-          // this script will:
-          // get the latest `deployed` release created by: https://github.com/department-of-veterans-affairs/appeals-deployment/blob/master/ansible/utility-roles/deployed-version/files/tag_deployed_commit.py
-          // compare current HEAD commit to the last deployed release
-          // save the message to be announced in Slack by the pipeline
-          script: "git log \$(git ls-remote --tags https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/caseflow-efolder.git \
-                   | awk '{print \$2}' | grep -E 'deployed' \
-                   | sort -t/ -nk4 \
-                   | awk -F\"/\" '{print \$0}' \
-                   | tail -n 1 \
-                   | awk '{print \$1}')..HEAD --pretty='format:%h %<(15)%an %s'",
+          // Save the most recent commit to a message to be announced in Slack by the commonPipeline.
+          script: "git log HEAD^..HEAD --pretty='format:%h %<(15)%an %s'",
           returnStdout: true
         ).trim()
       }


### PR DESCRIPTION
Currently we use tags to determine the message we will send to slack when deploying efolder. There are some issues with how we automatically tag deploys right now, so the messages we send to Slack include more commits than are actually being newly deployed. Because of the [recent changes](https://github.com/department-of-veterans-affairs/appeals-deployment/pull/1309) to appeals-deployment, efolder deploys every minute if there are any changes to master. As a result we can simplify the deploy message we display.

One downside to the change here is that we only display the most recent commit message instead of all commits that are being deployed. Since we will deploy every minute if there are changes to deploy, and since we require our CI suite to run after merging to master, and since efolder is transitioning out of active development, we can probably assume that there will not be more than one commit per minute.

## Before:
![image](https://user-images.githubusercontent.com/32683958/36851696-da2c2022-1d37-11e8-9f79-032f4c2a6719.png)

## After:
![image](https://user-images.githubusercontent.com/32683958/36851775-11befa78-1d38-11e8-986d-3f287ac7c4b8.png)
