### PR TITLE
Nemo/Update caseflow gem commit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source ENV["GEM_SERVER_URL"] || "https://rubygems.org"
 
-gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "6be9e1e95b1a012af1fb5b7aa292ec7123281dc2"
+gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "5e6830534124f578f43c619c8620c0560365aa55"
 
 gem "moment_timezone-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,17 +7,17 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/caseflow-commons
-  revision: 6be9e1e95b1a012af1fb5b7aa292ec7123281dc2
-  ref: 6be9e1e95b1a012af1fb5b7aa292ec7123281dc2
+  revision: 5e6830534124f578f43c619c8620c0560365aa55
+  ref: 5e6830534124f578f43c619c8620c0560365aa55
   specs:
-    caseflow (0.3.2)
+    caseflow (0.3.4)
       aws-sdk (~> 2.10)
       bourbon (= 4.2.7)
       d3-rails
       jquery-rails
       momentjs-rails
       neat
-      rails (= 4.2.7.1)
+      rails (>= 4.2.7.1)
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vbms.git
@@ -171,7 +171,7 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.4)
     connection_pool (2.2.1)
-    d3-rails (4.10.2)
+    d3-rails (4.13.0)
       railties (>= 3.1)
     database_cleaner (1.5.3)
     delayed_job (4.1.4)


### PR DESCRIPTION
The latest update of caseflow gem allows us to update rails gem in efolder to greater versions than 4.2.7 