### PR TITLE
Explicitly define the port for the rails server to listen on

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 js_server: ruby -run -e httpd app/assets/javascripts/react-app.js -p 3500
-rails: JAVASCRIPT_URL=http://localhost:3500 rails s
+rails: JAVASCRIPT_URL=http://localhost:3500 rails s -p 3000
 client: cd client && yarn run dev:watch
 sidekiq: bundle exec sidekiq


### PR DESCRIPTION
For whatever reason, when I fired up `foreman start` for efolder this morning it had the rails server listening on port 5100. I did some quick googling (duck duck go-ing to be honest) and couldn't find any reason why this might have changed (rails 5?). Either way, I don't think there is any harm is explicitly setting which port we expect the rails server to listen on (3000).