### PR TITLE
Set visibility timeout to 30 seconds instead of 0

### DIFF
--- a/app/jobs/middleware/job_sigterm_middleware.rb
+++ b/app/jobs/middleware/job_sigterm_middleware.rb
@@ -11,6 +11,6 @@ class JobSigtermMiddleware
     job_finished = true
   ensure
     # Ensures always execute even on SIGTERMs (unless we cannot wrap up fast enough and are killed)
-    msg.visibility_timeout = 0 if !job_finished
+    msg.visibility_timeout = 30 if !job_finished
   end
 end


### PR DESCRIPTION
It is not recommended to set visibility timeout to 0. Read here: 
https://github.com/aws/aws-sdk-js/issues/1279#issuecomment-268830676

Sentry error: https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/1190/