### PR TITLE
Changing rails logger to shoryuken logger

### DIFF
--- a/config/initializers/shoryuken.rb
+++ b/config/initializers/shoryuken.rb
@@ -21,6 +21,9 @@ end
 
 Shoryuken.configure_server do |config|
 
+  Rails.logger = Shoryuken::Logging.logger
+  Rails.logger.level = Logger::INFO
+
   # register all shoryuken middleware
   config.server_middleware do |chain|
     chain.add JobPrometheusMetricMiddleware


### PR DESCRIPTION
Currently Shoryuken does not output job id for every statement in production. However, it does in development (unclear why...) This change is from here: https://github.com/phstc/shoryuken/wiki/Rails-Integration-Active-Job. It's unclear if it will work in production, but seems like it can't hurt.

**AC**
- [ ] Every log line should have a job id.