### PR TITLE
Throw error if ManifestSource status update fails

### DIFF
--- a/app/services/manifest_fetcher.rb
+++ b/app/services/manifest_fetcher.rb
@@ -8,10 +8,10 @@ class ManifestFetcher
   def process
     documents = manifest_source.service.v2_fetch_documents_for(manifest_source)
     DocumentCreator.new(manifest_source: manifest_source, external_documents: documents).create
-    manifest_source.update(status: :success, fetched_at: Time.zone.now)
+    manifest_source.update!(status: :success, fetched_at: Time.zone.now)
     documents
   rescue *EXCEPTIONS => e
-    manifest_source.update(status: :failed)
+    manifest_source.update!(status: :failed)
     ExceptionLogger.capture(e)
     []
   end


### PR DESCRIPTION
Connects #945.

Currently there are only two ManifestSources out of 638 (~0.3%) that are in this state:
```
ManifestSource.find_by_sql("select * from manifest_sources where status = 1 and created_at + interval '1 day' < current_timestamp")
```

I think we should make this change, flip these two statuses to failed, and add a cron job that looks for ManifestSources that end up in this state so we can more thoroughly investigate the cause of this issue closer to the time when it occurs.