### PR TITLE
Adding job length metrics

### DIFF
--- a/app/jobs/middleware/job_data_dog_metric_middleware.rb
+++ b/app/jobs/middleware/job_data_dog_metric_middleware.rb
@@ -1,0 +1,19 @@
+class JobDataDogMetricMiddleware
+  def call(_worker, _queue, _msg, body)
+    job_class = body["job_class"]
+
+    stopwatch = Benchmark.measure do
+      yield
+    end
+
+    DataDogService.emit_gauge(
+      metric_group: "job",
+      metric_name: "elapsed_time",
+      metric_value: stopwatch.real,
+      app_name: "eFolder",
+      attrs: {
+        job: job_class
+      }
+    )
+  end
+end

--- a/config/initializers/shoryuken.rb
+++ b/config/initializers/shoryuken.rb
@@ -1,4 +1,5 @@
 require "#{Rails.root}/app/jobs/middleware/job_prometheus_metric_middleware"
+require "#{Rails.root}/app/jobs/middleware/job_data_dog_metric_middleware"
 
 # set up default exponential backoff parameters
 ActiveJob::QueueAdapters::ShoryukenAdapter::JobWrapper
@@ -21,5 +22,6 @@ Shoryuken.configure_server do |config|
   # register all shoryuken middleware
   config.server_middleware do |chain|
     chain.add JobPrometheusMetricMiddleware
+    chain.add JobDataDogMetricMiddleware
   end
 end


### PR DESCRIPTION
We currently don't have metrics on how long our jobs are taking. This adds a data dog metric so we can start to analyze it.

**Test Plan**
- [ ] Ran DD Agent on my machine to ensure I could send in job length metrics.