### PR TITLE
Upgrade omniauth-saml-va dependency to mitigate vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem "newrelic_rpm"
 gem "dogstatsd-ruby"
 
 # SSOI
-gem "omniauth-saml-va", git: "https://github.com/department-of-veterans-affairs/omniauth-saml-va", ref: "fc5d4132c150add221a79bf06b71d8dafefc3ca6"
+gem "omniauth-saml-va", git: "https://github.com/department-of-veterans-affairs/omniauth-saml-va", ref: "fbe2b878c250b14ee996ef6699c42df2c42e41a1"
 
 gem "puma"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,11 +43,11 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/omniauth-saml-va
-  revision: fc5d4132c150add221a79bf06b71d8dafefc3ca6
-  ref: fc5d4132c150add221a79bf06b71d8dafefc3ca6
+  revision: fbe2b878c250b14ee996ef6699c42df2c42e41a1
+  ref: fbe2b878c250b14ee996ef6699c42df2c42e41a1
   specs:
     omniauth-saml-va (0.1)
-      omniauth-saml (~> 1.9)
+      omniauth-saml (~> 1.10)
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/ruby-bgs.git
@@ -241,9 +241,9 @@ GEM
     omniauth (1.8.1)
       hashie (>= 3.4.6, < 3.6.0)
       rack (>= 1.6.2, < 3)
-    omniauth-saml (1.9.0)
+    omniauth-saml (1.10.0)
       omniauth (~> 1.3, >= 1.3.2)
-      ruby-saml (~> 1.4, >= 1.4.3)
+      ruby-saml (~> 1.7)
     parallel (1.12.1)
     parser (2.4.0.2)
       ast (~> 2.3)
@@ -352,7 +352,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
-    ruby-saml (1.7.0)
+    ruby-saml (1.7.2)
       nokogiri (>= 1.5.10)
     ruby2ruby (2.2.0)
       ruby_parser (~> 3.1)


### PR DESCRIPTION
Upgrading to most recent version of omniauth-saml-va to get [most recent version](https://rubygems.org/gems/omniauth-saml) of omniauth-saml.

Information on vulnerability here: https://www.securityweek.com/widespread-vulnerability-found-single-sign-products