### PR TITLE
Add cron job to check for stuck ManifestSources

### DIFF
--- a/app/jobs/alert_stuck_manifest_source_job.rb
+++ b/app/jobs/alert_stuck_manifest_source_job.rb
@@ -1,0 +1,16 @@
+class AlertStuckManifestSourceJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    stuck_manifest_ids = ManifestSource.find_by_sql("select * from manifest_sources where status = 1 and created_at + interval '1 day' < current_timestamp").map(&:id)
+
+    unless stuck_manifest_ids.empty?
+      msg = format(
+        "%<count>d ManifestSources with the following IDs have been stuck in the pending state for more than 1 day: %<ids>s",
+        count: stuck_manifest_ids.length,
+        ids: stuck_manifest_ids.join(", ")
+      )
+      ExceptionLogger.capture(msg)
+    end
+  end
+end

--- a/app/jobs/alert_stuck_manifest_source_job.rb
+++ b/app/jobs/alert_stuck_manifest_source_job.rb
@@ -3,11 +3,11 @@ class AlertStuckManifestSourceJob < ApplicationJob
 
   def perform
     if Date.current >= Date.new(2018, 5, 31)
-      # Remove the associate entry in config/sidekiq_cron.yml as well.
+      # Remove the associated entry in config/sidekiq_cron.yml as well.
       ExceptionLogger.capture("Consider removing the AlertStuckManifestSourceJob if we haven't seen a stuck ManifestSource in a while")
     end
 
-    stuck_manifest_ids = ManifestSource.find_by_sql("select * from manifest_sources where status = 1 and created_at + interval '1 day' < current_timestamp").map(&:id)
+    stuck_manifest_ids = ManifestSource.where(status: 1).where("updated_at < ?", 1.day.ago).pluck(:id)
 
     unless stuck_manifest_ids.empty?
       msg = format(

--- a/app/jobs/alert_stuck_manifest_source_job.rb
+++ b/app/jobs/alert_stuck_manifest_source_job.rb
@@ -11,9 +11,10 @@ class AlertStuckManifestSourceJob < ApplicationJob
 
     unless stuck_manifest_ids.empty?
       msg = format(
-        "%<count>d ManifestSources with the following IDs have been stuck in the pending state for more than 1 day: %<ids>s",
+        "%<count>d ManifestSources with the following IDs have been stuck in the pending state for more than 1 day: %<ids>s. Investigate! %<url>s",
         count: stuck_manifest_ids.length,
-        ids: stuck_manifest_ids.join(", ")
+        ids: stuck_manifest_ids.join(", "),
+        url: "https://github.com/department-of-veterans-affairs/caseflow-efolder/issues/945"
       )
       ExceptionLogger.capture(msg)
     end

--- a/app/jobs/alert_stuck_manifest_source_job.rb
+++ b/app/jobs/alert_stuck_manifest_source_job.rb
@@ -2,6 +2,11 @@ class AlertStuckManifestSourceJob < ApplicationJob
   queue_as :default
 
   def perform
+    if Date.current >= Date.new(2018, 5, 31)
+      # Remove the associate entry in config/sidekiq_cron.yml as well.
+      ExceptionLogger.capture("Consider removing the AlertStuckManifestSourceJob if we haven't seen a stuck ManifestSource in a while")
+    end
+
     stuck_manifest_ids = ManifestSource.find_by_sql("select * from manifest_sources where status = 1 and created_at + interval '1 day' < current_timestamp").map(&:id)
 
     unless stuck_manifest_ids.empty?

--- a/app/jobs/alert_stuck_manifest_source_job.rb
+++ b/app/jobs/alert_stuck_manifest_source_job.rb
@@ -4,7 +4,8 @@ class AlertStuckManifestSourceJob < ApplicationJob
   def perform
     if Date.current >= Date.new(2018, 5, 31)
       # Remove the associated entry in config/sidekiq_cron.yml as well.
-      ExceptionLogger.capture("Consider removing the AlertStuckManifestSourceJob if we haven't seen a stuck ManifestSource in a while")
+      msg = "Consider removing the AlertStuckManifestSourceJob if we haven't seen a stuck ManifestSource in a while"
+      Raven.capture_exception(StandardError.new(msg))
     end
 
     stuck_manifest_ids = ManifestSource.where(status: 1).where("updated_at < ?", 1.day.ago).pluck(:id)
@@ -16,7 +17,7 @@ class AlertStuckManifestSourceJob < ApplicationJob
         ids: stuck_manifest_ids.join(", "),
         url: "https://github.com/department-of-veterans-affairs/caseflow-efolder/issues/945"
       )
-      ExceptionLogger.capture(msg)
+      Raven.capture_exception(StandardError.new(msg))
     end
   end
 end

--- a/config/sidekiq_cron.yml
+++ b/config/sidekiq_cron.yml
@@ -20,7 +20,7 @@ clean_download_files_job:
   active_job: true
 
 # Check for ManifestSources stuck in pending state at the top of every hour during the workday, work week.
-calculate_stats_job:
+check_stuck_pending_manifest_source:
   cron: "0 9-17 * * 1-5"
   class: "AlertStuckManifestSourceJob"
   queue: default

--- a/config/sidekiq_cron.yml
+++ b/config/sidekiq_cron.yml
@@ -18,3 +18,10 @@ clean_download_files_job:
   class: "CleanDownloadFilesJob"
   queue: default
   active_job: true
+
+# Check for ManifestSources stuck in pending state at the top of every hour during the workday, work week.
+calculate_stats_job:
+  cron: "0 9-17 * * 1-5"
+  class: "AlertStuckManifestSourceJob"
+  queue: default
+  active_job: true


### PR DESCRIPTION
Connects #945.

Add this cron job so we can investigate the issue of ManifestSources getting stuck in the "pending" state closer to the first occurrence of this happening when (if?!) it happens next.

Have not yet reset the two ManifestSources that are stuck in this state because I want to confirm this runs by using those two ManifestSources as our guinea pigs.