### PR TITLE
Upgrade to latest version of connect_vva

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,7 @@ gem "httpclient"
 
 gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", branch: "e30db7fdf6f5c28c09d6081d062cad80820240a0"
 gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "f014b4772385814cd510712c46698653866f99dd"
-gem "connect_vva", git: "https://github.com/department-of-veterans-affairs/connect_vva.git"
+gem "connect_vva", git: "https://github.com/department-of-veterans-affairs/connect_vva.git", ref: "9400bed703272c0e9ed33aeb36404a1a6b2585d3"
 
 # catch problematic migrations
 gem "zero_downtime_migrations"

--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,7 @@ gem "httpclient"
 
 gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", branch: "e30db7fdf6f5c28c09d6081d062cad80820240a0"
 gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "f014b4772385814cd510712c46698653866f99dd"
-gem "connect_vva", git: "https://github.com/department-of-veterans-affairs/connect_vva.git", ref: "5af0ad0e2538c1039bce75dbc6c4019b3e0c3312"
+gem "connect_vva", git: "https://github.com/department-of-veterans-affairs/connect_vva.git"
 
 # catch problematic migrations
 gem "zero_downtime_migrations"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ GIT
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vva.git
   revision: 9400bed703272c0e9ed33aeb36404a1a6b2585d3
+  ref: 9400bed703272c0e9ed33aeb36404a1a6b2585d3
   specs:
     connect_vva (0.1)
       savon (~> 2.11, >= 2.11.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,8 +35,7 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vva.git
-  revision: 5af0ad0e2538c1039bce75dbc6c4019b3e0c3312
-  ref: 5af0ad0e2538c1039bce75dbc6c4019b3e0c3312
+  revision: 9400bed703272c0e9ed33aeb36404a1a6b2585d3
   specs:
     connect_vva (0.1)
       savon (~> 2.11, >= 2.11.0)

--- a/spec/jobs/download_vva_manifest_job_spec.rb
+++ b/spec/jobs/download_vva_manifest_job_spec.rb
@@ -36,5 +36,15 @@ describe DownloadVVAManifestJob do
         expect(download.documents.count).to eq(0)
       end
     end
+
+    context "when vva client encounters HTTP error" do
+      before do
+        allow(VVAService).to receive(:fetch_documents_for).and_raise(VVA::HTTPError.new(code: 503, body: "upstream connect error or disconnect/reset before headers", data: nil))
+      end
+
+      it "catches returns an error string and no documents" do
+        expect(DownloadVVAManifestJob.perform_now(download)).to eq(["vva_connection_error", nil])
+      end
+    end
   end
 end

--- a/spec/jobs/download_vva_manifest_job_spec.rb
+++ b/spec/jobs/download_vva_manifest_job_spec.rb
@@ -39,7 +39,7 @@ describe DownloadVVAManifestJob do
 
     context "when vva client encounters HTTP error" do
       before do
-        allow(VVAService).to receive(:fetch_documents_for).and_raise(VVA::HTTPError.new(code: 503, body: "upstream connect error or disconnect/reset before headers", data: nil))
+        allow(VVAService).to receive(:fetch_documents_for).and_raise(VVA::HTTPError.new(code: 503, body: "upstream connect error or disconnect/reset before headers"))
       end
 
       it "catches returns an error string and no documents" do


### PR DESCRIPTION
Connects #916.

Envoy is already handling these retries, and they are just all failing. With [the change to connect_vva](https://github.com/department-of-veterans-affairs/connect_vva/pull/23), we rethrow this error as a VVA::ClientError and will catch it in DownloadManifestJob. The ExceptionLogger will bypass sending this particular error to sentry, and we will set the download as errored in [DownloadAllManifestJob](https://github.com/department-of-veterans-affairs/caseflow-efolder/blob/864287fd3d818db516bb899f9dccf402ac642459/app/jobs/download_all_manifest_job.rb#L13).