### PR TITLE
Add a lock when creating a manifest source

### DIFF
--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -43,11 +43,11 @@ class Manifest < ActiveRecord::Base
   end
 
   def vbms_source
-    sources.find_or_create_by(name: "VBMS")
+    with_lock { sources.find_or_create_by(name: "VBMS") }
   end
 
   def vva_source
-    sources.find_or_create_by(name: "VVA")
+    with_lock { sources.find_or_create_by(name: "VVA") }
   end
 
   def number_successful_documents


### PR DESCRIPTION
This code should prevent from creating two manifest sources with the same name and manifest ID when done at exactly the same time: 

```
[#<ManifestSource id: 110, manifest_id: 55, status: 1, name: "VVA", fetched_at: nil, created_at: "2018-03-06 08:46:21", updated_at: "2018-03-06 08:46:21">]>
#<ManifestSource id: 111, manifest_id: 55, status: 0, name: "VVA", fetched_at: nil, created_at: "2018-03-06 08:46:21", updated_at: "2018-03-06 08:46:21">
```

Should fix this Sentry alert: https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/999/

Tested manually.