### PR TITLE
Adding another exception to VVA documents

### DIFF
--- a/app/services/manifest_fetcher.rb
+++ b/app/services/manifest_fetcher.rb
@@ -7,7 +7,7 @@ class ManifestFetcher
 
   # VVA has a bug where they return these ids in multiple veteran's eFolders. This violates our unique constraint
   # and since documents should be unique to veterans, we have decided to filter out these documents.
-  VVA_DUPLICATE_ID_LIST = %w[{F291C1BC-FCDE-4C58-8544-B4FCE2E59008}].freeze
+  VVA_DUPLICATE_ID_LIST = %w[{F291C1BC-FCDE-4C58-8544-B4FCE2E59008} {4F277E03-66ED-4263-9A43-075CFFF72393}].freeze
 
   def process
     documents = manifest_source.service.v2_fetch_documents_for(manifest_source).reject do |document|


### PR DESCRIPTION
There appears to be another duplicate in the VVA documents. This PR exempts it for now... but this will hopefully be removed soon. Here is the plan.

Minh (VVA owner) says he is looking into the duplicates and will have answers for us on Wednesday. We'll keep adding exemptions until then to keep things usable. If they can fix the problem easily, then GREAT. We'll keep our code as is and let them fix the problem. If they cannot, then here is our backup plan:

1) Remove unique constraint on `version_id`
1) Add unique constraint to `["manifest_source_id", "version_id"]`
1) When retrieving documents from VVA only allow each `version_id` once for each manifest source id.

Still not ideal... but will probably get us through.