### PR TITLE
Address loofah dependency vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,7 +223,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.2.0)
+    loofah (2.2.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)


### PR DESCRIPTION
Fixes CVE-2018-8048. See the [related issue on GitHub](https://github.com/flavorjones/loofah/issues/144).