### PR TITLE
Prevent error when visiting non-specified routes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,7 +39,7 @@ class ApplicationController < BaseController
   end
 
   def check_v2_app_access
-    serve_single_page_app if can_access_react_app?
+    can_access_react_app? ? serve_single_page_app : redirect_to("/unauthorized")
   end
 
   def initial_react_data

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < BaseController
   before_action :check_v2_app_access
 
   def serve_single_page_app
-    render "gui/single_page_app", layout: false
+    can_access_react_app? ? render("gui/single_page_app", layout: false) : redirect_to("/unauthorized")
   end
 
   def authenticate
@@ -39,7 +39,7 @@ class ApplicationController < BaseController
   end
 
   def check_v2_app_access
-    can_access_react_app? ? serve_single_page_app : redirect_to("/unauthorized")
+    serve_single_page_app if can_access_react_app?
   end
 
   def initial_react_data

--- a/app/controllers/health_checks_controller.rb
+++ b/app/controllers/health_checks_controller.rb
@@ -1,5 +1,6 @@
 class HealthChecksController < ApplicationController
   skip_before_action :authenticate
+  skip_before_action :check_v2_app_access
   newrelic_ignore_apdex
 
   def show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
     get code, :to => "errors#show", :status_code => code
   end
 
-  match '(*path)' => 'application#serve_single_page_app', via: [:get]
+  match '(*path)' => 'application#check_v2_app_access', via: [:get]
 
   require "sidekiq/web"
   require "sidekiq/cron/web"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
     get code, :to => "errors#show", :status_code => code
   end
 
-  match '(*path)' => 'application#check_v2_app_access', via: [:get]
+  match '(*path)' => 'application#serve_single_page_app', via: [:get]
 
   require "sidekiq/web"
   require "sidekiq/cron/web"


### PR DESCRIPTION
Whenever a user visits an efolder URL that is not specified in `config/routes.rb`, they will be presented with a rails error ([example sentry error](https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/1022/)). This change fixes that by redirecting non-specified routes to the unauthorized page if the user does not have access to the react single page app.

Tested this by altering the code to have `can_access_react_app?()` return false and navigating to *http://localhost:3000/browserconfig.xml* (triggers rails error) before this fix, as well as after (redirects to the react version of */unauthorized* or the html templates v1 version of */unauthorized* if `can_access_react_app?()` returns false).