### PR TITLE
Revert "Fix recent downloads list bug caused by calling wrong recent_downloads function"

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,7 +48,7 @@ class ApplicationController < BaseController
       dropdownUrls: dropdown_urls,
       efolderAccessImagePath: ActionController::Base.helpers.image_path("help/efolder-access.png"),
       feedbackUrl: feedback_url,
-      recentDownloads: ActiveModelSerializers::SerializableResource.new(current_user.recent_downloads, each_serializer: Serializers::V2::ManifestSerializer),
+      recentDownloads: recent_downloads.sort_by(&:created_at).reverse,
       referenceGuidePath: ActionController::Base.helpers.asset_path("reference_guide.pdf"),
       trainingGuidePath: ActionController::Base.helpers.asset_path("training_guide.pdf"),
       userDisplayName: current_user.try(:display_name),


### PR DESCRIPTION
Reverts department-of-veterans-affairs/caseflow-efolder#934. When this change was deployed, the Efolder UAT ELB started flapping:

<img width="1056" alt="screen shot 2018-03-13 at 10 47 33 pm" src="https://user-images.githubusercontent.com/357369/37381200-49c94624-2712-11e8-962f-999cf57c7e4f.png">
