### PR TITLE
Adding middleware to report errors correctly

### DIFF
--- a/app/jobs/middleware/job_raven_reporter_middleware.rb
+++ b/app/jobs/middleware/job_raven_reporter_middleware.rb
@@ -1,0 +1,12 @@
+# This job captures all Shoryuken job exceptions and forwards them to Raven.
+#
+class JobRavenReporterMiddleware
+  def call(_worker, queue, _msg, body)
+    yield
+  rescue StandardError => ex
+    tags = { job: body["job_class"], queue: queue }
+    context = { message: body }
+    Raven.capture_exception(ex, tags: tags, extra: context)
+    raise
+  end
+end

--- a/config/initializers/shoryuken.rb
+++ b/config/initializers/shoryuken.rb
@@ -1,5 +1,6 @@
 require "#{Rails.root}/app/jobs/middleware/job_prometheus_metric_middleware"
 require "#{Rails.root}/app/jobs/middleware/job_data_dog_metric_middleware"
+require "#{Rails.root}/app/jobs/middleware/job_raven_reporter_middleware"
 
 # set up default exponential backoff parameters
 ActiveJob::QueueAdapters::ShoryukenAdapter::JobWrapper
@@ -23,5 +24,6 @@ Shoryuken.configure_server do |config|
   config.server_middleware do |chain|
     chain.add JobPrometheusMetricMiddleware
     chain.add JobDataDogMetricMiddleware
+    chain.add JobRavenReporterMiddleware
   end
 end


### PR DESCRIPTION
Fixes: https://github.com/department-of-veterans-affairs/caseflow-efolder/issues/984

We lost a lot of detail in our Sentry error reporting when we move from sidekiq to SQS. This adds middleware to report the same level of detail.

**Test Plan**
- [ ] Printed out all the things it plans to send to Sentry and looks like the right data. Since it's only copied from caseflow, seems like a safe addition.