### PR TITLE
Adding meta tag to disable compatibility mode

### DIFF
--- a/app/views/gui/single_page_app.html.erb
+++ b/app/views/gui/single_page_app.html.erb
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title>eFolder Express</title>
-
+    <meta http-equiv='X-UA-Compatible' content='IE=edge' />
     <% if Rails.configuration.react_spa_javascript_url %>
       <script src="<%= Rails.configuration.react_spa_javascript_url %>"></script>
     <% else %>


### PR DESCRIPTION
We lost a meta tag in the refactor that tells IE to not render in compatibility mode. Adding it back in, seems to fix any rendering problems in IE when compatibility mode is turned on.