### PR TITLE
Lowell/hacky promise flutter fix

### DIFF
--- a/client/src/apiActions.jsx
+++ b/client/src/apiActions.jsx
@@ -158,4 +158,4 @@ export const getDownloadHistory = (csrfToken) => (dispatch) => {
     );
 };
 
-export const setCurrentManifest = (manifestId) => (dispatch) => { outstandingPromise = manifestId; }
+export const setPromiseManifestId = (manifestId) => outstandingPromise = manifestId;

--- a/client/src/apiActions.jsx
+++ b/client/src/apiActions.jsx
@@ -21,6 +21,8 @@ import {
 } from './Constants';
 import { documentDownloadComplete, documentDownloadStarted, manifestFetchComplete } from './Utils';
 
+let outstandingPromise = null;
+
 const setStateFromResponse = (dispatch, resp) => {
   const respAttrs = resp.body.data.attributes;
 
@@ -78,6 +80,8 @@ export const pollManifestFetchEndpoint = (retryCount, manifestId, csrfToken) => 
   getRequest(`/api/v2/manifests/${manifestId}`, csrfToken).
     then(
       (response) => { // eslint-disable-line max-statements
+        if (outstandingPromise && outstandingPromise !== manifestId) return;
+
         setStateFromResponse(dispatch, response);
 
         // efolder #959: Large efolders can take more than 20 seconds to fetch manifests. Set timeout to 90 seconds
@@ -118,6 +122,8 @@ export const pollManifestFetchEndpoint = (retryCount, manifestId, csrfToken) => 
 };
 
 export const startDocumentDownload = (manifestId, csrfToken) => (dispatch) => {
+  outstandingPromise = manifestId;
+
   postRequest(`/api/v2/manifests/${manifestId}/files_downloads`, csrfToken).
     then(
       (resp) => {
@@ -136,6 +142,7 @@ export const startManifestFetch = (veteranId, csrfToken, redirectFunction) => (d
 
         const manifestId = resp.body.data.id;
 
+        outstandingPromise = manifestId;
         dispatch(setManifestId(manifestId));
         redirectFunction(`/downloads/${manifestId}`);
       },
@@ -150,3 +157,5 @@ export const getDownloadHistory = (csrfToken) => (dispatch) => {
       (err) => dispatch(setErrorMessage(buildErrorMessageFromResponse(err.response)))
     );
 };
+
+export const setCurrentManifest = (manifestId) => (dispatch) => { outstandingPromise = manifestId; }

--- a/client/src/apiActions.jsx
+++ b/client/src/apiActions.jsx
@@ -21,7 +21,11 @@ import {
 } from './Constants';
 import { documentDownloadComplete, documentDownloadStarted, manifestFetchComplete } from './Utils';
 
+// Solution to multiple outstanding promises changing state back and forth.
+// https://github.com/department-of-veterans-affairs/caseflow-efolder/pull/978
 let outstandingPromise = null;
+
+export const setPromiseManifestId = (manifestId) => outstandingPromise = manifestId;
 
 const setStateFromResponse = (dispatch, resp) => {
   const respAttrs = resp.body.data.attributes;
@@ -80,7 +84,9 @@ export const pollManifestFetchEndpoint = (retryCount, manifestId, csrfToken) => 
   getRequest(`/api/v2/manifests/${manifestId}`, csrfToken).
     then(
       (response) => { // eslint-disable-line max-statements
-        if (outstandingPromise && outstandingPromise !== manifestId) return;
+        if (outstandingPromise && outstandingPromise !== manifestId) {
+          return;
+        }
 
         setStateFromResponse(dispatch, response);
 
@@ -157,5 +163,3 @@ export const getDownloadHistory = (csrfToken) => (dispatch) => {
       (err) => dispatch(setErrorMessage(buildErrorMessageFromResponse(err.response)))
     );
 };
-
-export const setPromiseManifestId = (manifestId) => outstandingPromise = manifestId;

--- a/client/src/containers/DownloadContainer.jsx
+++ b/client/src/containers/DownloadContainer.jsx
@@ -11,7 +11,7 @@ import {
   resetDefaultManifestState,
   setManifestId
 } from '../actions';
-import { pollManifestFetchEndpoint, setCurrentManifest } from '../apiActions';
+import { pollManifestFetchEndpoint, setPromiseManifestId } from '../apiActions';
 import DownloadPageFooter from '../components/DownloadPageFooter';
 import DownloadPageHeader from '../components/DownloadPageHeader';
 import PageLoadingIndicator from '../components/PageLoadingIndicator';
@@ -39,7 +39,7 @@ class DownloadContainer extends React.PureComponent {
       !manifestFetchComplete(this.props.documentSources) ||
       this.props.documentsFetchStatus === MANIFEST_DOWNLOAD_STATE.IN_PROGRESS
     ) {
-      this.props.setCurrentManifest(manifestId);
+      setPromiseManifestId(manifestId);
       this.props.pollManifestFetchEndpoint(0, manifestId, this.props.csrfToken);
     }
   }
@@ -101,8 +101,7 @@ const mapDispatchToProps = (dispatch) => bindActionCreators({
   pollManifestFetchEndpoint,
   clearErrorMessage,
   resetDefaultManifestState,
-  setManifestId,
-  setCurrentManifest
+  setManifestId
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(DownloadContainer);

--- a/client/src/containers/DownloadContainer.jsx
+++ b/client/src/containers/DownloadContainer.jsx
@@ -11,7 +11,7 @@ import {
   resetDefaultManifestState,
   setManifestId
 } from '../actions';
-import { pollManifestFetchEndpoint } from '../apiActions';
+import { pollManifestFetchEndpoint, setCurrentManifest } from '../apiActions';
 import DownloadPageFooter from '../components/DownloadPageFooter';
 import DownloadPageHeader from '../components/DownloadPageHeader';
 import PageLoadingIndicator from '../components/PageLoadingIndicator';
@@ -39,6 +39,7 @@ class DownloadContainer extends React.PureComponent {
       !manifestFetchComplete(this.props.documentSources) ||
       this.props.documentsFetchStatus === MANIFEST_DOWNLOAD_STATE.IN_PROGRESS
     ) {
+      this.props.setCurrentManifest(manifestId);
       this.props.pollManifestFetchEndpoint(0, manifestId, this.props.csrfToken);
     }
   }
@@ -100,7 +101,8 @@ const mapDispatchToProps = (dispatch) => bindActionCreators({
   pollManifestFetchEndpoint,
   clearErrorMessage,
   resetDefaultManifestState,
-  setManifestId
+  setManifestId,
+  setCurrentManifest
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(DownloadContainer);


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/appeals-support/issues/1761 and https://github.com/department-of-veterans-affairs/appeals-support/issues/1762 identified an bug that caused the downloading page to flutter between several different cases. This was caused by outstanding javascript promises setting state back and forth.

This fix is not very elegant, but it does solve the problem by only allowing one outstanding promise at a time and only continuing the polling of the current promise if the manifest ID of the request it is trying to make matches the manifest ID of the outstanding promise.