### PR TITLE
Automatically increase lease on SQS message while running job

### DIFF
--- a/config/initializers/shoryuken.rb
+++ b/config/initializers/shoryuken.rb
@@ -5,7 +5,8 @@ require "#{Rails.root}/app/jobs/middleware/job_sigterm_middleware"
 
 # set up default exponential backoff parameters
 ActiveJob::QueueAdapters::ShoryukenAdapter::JobWrapper
-  .shoryuken_options(retry_intervals: [3.seconds, 30.seconds, 5.minutes, 30.minutes, 2.hours, 5.hours])
+  .shoryuken_options(auto_visibility_timeout: true,
+                     retry_intervals: [3.seconds, 30.seconds, 5.minutes, 30.minutes, 2.hours, 5.hours])
 
 if Rails.application.config.sqs_endpoint
   # override the sqs_endpoint
@@ -14,13 +15,12 @@ end
 
 if Rails.application.config.sqs_create_queues
   # create the development queues
-  Shoryuken::Client.sqs.create_queue({ queue_name: ActiveJob::Base.queue_name_prefix + '_low_priority' })
-  Shoryuken::Client.sqs.create_queue({ queue_name: ActiveJob::Base.queue_name_prefix + '_med_priority' })
-  Shoryuken::Client.sqs.create_queue({ queue_name: ActiveJob::Base.queue_name_prefix + '_high_priority' })
+  Shoryuken::Client.sqs.create_queue(queue_name: ActiveJob::Base.queue_name_prefix + "_low_priority")
+  Shoryuken::Client.sqs.create_queue(queue_name: ActiveJob::Base.queue_name_prefix + "_med_priority")
+  Shoryuken::Client.sqs.create_queue(queue_name: ActiveJob::Base.queue_name_prefix + "_high_priority")
 end
 
 Shoryuken.configure_server do |config|
-
   Rails.logger = Shoryuken::Logging.logger
   Rails.logger.level = Logger::INFO
 


### PR DESCRIPTION
Connects #995. Part 2 of 3 (final PR will be in appeals-deployment) of attempt to fix the SQS models stuck in pending state when jobs are killed by deploys issue.

Adds the [auto_visibility_timeout parameter](https://github.com/phstc/shoryuken/wiki/Worker-options#auto_visibility_timeout) to the shoryuken options so we can reduce the default visibility timeout in SQS and have each job increase the visibility timeout when the job is about to be made available again in SQS.