### PR TITLE
upgrades connect_vbms version to support SHA256

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,7 @@ gem "mini_magick"
 gem "httpclient"
 
 gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", branch: "07a398fb0102ad93684f5423e73be68ba97c74d2"
-gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "1728de8d71ac9d7b3948aa8b6e2fa4e165b16810"
+gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "fd9771bafc48d98b56909c4466721da312a22739"
 gem "connect_vva", git: "https://github.com/department-of-veterans-affairs/connect_vva.git", ref: "ecc1da3f1027e6c270af264de46dc1cb4974fa47"
 
 # catch problematic migrations

--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,7 @@ gem "mini_magick"
 gem "httpclient"
 
 gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", branch: "07a398fb0102ad93684f5423e73be68ba97c74d2"
-gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "f014b4772385814cd510712c46698653866f99dd"
+gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "1728de8d71ac9d7b3948aa8b6e2fa4e165b16810"
 gem "connect_vva", git: "https://github.com/department-of-veterans-affairs/connect_vva.git", ref: "ecc1da3f1027e6c270af264de46dc1cb4974fa47"
 
 # catch problematic migrations

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,8 +21,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vbms.git
-  revision: 1728de8d71ac9d7b3948aa8b6e2fa4e165b16810
-  ref: 1728de8d71ac9d7b3948aa8b6e2fa4e165b16810
+  revision: fd9771bafc48d98b56909c4466721da312a22739
+  ref: fd9771bafc48d98b56909c4466721da312a22739
   specs:
     connect_vbms (1.2.0)
       httpclient (~> 2.8.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,10 +21,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vbms.git
-  revision: f014b4772385814cd510712c46698653866f99dd
-  ref: f014b4772385814cd510712c46698653866f99dd
+  revision: 1728de8d71ac9d7b3948aa8b6e2fa4e165b16810
+  ref: 1728de8d71ac9d7b3948aa8b6e2fa4e165b16810
   specs:
-    connect_vbms (1.0.1)
+    connect_vbms (1.2.0)
       httpclient (~> 2.8.0)
       httpi (~> 2.4)
       mail


### PR DESCRIPTION
### Description
Installs a newer version of the `connect_vbms` gem - this one supports SHA256 digests, which is critical for the upgraded certs VBMS is using in their uat environment. 

(the changes in `connect_vbms`: see [connect_vbms#178](https://github.com/department-of-veterans-affairs/connect_vbms/pull/178))

### Testing Plan

This is how I've been testing out the gem from an app server:
```
require 'vbms'
client = VBMS::Client.from_env_vars(env_name: ENV["CONNECT_VBMS_ENV"], use_forward_proxy:true)
request = VBMS::Requests::FindDocumentSeriesReference.new("<id>")
res = client.send_request(request)
```
Before the fix, we had been observing 503s on uat. After deploying this fix, we are seeing success responses.
