### PR TITLE
Recreating index with unique constraint

### DIFF
--- a/db/migrate/20180321175540_remove_duplicate_manifests.rb
+++ b/db/migrate/20180321175540_remove_duplicate_manifests.rb
@@ -1,0 +1,19 @@
+class RemoveDuplicateManifests < ActiveRecord::Migration[5.1]
+  def up
+    manifest_exists_for_file_number = {}
+    manifests_to_remove = []
+
+    Manifest.find_each do |manifest|
+      if manifest_exists_for_file_number[manifest[:file_number]]
+        manifests_to_remove.push(manifest.id)
+      end
+      manifest_exists_for_file_number[manifest[:file_number]] = true
+    end
+
+    Manifest.where(id: manifests_to_remove).destroy_all
+  end
+
+  def down
+    # Do nothing if we are rolling back. It's not reversible, but not an error to rollback either.
+  end
+end

--- a/db/migrate/20180321175556_remove_manifest_index.rb
+++ b/db/migrate/20180321175556_remove_manifest_index.rb
@@ -1,0 +1,5 @@
+class RemoveManifestIndex < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :manifests, :file_number
+  end
+end

--- a/db/migrate/20180321175607_add_manifest_index.rb
+++ b/db/migrate/20180321175607_add_manifest_index.rb
@@ -1,0 +1,7 @@
+class AddManifestIndex < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :manifests, :file_number, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20180321175607_add_manifest_index.rb
+++ b/db/migrate/20180321175607_add_manifest_index.rb
@@ -1,23 +1,7 @@
 class AddManifestIndex < ActiveRecord::Migration[5.1]
-  safety_assured
+  disable_ddl_transaction!
 
-  def up
-    manifest_exists_for_file_number = {}
-    manifests_to_remove = []
-
-    Manifest.find_each do |manifest|
-      if manifest_exists_for_file_number[manifest[:file_number]]
-        manifests_to_remove.push(manifest.id)
-      end
-      manifest_exists_for_file_number[manifest[:file_number]] = true
-    end
-
-    Manifest.where(id: manifests_to_remove).destroy_all
-
-    add_index :manifests, :file_number, unique: true
-  end
-
-  def down
-    remove_index :manifests, :file_number
+  def change
+    add_index :manifests, :file_number, unique: true, algorithm: :concurrently
   end
 end

--- a/db/migrate/20180321175607_add_manifest_index.rb
+++ b/db/migrate/20180321175607_add_manifest_index.rb
@@ -1,7 +1,23 @@
 class AddManifestIndex < ActiveRecord::Migration[5.1]
-  disable_ddl_transaction!
+  safety_assured
 
-  def change
-    add_index :manifests, :file_number, unique: true, algorithm: :concurrently
+  def up
+    manifest_exists_for_file_number = {}
+    manifests_to_remove = []
+
+    Manifest.find_each do |manifest|
+      if manifest_exists_for_file_number[manifest[:file_number]]
+        manifests_to_remove.push(manifest.id)
+      end
+      manifest_exists_for_file_number[manifest[:file_number]] = true
+    end
+
+    Manifest.where(id: manifests_to_remove).destroy_all
+
+    add_index :manifests, :file_number, unique: true
+  end
+
+  def down
+    remove_index :manifests, :file_number
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,156 +10,148 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180123192853) do
+ActiveRecord::Schema.define(version: 20180321175607) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "delayed_jobs", force: :cascade do |t|
-    t.integer  "priority",   default: 0, null: false
-    t.integer  "attempts",   default: 0, null: false
-    t.text     "handler",                null: false
-    t.text     "last_error"
+  create_table "delayed_jobs", id: :serial, force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
     t.datetime "run_at"
     t.datetime "locked_at"
     t.datetime "failed_at"
-    t.string   "locked_by"
-    t.string   "queue"
+    t.string "locked_by"
+    t.string "queue"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
-
-  create_table "documents", force: :cascade do |t|
-    t.integer  "download_id"
-    t.integer  "download_status",   default: 0
-    t.string   "document_id"
-    t.string   "vbms_filename"
-    t.string   "source"
-    t.string   "mime_type"
+  create_table "documents", id: :serial, force: :cascade do |t|
+    t.integer "download_id"
+    t.integer "download_status", default: 0
+    t.string "document_id"
+    t.string "vbms_filename"
+    t.string "source"
+    t.string "mime_type"
     t.datetime "received_at"
-    t.datetime "created_at",                         null: false
-    t.datetime "updated_at",                         null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.datetime "started_at"
     t.datetime "completed_at"
-    t.integer  "lock_version"
-    t.string   "type_description"
-    t.string   "type_id"
-    t.text     "error_message"
-    t.string   "downloaded_from",   default: "VBMS"
-    t.string   "jro"
-    t.string   "ssn"
-    t.integer  "size"
-    t.integer  "conversion_status"
+    t.integer "lock_version"
+    t.string "type_description"
+    t.string "type_id"
+    t.text "error_message"
+    t.string "downloaded_from", default: "VBMS"
+    t.string "jro"
+    t.string "ssn"
+    t.integer "size"
+    t.integer "conversion_status"
+    t.index ["completed_at"], name: "index_documents_on_completed_at"
+    t.index ["download_id", "document_id"], name: "index_documents_on_download_id_and_document_id"
+    t.index ["download_status"], name: "index_documents_on_download_status"
   end
 
-  add_index "documents", ["completed_at"], name: "index_documents_on_completed_at", using: :btree
-  add_index "documents", ["download_id", "document_id"], name: "index_documents_on_download_id_and_document_id", using: :btree
-  add_index "documents", ["download_status"], name: "index_documents_on_download_status", using: :btree
-
-  create_table "downloads", force: :cascade do |t|
-    t.string   "request_id"
-    t.string   "file_number"
-    t.integer  "status",                             default: 0
-    t.datetime "created_at",                                         null: false
-    t.datetime "updated_at",                                         null: false
-    t.integer  "lock_version"
+  create_table "downloads", id: :serial, force: :cascade do |t|
+    t.string "request_id"
+    t.string "file_number"
+    t.integer "status", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "lock_version"
     t.datetime "manifest_fetched_at"
     t.datetime "started_at"
     t.datetime "completed_at"
-    t.string   "veteran_last_name"
-    t.string   "veteran_first_name"
-    t.string   "veteran_last_four_ssn"
-    t.integer  "user_id"
-    t.integer  "zipfile_size",             limit: 8
-    t.boolean  "from_api",                           default: false
+    t.string "veteran_last_name"
+    t.string "veteran_first_name"
+    t.string "veteran_last_four_ssn"
+    t.integer "user_id"
+    t.bigint "zipfile_size"
+    t.boolean "from_api", default: false
     t.datetime "manifest_vva_fetched_at"
     t.datetime "manifest_vbms_fetched_at"
+    t.index ["completed_at"], name: "downloads_completed_at"
+    t.index ["file_number", "user_id"], name: "index_downloads_on_file_number_and_user_id"
+    t.index ["manifest_fetched_at"], name: "downloads_manifest_fetched_at"
+    t.index ["user_id"], name: "index_downloads_on_user_id"
   end
 
-  add_index "downloads", ["completed_at"], name: "downloads_completed_at", using: :btree
-  add_index "downloads", ["file_number", "user_id"], name: "index_downloads_on_file_number_and_user_id", using: :btree
-  add_index "downloads", ["manifest_fetched_at"], name: "downloads_manifest_fetched_at", using: :btree
-  add_index "downloads", ["user_id"], name: "index_downloads_on_user_id", using: :btree
-
-  create_table "files_downloads", force: :cascade do |t|
-    t.integer  "manifest_id"
-    t.integer  "user_id"
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
+  create_table "files_downloads", id: :serial, force: :cascade do |t|
+    t.integer "manifest_id"
+    t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.datetime "requested_zip_at"
+    t.index ["manifest_id", "user_id"], name: "index_files_downloads_on_manifest_id_and_user_id"
   end
 
-  add_index "files_downloads", ["manifest_id", "user_id"], name: "index_files_downloads_on_manifest_id_and_user_id", using: :btree
-
-  create_table "manifest_sources", force: :cascade do |t|
-    t.integer  "manifest_id"
-    t.integer  "status",      default: 0
-    t.string   "name"
+  create_table "manifest_sources", id: :serial, force: :cascade do |t|
+    t.integer "manifest_id"
+    t.integer "status", default: 0
+    t.string "name"
     t.datetime "fetched_at"
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table "manifests", force: :cascade do |t|
-    t.string   "file_number"
-    t.string   "veteran_last_name"
-    t.string   "veteran_first_name"
-    t.string   "veteran_last_four_ssn"
-    t.integer  "zipfile_size",          limit: 8
-    t.datetime "created_at",                                  null: false
-    t.datetime "updated_at",                                  null: false
-    t.integer  "fetched_files_status",            default: 0
+  create_table "manifests", id: :serial, force: :cascade do |t|
+    t.string "file_number"
+    t.string "veteran_last_name"
+    t.string "veteran_first_name"
+    t.string "veteran_last_four_ssn"
+    t.bigint "zipfile_size"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "fetched_files_status", default: 0
     t.datetime "fetched_files_at"
+    t.index ["file_number"], name: "index_manifests_on_file_number", unique: true
   end
 
-  add_index "manifests", ["file_number"], name: "index_manifests_on_file_number", using: :btree
-
-  create_table "records", force: :cascade do |t|
-    t.integer  "manifest_source_id"
-    t.integer  "status",             default: 0
-    t.string   "version_id"
-    t.string   "mime_type"
+  create_table "records", id: :serial, force: :cascade do |t|
+    t.integer "manifest_source_id"
+    t.integer "status", default: 0
+    t.string "version_id"
+    t.string "mime_type"
     t.datetime "received_at"
-    t.string   "type_description"
-    t.string   "type_id"
-    t.integer  "size"
-    t.string   "jro"
-    t.string   "source"
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
-    t.integer  "conversion_status",  default: 0
-    t.string   "series_id"
-    t.integer  "version"
+    t.string "type_description"
+    t.string "type_id"
+    t.integer "size"
+    t.string "jro"
+    t.string "source"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "conversion_status", default: 0
+    t.string "series_id"
+    t.integer "version"
+    t.index ["manifest_source_id", "series_id"], name: "index_records_on_manifest_source_id_and_series_id"
+    t.index ["manifest_source_id", "version_id"], name: "index_records_on_manifest_source_id_and_version_id"
   end
 
-  add_index "records", ["manifest_source_id", "series_id"], name: "index_records_on_manifest_source_id_and_series_id", using: :btree
-  add_index "records", ["manifest_source_id", "version_id"], name: "index_records_on_manifest_source_id_and_version_id", using: :btree
-
-  create_table "searches", force: :cascade do |t|
-    t.integer  "download_id"
-    t.string   "file_number"
-    t.integer  "status",      default: 0
+  create_table "searches", id: :serial, force: :cascade do |t|
+    t.integer "download_id"
+    t.string "file_number"
+    t.integer "status", default: 0
     t.datetime "created_at"
-    t.integer  "user_id"
+    t.integer "user_id"
+    t.index ["created_at"], name: "searches_created_at"
+    t.index ["download_id"], name: "index_searches_on_download_id"
+    t.index ["status", "created_at"], name: "searches_status_created_at"
+    t.index ["user_id"], name: "index_searches_on_user_id"
   end
 
-  add_index "searches", ["created_at"], name: "searches_created_at", using: :btree
-  add_index "searches", ["download_id"], name: "index_searches_on_download_id", using: :btree
-  add_index "searches", ["status", "created_at"], name: "searches_status_created_at", using: :btree
-  add_index "searches", ["user_id"], name: "index_searches_on_user_id", using: :btree
-
-  create_table "users", force: :cascade do |t|
-    t.string   "css_id",                                null: false
-    t.string   "station_id",                            null: false
-    t.string   "email"
-    t.datetime "created_at",                            null: false
-    t.datetime "updated_at",                            null: false
-    t.integer  "vva_coachmarks_view_count", default: 0
+  create_table "users", id: :serial, force: :cascade do |t|
+    t.string "css_id", null: false
+    t.string "station_id", null: false
+    t.string "email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "vva_coachmarks_view_count", default: 0
+    t.index ["css_id", "station_id"], name: "index_users_on_css_id_and_station_id"
   end
-
-  add_index "users", ["css_id", "station_id"], name: "index_users_on_css_id_and_station_id", using: :btree
 
   add_foreign_key "downloads", "users"
   add_foreign_key "searches", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,7 @@ ActiveRecord::Schema.define(version: 20180321175607) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "delayed_jobs", id: :serial, force: :cascade do |t|
+  create_table "delayed_jobs", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
     t.integer "attempts", default: 0, null: false
     t.text "handler", null: false
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 20180321175607) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  create_table "documents", id: :serial, force: :cascade do |t|
+  create_table "documents", force: :cascade do |t|
     t.integer "download_id"
     t.integer "download_status", default: 0
     t.string "document_id"
@@ -56,7 +56,7 @@ ActiveRecord::Schema.define(version: 20180321175607) do
     t.index ["download_status"], name: "index_documents_on_download_status"
   end
 
-  create_table "downloads", id: :serial, force: :cascade do |t|
+  create_table "downloads", force: :cascade do |t|
     t.string "request_id"
     t.string "file_number"
     t.integer "status", default: 0
@@ -80,7 +80,7 @@ ActiveRecord::Schema.define(version: 20180321175607) do
     t.index ["user_id"], name: "index_downloads_on_user_id"
   end
 
-  create_table "files_downloads", id: :serial, force: :cascade do |t|
+  create_table "files_downloads", force: :cascade do |t|
     t.integer "manifest_id"
     t.integer "user_id"
     t.datetime "created_at", null: false
@@ -89,7 +89,7 @@ ActiveRecord::Schema.define(version: 20180321175607) do
     t.index ["manifest_id", "user_id"], name: "index_files_downloads_on_manifest_id_and_user_id"
   end
 
-  create_table "manifest_sources", id: :serial, force: :cascade do |t|
+  create_table "manifest_sources", force: :cascade do |t|
     t.integer "manifest_id"
     t.integer "status", default: 0
     t.string "name"
@@ -98,7 +98,7 @@ ActiveRecord::Schema.define(version: 20180321175607) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "manifests", id: :serial, force: :cascade do |t|
+  create_table "manifests", force: :cascade do |t|
     t.string "file_number"
     t.string "veteran_last_name"
     t.string "veteran_first_name"
@@ -111,7 +111,7 @@ ActiveRecord::Schema.define(version: 20180321175607) do
     t.index ["file_number"], name: "index_manifests_on_file_number", unique: true
   end
 
-  create_table "records", id: :serial, force: :cascade do |t|
+  create_table "records", force: :cascade do |t|
     t.integer "manifest_source_id"
     t.integer "status", default: 0
     t.string "version_id"
@@ -131,7 +131,7 @@ ActiveRecord::Schema.define(version: 20180321175607) do
     t.index ["manifest_source_id", "version_id"], name: "index_records_on_manifest_source_id_and_version_id"
   end
 
-  create_table "searches", id: :serial, force: :cascade do |t|
+  create_table "searches", force: :cascade do |t|
     t.integer "download_id"
     t.string "file_number"
     t.integer "status", default: 0
@@ -143,7 +143,7 @@ ActiveRecord::Schema.define(version: 20180321175607) do
     t.index ["user_id"], name: "index_searches_on_user_id"
   end
 
-  create_table "users", id: :serial, force: :cascade do |t|
+  create_table "users", force: :cascade do |t|
     t.string "css_id", null: false
     t.string "station_id", null: false
     t.string "email"


### PR DESCRIPTION
We want to have a DB level validation to ensure our manifests are unique per file_number. This PR recreates the index on the Manifest table to make it unique.

**Test plan**
- [ ] Ran the query in the first migration to determine how many manifests we'll need to delete in production. Only one, id: 464.
- [ ] Ran the migrations locally where I artificially created duplicate manifests, with associated manifest sources and records. Ensured it delete those extras before creating the unique index.
- [ ] Rolled back all the migrations to ensure we can go down as well as up.