### PR TITLE
Dealing with VVA's non-unique document ids

### DIFF
--- a/app/services/manifest_fetcher.rb
+++ b/app/services/manifest_fetcher.rb
@@ -5,14 +5,23 @@ class ManifestFetcher
 
   EXCEPTIONS = [VBMS::ClientError, VVA::ClientError].freeze
 
-  # VVA has a bug where they return these ids in multiple veteran's eFolders. This violates our unique constraint
-  # and since documents should be unique to veterans, we have decided to filter out these documents.
-  VVA_DUPLICATE_ID_LIST = %w[{F291C1BC-FCDE-4C58-8544-B4FCE2E59008} {4F277E03-66ED-4263-9A43-075CFFF72393}].freeze
+  # We've found for some veteran eFolders, VVA returns the same document multiple times. We filter those out here.
+  def remove_duplicates(documents)
+    list_of_ids = {}
+
+    documents.select do |doc|
+      if !list_of_ids[doc.document_id]
+        list_of_ids[doc.document_id] = true
+        true
+      else
+        false
+      end
+    end
+  end
 
   def process
-    documents = manifest_source.service.v2_fetch_documents_for(manifest_source).reject do |document|
-      VVA_DUPLICATE_ID_LIST.include?(document.document_id)
-    end
+    documents = remove_duplicates(manifest_source.service.v2_fetch_documents_for(manifest_source))
+
     DocumentCreator.new(manifest_source: manifest_source, external_documents: documents).create
     manifest_source.update!(status: :success, fetched_at: Time.zone.now)
     documents

--- a/db/migrate/20180412192820_remove_unique_version_id_index_to_record.rb
+++ b/db/migrate/20180412192820_remove_unique_version_id_index_to_record.rb
@@ -1,0 +1,5 @@
+class RemoveUniqueVersionIdIndexToRecord < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :records, column: :version_id
+  end
+end

--- a/db/migrate/20180412192848_add_unique_version_id_manifest_id_index_to_record.rb
+++ b/db/migrate/20180412192848_add_unique_version_id_manifest_id_index_to_record.rb
@@ -1,0 +1,7 @@
+class AddUniqueVersionIdManifestIdIndexToRecord < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :records, [:version_id, :manifest_source_id], unique: true, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20180412193906_remove_manifest_id_version_id_index_to_record.rb
+++ b/db/migrate/20180412193906_remove_manifest_id_version_id_index_to_record.rb
@@ -1,0 +1,5 @@
+class RemoveManifestIdVersionIdIndexToRecord < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :records, column: [:manifest_source_id, :version_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180323021917) do
+ActiveRecord::Schema.define(version: 20180412193906) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -128,8 +128,7 @@ ActiveRecord::Schema.define(version: 20180323021917) do
     t.string "series_id"
     t.integer "version"
     t.index ["manifest_source_id", "series_id"], name: "index_records_on_manifest_source_id_and_series_id"
-    t.index ["manifest_source_id", "version_id"], name: "index_records_on_manifest_source_id_and_version_id"
-    t.index ["version_id"], name: "index_records_on_version_id", unique: true
+    t.index ["version_id", "manifest_source_id"], name: "index_records_on_version_id_and_manifest_source_id", unique: true
   end
 
   create_table "searches", force: :cascade do |t|

--- a/spec/services/manifest_fetcher_spec.rb
+++ b/spec/services/manifest_fetcher_spec.rb
@@ -55,10 +55,11 @@ describe ManifestFetcher do
         end
       end
 
-      context "when VVA client returns manifest with {F291C1BC-FCDE-4C58-8544-B4FCE2E59008}" do
+      context "when VVA client returns manifest with duplicates" do
         let(:documents) do
           [
-            OpenStruct.new(document_id: "{F291C1BC-FCDE-4C58-8544-B4FCE2E59008}", series_id: "3"),
+            OpenStruct.new(document_id: "1", series_id: "3"),
+            OpenStruct.new(document_id: "2", series_id: "4"),
             OpenStruct.new(document_id: "2", series_id: "4")
           ]
         end
@@ -67,11 +68,12 @@ describe ManifestFetcher do
           allow(VVAService).to receive(:v2_fetch_documents_for).and_return(documents)
         end
 
-        it "saves manifest status as success and updated fetched at" do
-          expect(subject.size).to eq 1
+        it "only saves duplicate once" do
+          expect(subject.size).to eq 2
           expect(source.reload.status).to eq "success"
           expect(source.reload.fetched_at).to_not be_nil
-          expect(subject[0].document_id).to eq "2"
+          expect(subject[0].document_id).to eq "1"
+          expect(subject[1].document_id).to eq "2"
         end
       end
 


### PR DESCRIPTION
This is to deal (hopefully once and for all) with the duplicate document ids we receive from VVA. We will stop excluding documents. Instead, we'll download them all to eX. However, we change around our uniqueness constraints. This PR does three things:

1) Remove the unique index on version_id. Instead we replace that with a uniqueness constraint on [version_id, manifest_source_id]. This means we can only have a document appear once per manifest source. It also means we can still have fast lookups keying in with either `version_id` or `version_id and manifest_source_id`. 
2) We remove the [manifest_source_id, version_id] index since it should be superseded by the above index.
3) We add logic in manifest_fetcher to remove duplicates that appear in a single manifest source.

**Test Plan**
- [ ] Automated tests to ensure we filter out duplicates within a manifest source.