### PR TITLE
Improve sensitive record message

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -27,8 +27,8 @@ class Api::V1::ApplicationController < BaseController
     forbidden("It looks like you don't have permission to view this eFolder. This usually happens if the eFolder contains sensitive information.")
   end
 
-  def forbidden(reason = "unspecified")
-    render json: { status: "forbidden: #{reason}" }, status: 403
+  def forbidden(reason = "Forbidden: unspecified")
+    render json: { status: reason }, status: 403
   end
 
   def missing_header(header)

--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -23,6 +23,10 @@ class Api::V1::ApplicationController < BaseController
     render json: { status: "unauthorized" }, status: 401
   end
 
+  def sensitive_record
+    forbidden("It looks like you don't have permission to view this eFolder. This usually happens if the eFolder contains sensitive information.")
+  end
+
   def forbidden(reason = "unspecified")
     render json: { status: "forbidden: #{reason}" }, status: 403
   end

--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -40,7 +40,7 @@ class Api::V1::DocumentsController < Api::V1::ApplicationController
   end
 
   def can_access?
-    forbidden("sensitive record") if !document.can_be_access_by?(current_user)
+    sensitive_record if !document.can_be_access_by?(current_user)
   rescue ActiveRecord::RecordNotFound
     document_not_found
   end

--- a/app/controllers/api/v1/files_controller.rb
+++ b/app/controllers/api/v1/files_controller.rb
@@ -29,7 +29,7 @@ class Api::V1::FilesController < Api::V1::ApplicationController
   end
 
   def can_access?
-    forbidden("sensitive record") if !BGSService.new.check_sensitivity(id)
+    sensitive_record if !BGSService.new.check_sensitivity(id)
   end
 
   def download

--- a/app/controllers/api/v2/manifests_controller.rb
+++ b/app/controllers/api/v2/manifests_controller.rb
@@ -6,7 +6,7 @@ class Api::V2::ManifestsController < Api::V1::ApplicationController
 
     return invalid_file_number unless bgs_service.valid_file_number?(file_number)
     return veteran_not_found(file_number) if bgs_service.fetch_veteran_info(file_number).nil?
-    return forbidden("sensitive record") unless bgs_service.check_sensitivity(file_number)
+    return sensitive_record unless bgs_service.check_sensitivity(file_number)
 
     manifest = Manifest.find_or_create_by_user(user: current_user, file_number: file_number)
     manifest.start!

--- a/app/controllers/api/v2/records_controller.rb
+++ b/app/controllers/api/v2/records_controller.rb
@@ -37,6 +37,6 @@ class Api::V2::RecordsController < Api::V1::ApplicationController
 
   def validate_access
     return record_not_found unless record
-    forbidden("sensitive record") unless record.accessible_by?(current_user)
+    sensitive_record unless record.accessible_by?(current_user)
   end
 end

--- a/spec/requests/api/v2/manifests_spec.rb
+++ b/spec/requests/api/v2/manifests_spec.rb
@@ -207,7 +207,7 @@ describe "Manifests API v2", type: :request do
       post "/api/v2/manifests/", params: nil, headers: headers
       expect(response.code).to eq("403")
       body = JSON.parse(response.body)
-      expect(body["status"]).to eq("forbidden: #{error_string}")
+      expect(body["status"]).to eq(error_string)
     end
   end
 end


### PR DESCRIPTION
Added more expressive copy for sensitive records alert to match what [currently exists in efolder html](https://github.com/department-of-veterans-affairs/caseflow-efolder/blob/3a55456ea222374c7e7ee5217ae3621d7ce5b2e7/app/views/downloads/new.html.erb#L31) templates UI. Changing this copy should have no effect on the caseflow code that depends on this response since [that code](https://github.com/department-of-veterans-affairs/caseflow/blob/db575e1162ddf169074980fc97dca1ae826a4d55/app/services/external_api/efolder_service.rb#L19) only checks the HTTP response code and not the text of the message.

## Before
![image](https://user-images.githubusercontent.com/32683958/37674101-69099472-2c48-11e8-8131-98317f7ce97f.png)

## After
![image](https://user-images.githubusercontent.com/32683958/37674057-4dd5e368-2c48-11e8-9e01-5adf7bed9ca3.png)
