### PR TITLE
Change text of document source error banner

### DIFF
--- a/client/src/containers/DownloadContainer.jsx
+++ b/client/src/containers/DownloadContainer.jsx
@@ -56,22 +56,26 @@ class DownloadContainer extends React.PureComponent {
         <StatusMessage title="Could not fetch manifest">{this.props.errorMessage}</StatusMessage>
         <DownloadPageFooter />
       </React.Fragment>;
-    } else if (!this.props.documents.count) {
-      pageBody = <React.Fragment>
-        <AppSegment filledBackground>
-          <h1 className="cf-msg-screen-heading">No Documents in eFolder</h1>
-          <h2 className="cf-msg-screen-deck">
-            eFolder Express could not find any documents in the eFolder with Veteran ID #{this.props.veteranId}.
-            It's possible this eFolder does not exist.
-          </h2>
-          <p className="cf-msg-screen-text">Please check the Veteran ID number and <Link to="/">search again</Link>.</p>
-        </AppSegment>
-        <DownloadPageFooter />
-      </React.Fragment>;
     } else if (documentDownloadStarted(this.props.documentsFetchStatus)) {
       pageBody = <DownloadProgressContainer />;
     } else if (manifestFetchComplete(this.props.documentSources)) {
-      pageBody = <DownloadListContainer />;
+      if (this.props.documents.length) {
+        pageBody = <DownloadListContainer />;
+      } else {
+        pageBody = <React.Fragment>
+          <AppSegment filledBackground>
+            <h1 className="cf-msg-screen-heading">No Documents in eFolder</h1>
+            <h2 className="cf-msg-screen-deck">
+              eFolder Express could not find any documents in the eFolder with Veteran ID #{this.props.veteranId}.
+              It's possible this eFolder does not exist.
+            </h2>
+            <p className="cf-msg-screen-text">
+              Please check the Veteran ID number and <Link to="/">search again</Link>.
+            </p>
+          </AppSegment>
+          <DownloadPageFooter />
+        </React.Fragment>;
+      }
     }
 
     return <React.Fragment>

--- a/client/src/containers/DownloadListContainer.jsx
+++ b/client/src/containers/DownloadListContainer.jsx
@@ -35,10 +35,12 @@ class DownloadListContainer extends React.PureComponent {
     return <React.Fragment>
       <AppSegment filledBackground>
         { unavailableSourceText &&
-          <AlertBanner title={`Can't connect to ${unavailableSourceText}`} alertType="warning">
-            <p>Please give {unavailableSourceText} a few moments to come back online,
-              then try searching for the eFolder again.</p>
-            <p><Link to="/">Try again</Link></p>
+          <AlertBanner title={`We are having trouble connecting to ${unavailableSourceText}`} alertType="warning">
+            <p>Please wait a few minutes and try searching this efolder again using the "Back to eFolder Express"&nbsp;
+              button below. If you continue to experience issues, you can also&nbsp;
+              <Link href={this.props.feedbackUrl}>send feedback</Link> to reach our support team.
+            </p>
+            <Link to="/"><button className="usa-button usa-button-outline">Back to eFolder Express</button></Link>
           </AlertBanner>
         }
 
@@ -66,6 +68,7 @@ const mapStateToProps = (state) => ({
   csrfToken: state.csrfToken,
   documents: state.documents,
   documentSources: state.documentSources,
+  feedbackUrl: state.feedbackUrl,
   manifestId: state.manifestId,
   veteranId: state.veteranId,
   veteranName: state.veteranName

--- a/client/src/containers/DownloadListContainer.jsx
+++ b/client/src/containers/DownloadListContainer.jsx
@@ -36,7 +36,7 @@ class DownloadListContainer extends React.PureComponent {
       <AppSegment filledBackground>
         { unavailableSourceText &&
           <AlertBanner title={`We are having trouble connecting to ${unavailableSourceText}`} alertType="warning">
-            <p>Please wait a few minutes and try searching this efolder again using the "Back to eFolder Express"&nbsp;
+            <p>Please wait a few minutes and try searching this eFolder again using the "Back to eFolder Express"&nbsp;
               button below. If you continue to experience issues, you can also&nbsp;
               <Link href={this.props.feedbackUrl}>send feedback</Link> to reach our support team.
             </p>


### PR DESCRIPTION
Connects #907.

Make some tweaks to the text and style of the banner we display when we have an error reaching VVA or VBMS. Result of @Chingujo's [suggestions on the original issue](https://github.com/department-of-veterans-affairs/caseflow-efolder/issues/907#issuecomment-371291342).

## Before
![image](https://user-images.githubusercontent.com/32683958/36763804-9be36294-1bf7-11e8-8a23-3886c8add0f9.png)

## After
![image](https://user-images.githubusercontent.com/32683958/37171392-90d2f91a-22c2-11e8-9f46-aabede6afcd7.png)