### PR TITLE
Fix recent downloads list bug caused by calling wrong recent_downloads function

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,7 +48,7 @@ class ApplicationController < BaseController
       dropdownUrls: dropdown_urls,
       efolderAccessImagePath: ActionController::Base.helpers.image_path("help/efolder-access.png"),
       feedbackUrl: feedback_url,
-      recentDownloads: ActiveModelSerializers::SerializableResource.new(current_user.recent_downloads.sort_by(&:created_at).reverse, each_serializer: Serializers::V2::ManifestSerializer),
+      recentDownloads: ActiveModelSerializers::SerializableResource.new(current_user.recent_downloads, each_serializer: Serializers::V2::ManifestSerializer),
       referenceGuidePath: ActionController::Base.helpers.asset_path("reference_guide.pdf"),
       trainingGuidePath: ActionController::Base.helpers.asset_path("training_guide.pdf"),
       userDisplayName: current_user.try(:display_name),

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,7 +48,6 @@ class ApplicationController < BaseController
       dropdownUrls: dropdown_urls,
       efolderAccessImagePath: ActionController::Base.helpers.image_path("help/efolder-access.png"),
       feedbackUrl: feedback_url,
-      recentDownloads: recent_downloads.sort_by(&:created_at).reverse,
       referenceGuidePath: ActionController::Base.helpers.asset_path("reference_guide.pdf"),
       trainingGuidePath: ActionController::Base.helpers.asset_path("training_guide.pdf"),
       userDisplayName: current_user.try(:display_name),

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,7 +48,7 @@ class ApplicationController < BaseController
       dropdownUrls: dropdown_urls,
       efolderAccessImagePath: ActionController::Base.helpers.image_path("help/efolder-access.png"),
       feedbackUrl: feedback_url,
-      recentDownloads: ActiveModelSerializers::SerializableResource.new(current_user.recent_downloads, each_serializer: Serializers::V2::ManifestSerializer),
+      recentDownloads: ActiveModelSerializers::SerializableResource.new(current_user.recent_downloads.sort_by(&:created_at).reverse, each_serializer: Serializers::V2::ManifestSerializer),
       referenceGuidePath: ActionController::Base.helpers.asset_path("reference_guide.pdf"),
       trainingGuidePath: ActionController::Base.helpers.asset_path("training_guide.pdf"),
       userDisplayName: current_user.try(:display_name),

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,6 +48,7 @@ class ApplicationController < BaseController
       dropdownUrls: dropdown_urls,
       efolderAccessImagePath: ActionController::Base.helpers.image_path("help/efolder-access.png"),
       feedbackUrl: feedback_url,
+      recentDownloads: ActiveModelSerializers::SerializableResource.new(current_user.recent_downloads, each_serializer: Serializers::V2::ManifestSerializer),
       referenceGuidePath: ActionController::Base.helpers.asset_path("reference_guide.pdf"),
       trainingGuidePath: ActionController::Base.helpers.asset_path("training_guide.pdf"),
       userDisplayName: current_user.try(:display_name),


### PR DESCRIPTION
Prior to this change we seeded the react app with the wrong list of recent downloads (we used the `recent_downloads()` function from ApplicationController instead of the [function of the same name](https://github.com/department-of-veterans-affairs/caseflow-efolder/blob/bd04b811eef545988955db99b47bb7cef5a950e6/app/models/user.rb#L44) from the User model. This PR fixes that.

An image of the previous error we would get if the user had any recent v1 downloads:
![image](https://user-images.githubusercontent.com/32683958/37315924-8307fc0e-2619-11e8-85d5-82650b21bfe2.png)
