### PR TITLE
Special case the VVA duplicate document id error

### DIFF
--- a/app/services/manifest_fetcher.rb
+++ b/app/services/manifest_fetcher.rb
@@ -5,8 +5,14 @@ class ManifestFetcher
 
   EXCEPTIONS = [VBMS::ClientError, VVA::ClientError].freeze
 
+  # VVA has a bug where they return these ids in multiple veteran's eFolders. This violates our unique constraint
+  # and since documents should be unique to veterans, we have decided to filter out these documents.
+  VVA_DUPLICATE_ID_LIST = %w[{F291C1BC-FCDE-4C58-8544-B4FCE2E59008}].freeze
+
   def process
-    documents = manifest_source.service.v2_fetch_documents_for(manifest_source)
+    documents = manifest_source.service.v2_fetch_documents_for(manifest_source).reject do |document|
+      VVA_DUPLICATE_ID_LIST.include?(document.document_id)
+    end
     DocumentCreator.new(manifest_source: manifest_source, external_documents: documents).create
     manifest_source.update!(status: :success, fetched_at: Time.zone.now)
     documents

--- a/spec/services/manifest_fetcher_spec.rb
+++ b/spec/services/manifest_fetcher_spec.rb
@@ -55,6 +55,26 @@ describe ManifestFetcher do
         end
       end
 
+      context "when VVA client returns manifest with {F291C1BC-FCDE-4C58-8544-B4FCE2E59008}" do
+        let(:documents) do
+          [
+            OpenStruct.new(document_id: "{F291C1BC-FCDE-4C58-8544-B4FCE2E59008}", series_id: "3"),
+            OpenStruct.new(document_id: "2", series_id: "4")
+          ]
+        end
+
+        before do
+          allow(VVAService).to receive(:v2_fetch_documents_for).and_return(documents)
+        end
+
+        it "saves manifest status as success and updated fetched at" do
+          expect(subject.size).to eq 1
+          expect(source.reload.status).to eq "success"
+          expect(source.reload.fetched_at).to_not be_nil
+          expect(subject[0].document_id).to eq "2"
+        end
+      end
+
       context "when VVA client returns error" do
         before do
           allow(VVAService).to receive(:v2_fetch_documents_for).and_raise(VVA::ClientError)


### PR DESCRIPTION
We recently added a unique constraint to the document_id field of the records table. Previously we were using rails validations. However, using unique constraints in validations doesn't guarantee uniqueness since there can be race conditions. The only way to ensure this is to put the constraint at the DB level. We also made a change to start using `create!` instead of `create` to build our records. This way we are alerted when record creations fail. Last night we began receiving a lot of this error: https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/1079/events/latest/. `PG::UniqueViolation: ERROR: duplicate key value violates unique constraint "index_records_on_version_id" DETAIL: Key (version_id)=({F291C1BC-FCDE-4C58-8544-B4FCE2E59008}) already exists.` Each of the 200+ errors reported seemed to have the same version_id.

Upon investigation we determined that VVA returned this document_id for several different veteran case files. This is surprising since, the document_id is a GUID. We didn't see this problem before because `create` just silently failed. Interestingly, Reader does have this unique constraint, but it just updates documents when it already sees them in the DB, so Reader has not been showing these duplicates anyway. v1 of eX would likely show these duplicates, but v2 does not. I think we can go under the assumption (for now) that we can just filter these documents out, since that is what Reader has been doing, and we haven't received any complaints so far.

We're reaching out to the VVA team to see if this is expected behavior.

Welcome to the VA...