### PR TITLE
Explicitly set time zone in sidekiq cron job

### DIFF
--- a/config/sidekiq_cron.yml
+++ b/config/sidekiq_cron.yml
@@ -21,7 +21,7 @@ clean_download_files_job:
 
 # Check for ManifestSources stuck in pending state at the top of every hour during the workday, work week.
 check_stuck_pending_manifest_source:
-  cron: "0 9-17 * * 1-5"
+  cron: "0 9-17 * * 1-5 America/New_York"
   class: "AlertStuckManifestSourceJob"
   queue: default
   active_job: true


### PR DESCRIPTION
Connects #945.

Efolder's time zone is set to UTC, when I wrote this code I incorrectly assumed our application's time zone was set to eastern. We want this cron job to run in eastern time. This code change fixes that.

### efolder time zone check!
![image](https://user-images.githubusercontent.com/32683958/37683695-d086e8be-2c63-11e8-97c0-9ed4e928e714.png)
