### PR TITLE
Return error to calling code if error is a PublicError

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,7 @@ gem "mini_magick"
 
 gem "httpclient"
 
-gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", branch: "e30db7fdf6f5c28c09d6081d062cad80820240a0"
+gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", branch: "8c36e65cfec998ac9dcef4cb2caa433c2d0c5550"
 gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "f014b4772385814cd510712c46698653866f99dd"
 gem "connect_vva", git: "https://github.com/department-of-veterans-affairs/connect_vva.git", ref: "ecc1da3f1027e6c270af264de46dc1cb4974fa47"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,8 +51,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/ruby-bgs.git
-  revision: e30db7fdf6f5c28c09d6081d062cad80820240a0
-  branch: e30db7fdf6f5c28c09d6081d062cad80820240a0
+  revision: 8c36e65cfec998ac9dcef4cb2caa433c2d0c5550
+  branch: 8c36e65cfec998ac9dcef4cb2caa433c2d0c5550
   specs:
     bgs (0.1)
       nokogiri (~> 1.8.2)

--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -3,15 +3,18 @@ class Api::V1::ApplicationController < BaseController
   before_action :authenticate_or_authorize
 
   rescue_from StandardError do |error|
-    ExceptionLogger.capture(error)
-
-    render json: {
-      "errors": [
-        "status": "500",
-        "title": "Unknown error occured",
-        "detail": "#{error} (Sentry event id: #{Raven.last_event_id})"
-      ]
-    }, status: 500
+    if error.respond_to?(:public_message)
+      forbidden(error.public_message)
+    else
+      ExceptionLogger.capture(error)
+      render json: {
+        "errors": [
+          "status": "500",
+          "title": "Unknown error occured",
+          "detail": "#{error} (Sentry event id: #{Raven.last_event_id})"
+        ]
+      }, status: 500
+    end
   end
 
   private

--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -3,18 +3,18 @@ class Api::V1::ApplicationController < BaseController
   before_action :authenticate_or_authorize
 
   rescue_from StandardError do |error|
-    if error.is_a?(BGS::PublicError) && error.respond_to?(:public_message)
-      forbidden(error.public_message)
-    else
-      ExceptionLogger.capture(error)
-      render json: {
-        "errors": [
-          "status": "500",
-          "title": "Unknown error occured",
-          "detail": "#{error} (Sentry event id: #{Raven.last_event_id})"
-        ]
-      }, status: 500
-    end
+    ExceptionLogger.capture(error)
+    render json: {
+      "errors": [
+        "status": "500",
+        "title": "Unknown error occured",
+        "detail": "#{error} (Sentry event id: #{Raven.last_event_id})"
+      ]
+    }, status: 500
+  end
+
+  rescue_from BGS::PublicError do |error|
+    forbidden(error.public_message)
   end
 
   private

--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::ApplicationController < BaseController
   before_action :authenticate_or_authorize
 
   rescue_from StandardError do |error|
-    if error.respond_to?(:public_message)
+    if error.is_a?(BGS::PublicError) && error.respond_to?(:public_message)
       forbidden(error.public_message)
     else
       ExceptionLogger.capture(error)

--- a/spec/requests/api/v2/manifests_spec.rb
+++ b/spec/requests/api/v2/manifests_spec.rb
@@ -196,4 +196,18 @@ describe "Manifests API v2", type: :request do
       expect(body["status"]).to match(/sensitive/)
     end
   end
+
+  context "When user does not exist in BGS" do
+    let(:error_string) { "Logon ID VACOHSOLO Not Found in the Benefits Gateway Service (BGS). Contact your ISO if you need assistance gaining access to BGS." }
+    before do
+      allow_any_instance_of(Fakes::BGSService).to receive(:check_sensitivity).and_raise(BGS::PublicError.new(error_string))
+    end
+
+    it "returns 403 forbidden response" do
+      post "/api/v2/manifests/", params: nil, headers: headers
+      expect(response.code).to eq("403")
+      body = JSON.parse(response.body)
+      expect(body["status"]).to eq("forbidden: #{error_string}")
+    end
+  end
 end


### PR DESCRIPTION
Connects #946.

Since the caseflow application cannot do anything to resolve the "Savon::SOAPFault: (S:Client) ID: {{UUID}}: Logon ID {{CSS_ID}} Not Found" errors, we will pass along those errors to the calling client code.

This code change relies on changes in [ruby-bgs PR#51](https://github.com/department-of-veterans-affairs/ruby-bgs/pull/51).