### PR TITLE
Return veteran efolder not found message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,6 @@ before_install:
   - "export PATH=$PATH:/usr/lib/chromium-browser/"
   - "export DISPLAY=:99.0"
 
-  # Set screen size to 1280x1024
-  # https://docs.travis-ci.com/user/gui-and-headless-browsers/
-  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
-
 before_script:
   - RAILS_ENV=test bundle exec rake db:create
   - RAILS_ENV=test bundle exec rake db:schema:load

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
   - RAILS_ENV=test bundle exec rake db:schema:load
   - sudo apt-get install pdftk
 
-  - sh -e /etc/init.d/xvfb start
+  - sh -e /etc/init.d/xvfb start -screen 0 1280x1024x24
   - sleep 3 # give xvfb some time to start
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,10 @@ before_install:
   - "export PATH=$PATH:/usr/lib/chromium-browser/"
   - "export DISPLAY=:99.0"
 
+  # Set screen size to 1280x1024
+  # https://docs.travis-ci.com/user/gui-and-headless-browsers/
+  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
+
 before_script:
   - RAILS_ENV=test bundle exec rake db:create
   - RAILS_ENV=test bundle exec rake db:schema:load

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_script:
   - RAILS_ENV=test bundle exec rake db:schema:load
   - sudo apt-get install pdftk
 
-  - sh -e /etc/init.d/xvfb start -screen 0 1280x1024x24
+  - sh -e /etc/init.d/xvfb start
   - sleep 3 # give xvfb some time to start
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ before_install:
   # so we need to explicitly point to the version of Yarn we just installed.
   - export YARN=/usr/bin/yarn
   - cd ./client && $YARN --frozen-lockfile
+
+  # Build the javascript bundle that forms the basis of the single page app
+  - yarn run build
   - cd ..
 
   - wget https://s3-us-gov-west-1.amazonaws.com/dsva-appeals-devops/chromium-chromedriver_53.0.2785.143-0ubuntu0.14.04.1.1145_amd64.deb -O $PWD/chromium-chromedriver.deb

--- a/app/controllers/api/v2/manifests_controller.rb
+++ b/app/controllers/api/v2/manifests_controller.rb
@@ -3,7 +3,9 @@ class Api::V2::ManifestsController < Api::V1::ApplicationController
   def start
     file_number = request.headers["HTTP_FILE_NUMBER"]
     return missing_header("File Number") unless file_number
+
     return invalid_file_number unless bgs_service.valid_file_number?(file_number)
+    return veteran_not_found(file_number) if bgs_service.fetch_veteran_info(file_number).nil?
     return forbidden("sensitive record") unless bgs_service.check_sensitivity(file_number)
 
     manifest = Manifest.find_or_create_by_user(user: current_user, file_number: file_number)
@@ -37,6 +39,10 @@ class Api::V2::ManifestsController < Api::V1::ApplicationController
 
   def bgs_service
     @bgs_service ||= BGSService.new
+  end
+
+  def veteran_not_found(file_number)
+    render json: { status: "eFolder Express could not find an eFolder with the Veteran ID #{file_number}. Check to make sure you entered the ID correctly and try again." }, status: 400
   end
 
   def invalid_file_number

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -49,9 +49,6 @@ RSpec.feature "Downloads" do
       allow_any_instance_of(Fakes::BGSService).to receive(:fetch_veteran_info).and_return(nil)
 
       visit "/"
-
-      # Allow page time to load
-      sleep 1
       fill_in "Search for a Veteran ID number below to get started.", with: "DEMO1901"
       click_button "Search"
       expect(page).to have_content("could not find an eFolder with the Veteran ID")

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -51,6 +51,9 @@ RSpec.feature "Downloads" do
       visit "/"
       fill_in "Search for a Veteran ID number below to get started.", with: "DEMO1901"
       click_button "Search"
+
+      # For debugging
+      it {puts page.body}
       expect(page).to have_content("could not find an eFolder with the Veteran ID")
     end
   end

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -49,6 +49,9 @@ RSpec.feature "Downloads" do
       allow_any_instance_of(Fakes::BGSService).to receive(:fetch_veteran_info).and_return(nil)
 
       visit "/"
+
+      # Allow page time to load
+      sleep 1
       fill_in "Search for a Veteran ID number below to get started.", with: "DEMO1901"
       click_button "Search"
       expect(page).to have_content("could not find an eFolder with the Veteran ID")

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -40,9 +40,18 @@ RSpec.feature "Downloads" do
     before { FeatureToggle.enable!(:efolder_react_app, users: [@user.css_id]) }
     after { FeatureToggle.disable!(:efolder_react_app, users: [@user.css_id]) }
 
-    it "coachmarks are not displayed indicating that we are viewing the react app" do
+    scenario "coachmarks are not displayed indicating that we are viewing the react app" do
       visit "/"
       expect(page).to_not have_content("See what's new!")
+    end
+
+    scenario "requesting veteran that does not exist results in veteran not found error" do
+      allow_any_instance_of(Fakes::BGSService).to receive(:fetch_veteran_info).and_return(nil)
+
+      visit "/"
+      fill_in "Search for a Veteran ID number below to get started.", with: "DEMO1901"
+      click_button "Search"
+      expect(page).to have_content("could not find an eFolder with the Veteran ID")
     end
   end
 

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -42,7 +42,6 @@ RSpec.feature "Downloads" do
 
     scenario "coachmarks are not displayed indicating that we are viewing the react app" do
       visit "/"
-      expect(page).to have_current_path("/")
       expect(page).to_not have_content("See what's new!")
     end
 
@@ -50,7 +49,6 @@ RSpec.feature "Downloads" do
       allow_any_instance_of(Fakes::BGSService).to receive(:fetch_veteran_info).and_return(nil)
 
       visit "/"
-      expect(page).to have_current_path("/")
       fill_in "Search for a Veteran ID number below to get started.", with: "DEMO1901"
       click_button "Search"
       expect(page).to have_content("could not find an eFolder with the Veteran ID")

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -42,6 +42,7 @@ RSpec.feature "Downloads" do
 
     scenario "coachmarks are not displayed indicating that we are viewing the react app" do
       visit "/"
+      expect(page).to have_current_path("/")
       expect(page).to_not have_content("See what's new!")
     end
 
@@ -49,6 +50,7 @@ RSpec.feature "Downloads" do
       allow_any_instance_of(Fakes::BGSService).to receive(:fetch_veteran_info).and_return(nil)
 
       visit "/"
+      expect(page).to have_current_path("/")
       fill_in "Search for a Veteran ID number below to get started.", with: "DEMO1901"
       click_button "Search"
       expect(page).to have_content("could not find an eFolder with the Veteran ID")

--- a/spec/features/download_spec.rb
+++ b/spec/features/download_spec.rb
@@ -51,9 +51,6 @@ RSpec.feature "Downloads" do
       visit "/"
       fill_in "Search for a Veteran ID number below to get started.", with: "DEMO1901"
       click_button "Search"
-
-      # For debugging
-      it {puts page.body}
       expect(page).to have_content("could not find an eFolder with the Veteran ID")
     end
   end


### PR DESCRIPTION
Connects #943.

Efolder Express UI v1's [DowloadsController](https://github.com/department-of-veterans-affairs/caseflow-efolder/blob/1284734617e65d66d2e4a4a216b80ec44c399f9b/app/controllers/downloads_controller.rb#L13) validates that an [efolder exists for a given file number](https://github.com/department-of-veterans-affairs/caseflow-efolder/blob/1284734617e65d66d2e4a4a216b80ec44c399f9b/app/models/search.rb#L73) (by way of `[Search.perform()](https://github.com/department-of-veterans-affairs/caseflow-efolder/blob/1284734617e65d66d2e4a4a216b80ec44c399f9b/app/models/search.rb#L30)`and displays a message on the [search results page](https://github.com/department-of-veterans-affairs/caseflow-efolder/blob/1284734617e65d66d2e4a4a216b80ec44c399f9b/app/views/downloads/new.html.erb#L2) if one does not. Similar behaviour for v2 except that we present the message on the search/landing page, before ever redirecting to the search results page.

## Before
![image](https://user-images.githubusercontent.com/32683958/37531089-87905a00-2911-11e8-8330-e19c84d93baf.png)

## After
![image](https://user-images.githubusercontent.com/32683958/37531043-682470c0-2911-11e8-80bb-3b3e6188b5bf.png)
