### PR TITLE
Add manifest failed page and fix active tab

### DIFF
--- a/client/src/apiActions.jsx
+++ b/client/src/apiActions.jsx
@@ -26,6 +26,10 @@ const setActiveTab = (dispatch, respAttrs) => {
   const pendingRecords = respAttrs.records.some((record) => record.status === DOCUMENT_DOWNLOAD_STATE.IN_PROGRESS);
   const allPendingRecords = respAttrs.records.every((record) => record.status === DOCUMENT_DOWNLOAD_STATE.IN_PROGRESS);
 
+  // When all the records are pending, the pending tab will be selected. Once a single document is completed or
+  // failed the user can choose any tab. Once the download is complete either the completed tab (if there are no errors)
+  // or the error tab (if there are any errors) is automatically selected for the user. Then the user can switch
+  // to any tab with documents.
   if (allPendingRecords) {
     dispatch(setActiveDownloadProgressTab(IN_PROGRESS_TAB));
   } else if (!pendingRecords) {

--- a/client/src/apiActions.jsx
+++ b/client/src/apiActions.jsx
@@ -31,20 +31,11 @@ const setStateFromResponse = (dispatch, resp) => {
   dispatch(setVeteranId(respAttrs.file_number));
   dispatch(setVeteranName(`${respAttrs.veteran_first_name} ${respAttrs.veteran_last_name}`));
 
-  let activeTab = IN_PROGRESS_TAB;
-
-  switch (respAttrs.fetched_files_status) {
-  case MANIFEST_DOWNLOAD_STATE.SUCCEEDED:
-    activeTab = SUCCESS_TAB;
-    break;
-  case MANIFEST_DOWNLOAD_STATE.FAILED:
-    activeTab = ERRORS_TAB;
-    break;
-  default:
-    activeTab = IN_PROGRESS_TAB;
-    break;
+  if (respAttrs.fetched_files_status === MANIFEST_DOWNLOAD_STATE.SUCCEEDED) {
+    dispatch(setActiveDownloadProgressTab(SUCCESS_TAB));
+  } else if (respAttrs.fetched_files_status === MANIFEST_DOWNLOAD_STATE.FAILED) {
+    dispatch(setActiveDownloadProgressTab(ERRORS_TAB));
   }
-  dispatch(setActiveDownloadProgressTab(activeTab));
 };
 
 const baseRequest = (endpoint, csrfToken, method, options = {}) => {

--- a/client/src/containers/DownloadProgressContainer.jsx
+++ b/client/src/containers/DownloadProgressContainer.jsx
@@ -239,7 +239,7 @@ class DownloadProgressContainer extends React.PureComponent {
       title="There was an error downloading this efolder"
       alertType="error">
       <p>You can try to download this efolder again using the ‘Retry Download' button below.
-      If the problem persists, please send in feedback.</p>
+      If the problem persists, please <Link href={this.props.feedbackUrl}>send feedback.</Link></p>
       <ul className="ee-button-list">
         <li>
           <button
@@ -312,7 +312,8 @@ const mapStateToProps = (state) => ({
   },
   documentSources: state.documentSources,
   manifestId: state.manifestId,
-  veteranId: state.veteranId
+  veteranId: state.veteranId,
+  feedbackUrl: state.feedbackUrl
 });
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({

--- a/client/src/containers/DownloadProgressContainer.jsx
+++ b/client/src/containers/DownloadProgressContainer.jsx
@@ -236,11 +236,11 @@ class DownloadProgressContainer extends React.PureComponent {
 
   manifestFailedBanner = () => {
     return <AlertBanner
-      title="There was an error while downloading"
+      title="There was an error downloading this efolder"
       alertType="error"
     >
-      <p>We're sorry, but our systems had an error! Please try to download the case again, and if it still fails
-      please send in feedback.</p>
+      <p>You can try to download this efolder again using the ‘Retry Download' button below.
+      If the problem persists, please send in feedback.</p>
       <ul className="ee-button-list">
         <li>
           <button

--- a/client/src/containers/DownloadProgressContainer.jsx
+++ b/client/src/containers/DownloadProgressContainer.jsx
@@ -237,8 +237,7 @@ class DownloadProgressContainer extends React.PureComponent {
   manifestFailedBanner = () => {
     return <AlertBanner
       title="There was an error downloading this efolder"
-      alertType="error"
-    >
+      alertType="error">
       <p>You can try to download this efolder again using the ‘Retry Download' button below.
       If the problem persists, please send in feedback.</p>
       <ul className="ee-button-list">
@@ -280,9 +279,9 @@ class DownloadProgressContainer extends React.PureComponent {
       return this.manifestFailedBanner();
     } else if (this.props.documentsFetchStatus === MANIFEST_DOWNLOAD_STATE.SUCCEEDED) {
       return this.completeBanner();
-    } else {
-      return this.inProgressBanner();
     }
+
+    return this.inProgressBanner();
   }
 
   render() {

--- a/client/src/containers/DownloadProgressContainer.jsx
+++ b/client/src/containers/DownloadProgressContainer.jsx
@@ -245,7 +245,6 @@ class DownloadProgressContainer extends React.PureComponent {
           <button
             className="usa-button-outline"
             onClick={this.restartDocumentDownload}
-            {...css({ marginLeft: '2rem' })}
           >
             Retry download
           </button>

--- a/client/src/containers/DownloadProgressContainer.jsx
+++ b/client/src/containers/DownloadProgressContainer.jsx
@@ -26,7 +26,8 @@ import {
   IN_PROGRESS_TAB,
   SUCCESS_TAB,
   DOCUMENT_DOWNLOAD_STATE,
-  MANIFEST_SOURCE_FETCH_STATE
+  MANIFEST_SOURCE_FETCH_STATE,
+  MANIFEST_DOWNLOAD_STATE
 } from '../Constants';
 import DownloadProgressTab from './DownloadProgressTab';
 import ManifestDocumentsTable from '../components/ManifestDocumentsTable';
@@ -233,27 +234,62 @@ class DownloadProgressContainer extends React.PureComponent {
     </section>;
   }
 
+  manifestFailedBanner = () => {
+    return <AlertBanner
+      title="There was an error while downloading"
+      alertType="error"
+    >
+      <p>We're sorry, but our systems had an error! Please try to download the case again, and if it still fails
+      please send in feedback.</p>
+      <ul className="ee-button-list">
+        <li>
+          <button
+            className="usa-button-outline"
+            onClick={this.restartDocumentDownload}
+            {...css({ marginLeft: '2rem' })}
+          >
+            Retry download
+          </button>
+        </li>
+      </ul>
+    </AlertBanner>;
+  }
+
+  progressTabsAndTable = () => {
+    return <React.Fragment>
+      <div className="cf-tab-navigation">
+        <DownloadProgressTab name={IN_PROGRESS_TAB} documentCount={this.props.documentsForStatus.progress.length}>
+          <ProgressIcon /> Progress ({this.props.documentsForStatus.progress.length})
+        </DownloadProgressTab>
+
+        <DownloadProgressTab name={SUCCESS_TAB} documentCount={this.props.documentsForStatus.success.length}>
+          <SuccessIcon /> Completed ({this.props.documentsForStatus.success.length})
+        </DownloadProgressTab>
+
+        <DownloadProgressTab name={ERRORS_TAB} documentCount={this.props.documentsForStatus.failed.length}>
+          <FailedIcon /> Errors ({this.props.documentsForStatus.failed.length})
+        </DownloadProgressTab>
+      </div>
+
+      { this.getActiveTable() }
+    </React.Fragment>;
+  }
+
+  banner = () => {
+    if (this.props.documentsFetchStatus === MANIFEST_DOWNLOAD_STATE.FAILED) {
+      return this.manifestFailedBanner();
+    } else if (this.props.documentsFetchStatus === MANIFEST_DOWNLOAD_STATE.SUCCEEDED) {
+      return this.completeBanner();
+    } else {
+      return this.inProgressBanner();
+    }
+  }
+
   render() {
     return <React.Fragment>
       <AppSegment filledBackground>
-
-        { documentDownloadComplete(this.props.documentsFetchStatus) ? this.completeBanner() : this.inProgressBanner() }
-
-        <div className="cf-tab-navigation">
-          <DownloadProgressTab name={IN_PROGRESS_TAB} documentCount={this.props.documentsForStatus.progress.length}>
-            <ProgressIcon /> Progress ({this.props.documentsForStatus.progress.length})
-          </DownloadProgressTab>
-
-          <DownloadProgressTab name={SUCCESS_TAB} documentCount={this.props.documentsForStatus.success.length}>
-            <SuccessIcon /> Completed ({this.props.documentsForStatus.success.length})
-          </DownloadProgressTab>
-
-          <DownloadProgressTab name={ERRORS_TAB} documentCount={this.props.documentsForStatus.failed.length}>
-            <FailedIcon /> Errors ({this.props.documentsForStatus.failed.length})
-          </DownloadProgressTab>
-        </div>
-
-        { this.getActiveTable() }
+        { this.banner() }
+        { this.props.documentsFetchStatus !== MANIFEST_DOWNLOAD_STATE.FAILED && this.progressTabsAndTable() }
       </AppSegment>
 
       <DownloadPageFooter>{ this.getFooterDownloadButton() }</DownloadPageFooter>

--- a/lib/tasks/spec_browsers.rake
+++ b/lib/tasks/spec_browsers.rake
@@ -4,6 +4,8 @@ begin
   namespace :spec do
     desc "Run the feature specs on supported browsers"
 
+    Rake::Task["assets:precompile"].execute
+
     RSpec::Core::RakeTask.new(:browsers) do |t|
       t.pattern = "spec/feature/**/*_spec.rb"
     end

--- a/spec/features/backend_error_flows_spec.rb
+++ b/spec/features/backend_error_flows_spec.rb
@@ -131,14 +131,14 @@ RSpec.feature "Backend Error Flows" do
         expect(page).to have_css ".cf-tab.cf-active", text: "Errors (1)"
         expect(page).to have_content "Some files could not be retrieved"
 
-        expect(page).to have_content Caseflow::DocumentTypes::TYPES[documents[1].type_id]
+        expect(page).to have_content Caseflow::DocumentTypes::TYPES[documents[0].type_id]
 
         # Clicking on progress shouldn't change tabs since there number is 0.
         click_on "Progress (0)"
-        expect(page).to have_content Caseflow::DocumentTypes::TYPES[documents[1].type_id]
-
-        click_on "Errors (1)"
         expect(page).to have_content Caseflow::DocumentTypes::TYPES[documents[0].type_id]
+
+        click_on "Completed (1)"
+        expect(page).to have_content Caseflow::DocumentTypes::TYPES[documents[1].type_id]
 
         within first(".usa-alert-body") do
           click_on "Download anyway"

--- a/spec/features/backend_error_flows_spec.rb
+++ b/spec/features/backend_error_flows_spec.rb
@@ -128,7 +128,7 @@ RSpec.feature "Backend Error Flows" do
           click_button "Start retrieving efolder"
         end
 
-        expect(page).to have_css ".cf-tab.cf-active", text: "Completed (1)"
+        expect(page).to have_css ".cf-tab.cf-active", text: "Errors (1)"
         expect(page).to have_content "Some files could not be retrieved"
 
         expect(page).to have_content Caseflow::DocumentTypes::TYPES[documents[1].type_id]
@@ -180,7 +180,7 @@ RSpec.feature "Backend Error Flows" do
           click_button "Start retrieving efolder"
         end
 
-        expect(page).to have_css ".cf-tab.cf-active", text: "Completed (1)"
+        expect(page).to have_css ".cf-tab.cf-active", text: "Errors (1)"
         expect(page).to have_content "Some files could not be retrieved"
 
         allow(Fakes::DocumentService).to receive(:v2_fetch_document_file).and_return("Test content")

--- a/spec/features/backend_error_flows_spec.rb
+++ b/spec/features/backend_error_flows_spec.rb
@@ -191,4 +191,31 @@ RSpec.feature "Backend Error Flows" do
       end
     end
   end
+
+  context "When manifest has failed status" do
+    let!(:manifest) { Manifest.create(file_number: veteran_id, fetched_files_status: "failed") }
+    let!(:source) do
+      [
+        manifest.sources.create(status: :success, name: "VBMS"),
+        manifest.sources.create(status: :success, name: "VVA")
+      ]
+    end
+    let!(:files_download) do
+      manifest.files_downloads.find_or_create_by(
+        user: User.first,
+        requested_zip_at: Time.zone.now
+      )
+    end
+
+    scenario "Download progress shows correct information" do
+      visit "/downloads/1"
+
+      expect(page).to have_css ".usa-alert-heading", text: "There was an error downloading this efolder"
+      expect(page).to have_content "You can try to download this efolder again"
+
+      click_on "Retry download"
+
+      expect(page).to have_content "Retrieving Files"
+    end
+  end
 end


### PR DESCRIPTION
Fixes: https://github.com/department-of-veterans-affairs/caseflow-efolder/issues/976

This PR address two issues:
1) Stops the download page from always making the progress tab active whenever the list of files changes.
2) Adds a failed message when the manifest status is set to failed. This means there was some error on our end when processing the download. The user should try again or send feedback if that fails.

**Test Plan**
- [ ] Start app, search for demo case then change the manifests' fetched_files_status to failed in the rails console. Ensure the new error message displays and the retry button successfully retries the download.
- [ ] When downloading a case, ensure the progress tab starts highlighted, and when completed either the completed or if there are any errors the error tab are highlighted. While in progress is the completed tab is selected, it should not revert to the progress tab.