### PR TITLE
Release message after SIGTERM

### DIFF
--- a/app/jobs/middleware/job_sigterm_middleware.rb
+++ b/app/jobs/middleware/job_sigterm_middleware.rb
@@ -1,0 +1,16 @@
+class JobSigtermMiddleware
+  # When Shoryuken receives a call to shutdown (i.e. SIGTERM), it stops jobs that
+  # are not complete. Since some of our jobs have long visibility timeouts they
+  # may not be restarted for a long time. This gets around that problem by
+  # forcing the visibility timeout on a job that did not complete to be 0, as is
+  # suggested here: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html#terminating-message-visibility-timeout
+  def call(_worker, _queue, msg, _body)
+    job_finished = false
+    yield
+    # Note we only get to this point if the job was allowed to finish.
+    job_finished = true
+  ensure
+    # Ensures always execute even on SIGTERMs (unless we cannot wrap up fast enough and are killed)
+    msg.visibility_timeout = 0 if !job_finished
+  end
+end

--- a/app/jobs/v2/package_files_job.rb
+++ b/app/jobs/v2/package_files_job.rb
@@ -1,7 +1,7 @@
 class V2::PackageFilesJob < ActiveJob::Base
   queue_as :med_priority
 
-  SECONDS_TO_AUTO_UNLOCK = 14_400
+  SECONDS_TO_AUTO_UNLOCK = 21_600
 
   def perform(manifest)
     s = Redis::Semaphore.new("package_files_#{manifest.id}".to_s,

--- a/app/jobs/v2/package_files_job.rb
+++ b/app/jobs/v2/package_files_job.rb
@@ -1,7 +1,7 @@
 class V2::PackageFilesJob < ActiveJob::Base
   queue_as :med_priority
 
-  SECONDS_TO_AUTO_UNLOCK = 43_200
+  SECONDS_TO_AUTO_UNLOCK = 14_400
 
   def perform(manifest)
     s = Redis::Semaphore.new("package_files_#{manifest.id}".to_s,

--- a/config/initializers/shoryuken.rb
+++ b/config/initializers/shoryuken.rb
@@ -1,6 +1,7 @@
 require "#{Rails.root}/app/jobs/middleware/job_prometheus_metric_middleware"
 require "#{Rails.root}/app/jobs/middleware/job_data_dog_metric_middleware"
 require "#{Rails.root}/app/jobs/middleware/job_raven_reporter_middleware"
+require "#{Rails.root}/app/jobs/middleware/job_sigterm_middleware"
 
 # set up default exponential backoff parameters
 ActiveJob::QueueAdapters::ShoryukenAdapter::JobWrapper
@@ -25,5 +26,6 @@ Shoryuken.configure_server do |config|
     chain.add JobPrometheusMetricMiddleware
     chain.add JobDataDogMetricMiddleware
     chain.add JobRavenReporterMiddleware
+    chain.add JobSigtermMiddleware
   end
 end


### PR DESCRIPTION
Connects: https://github.com/department-of-veterans-affairs/caseflow-efolder/issues/975

Lots of interesting things to report about Ruby, SQS and Shoryuken.

1) Ensure blocks are run even when a process is shutting down. When shoryuken receives a SIGTERM it goes into a shutdown cycle. It somehow terminates any running jobs (I can't figure out how since I cannot seem to catch a relevant exception). But since ensure blocks still run, the locks we acquire on each job start are released.
2) Setting visibility timeout of a message to 0 allows another worker to pick it up immediately.
3) Shoryuken allows you to write middleware where you can modify the SQS visibility timeout.

Putting these altogether gives us the ability to use ensure blocks to make visibility timeouts 0 when Shoryuken is shutting down.

I've also reduced the timeout on our package files job lock. Over the past 10 days the longest we've waited for a job is 5,850 seconds. The average is around 1,000 seconds. So our current lock time of 12 hours seems too long. I've moved it down to a still very comfortable 6 hours (21,200 seconds).

Data can be found here: https://app.datadoghq.com/dash/422343/efolder-express-overview?live=true&page=0&is_auto=false&from_ts=1521065479628&to_ts=1523657479628&tile_size=m&fullscreen=false

Note I'm not actually sure all of this is a good idea, so I welcome y'alls thoughts on it!