### PR TITLE
Remove period at end of banner title

### DIFF
--- a/client/src/containers/DownloadProgressContainer.jsx
+++ b/client/src/containers/DownloadProgressContainer.jsx
@@ -44,7 +44,7 @@ class DownloadProgressContainer extends React.PureComponent {
     const percentComplete = 100 * (totalDocCount - this.props.documentsForStatus.progress.length) / totalDocCount;
 
     return <React.Fragment>
-      <AlertBanner title="You can close this page at any time." alertType="info">
+      <AlertBanner title="You can close this page at any time" alertType="info">
         <p>
           You can close this page at any time and eFolder Express will continue retrieving files in the&nbsp;
           background. View progress and download eFolders from the History on the&nbsp;


### PR DESCRIPTION
Connects #928.

Addresses one of the nits in the "React Design Pass" issue.

## After
![image](https://user-images.githubusercontent.com/32683958/37313417-633c8172-260c-11e8-8be6-0dd18a786cbd.png)
