### PR TITLE
Allow users to visit efolder pages for manifests they did not kick off

### DIFF
--- a/app/controllers/api/v2/manifests_controller.rb
+++ b/app/controllers/api/v2/manifests_controller.rb
@@ -8,7 +8,7 @@ class Api::V2::ManifestsController < Api::V1::ApplicationController
     return veteran_not_found(file_number) if bgs_service.fetch_veteran_info(file_number).nil?
     return sensitive_record unless bgs_service.check_sensitivity(file_number)
 
-    manifest = Manifest.find_or_create_by_user(user: current_user, file_number: file_number)
+    manifest = Manifest.find_or_create_by(file_number: file_number)
     manifest.start!
     render json: json_manifests(manifest)
   end
@@ -16,7 +16,7 @@ class Api::V2::ManifestsController < Api::V1::ApplicationController
   def progress
     manifest = Manifest.find(params[:id])
     return record_not_found unless manifest
-    return sensitive_record unless bgs_service.check_sensitivity(file_number)
+    return sensitive_record unless bgs_service.check_sensitivity(manifest.file_number)
 
     render json: json_manifests(manifest)
   end

--- a/app/controllers/api/v2/manifests_controller.rb
+++ b/app/controllers/api/v2/manifests_controller.rb
@@ -16,6 +16,7 @@ class Api::V2::ManifestsController < Api::V1::ApplicationController
   def progress
     manifest = Manifest.find(params[:id])
     return record_not_found unless manifest
+    return sensitive_record unless bgs_service.check_sensitivity(file_number)
 
     render json: json_manifests(manifest)
   end

--- a/app/controllers/api/v2/manifests_controller.rb
+++ b/app/controllers/api/v2/manifests_controller.rb
@@ -14,10 +14,10 @@ class Api::V2::ManifestsController < Api::V1::ApplicationController
   end
 
   def progress
-    files_download ||= FilesDownload.includes(:manifest).find_by(manifest_id: params[:id], user_id: current_user.id)
-    return record_not_found unless files_download
+    manifest = Manifest.find(params[:id])
+    return record_not_found unless manifest
 
-    render json: json_manifests(files_download.manifest)
+    render json: json_manifests(manifest)
   end
 
   def history

--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -102,12 +102,6 @@ class Manifest < ApplicationRecord
     @veteran ||= Veteran.new(file_number: file_number).load_bgs_record!
   end
 
-  def self.find_or_create_by_user(user:, file_number:)
-    manifest = Manifest.find_or_create_by(file_number: file_number)
-    manifest.files_downloads.find_or_create_by(user: user)
-    manifest
-  end
-
   private
 
   def file_download

--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -111,7 +111,7 @@ class Manifest < ApplicationRecord
   private
 
   def file_download
-    files_downloads.find_by(user: RequestStore[:current_user])
+    files_downloads.find_or_create_by(user: RequestStore[:current_user])
   end
 
   def requested_zip_at

--- a/spec/features/react_download_spec.rb
+++ b/spec/features/react_download_spec.rb
@@ -237,4 +237,25 @@ RSpec.feature "React Downloads" do
       end
     end
   end
+
+  context "Two users attempt to view manifest for same Veteran ID" do
+    let(:veteran_id) { "198912130" }
+
+    scenario "Visiting URL for manifest that a different user started" do
+      perform_enqueued_jobs do
+        # User A kicks off the initial search for a given Veteran ID.
+        visit "/"
+        fill_in "Search for a Veteran ID number below to get started.", with: veteran_id
+        click_on "Search"
+        expect(page).to have_content "Start retrieving efolder"
+
+        # Sign in as a different user.
+        User.authenticate!(css_id: "DINOUYE")
+
+        # User B attempts to visit the URL for that manifest.
+        visit "/downloads/#{Manifest.last.id}"
+        expect(page).to have_content "Start retrieving efolder"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Connects #971.

In the course of working on #954, I discovered the following edge case that could cause problems (and complicates the solution to #954 significantly).

Anna searches for file number 123456789, sends the URL to coworker Billie. Billie pastes the URL into their browser but is presented with a record not found message. Billie should be able to view the page without issue.