### PR TITLE
Move lock from job to model

### DIFF
--- a/app/models/manifest_source.rb
+++ b/app/models/manifest_source.rb
@@ -17,9 +17,13 @@ class ManifestSource < ApplicationRecord
 
   delegate :file_number, to: :manifest
 
+  SECONDS_TO_AUTO_UNLOCK = 5
+
   def start!
-    s = Redis::Semaphore.new("download_manifest_source_#{id}".to_s, url: Rails.application.secrets.redis_url)
-    s.lock do
+    s = Redis::Semaphore.new("download_manifest_source_#{id}".to_s,
+                             url: Rails.application.secrets.redis_url,
+                             expiration: SECONDS_TO_AUTO_UNLOCK)
+    s.lock(SECONDS_TO_AUTO_UNLOCK) do
       return if current? || pending?
       update(status: :pending)
     end


### PR DESCRIPTION
Connects #995.

First half of the fix for #995 here. The ultimate fix is to offload all of the queue handling to SQS by way of Shoryuken and make extensive use of [SQS ChangeMessageVisibility](https://github.com/phstc/shoryuken/wiki/Worker-options#auto_visibility_timeout) to ensure that the job is always in process or soon to be made available on the queue.

In order to allow for that approach, we need to have jobs execute when we fire them off. The Redis/Semaphore lock could prevent that from happening (if an EC2 instance is killed while the job is running we will try to run it again when SQS makes the message available, but will run into the lock once we start executing the job). Since the lock exists to prevent us from doing the work in the job multiple times, we can move that lock out of the job and instead use the lock to make sure we don't create more than one job for the same manifest.