### PR TITLE
Add user_id index on files_downloads table

### DIFF
--- a/db/migrate/20180516212947_add_user_id_index_to_files_download.rb
+++ b/db/migrate/20180516212947_add_user_id_index_to_files_download.rb
@@ -1,0 +1,7 @@
+class AddUserIdIndexToFilesDownload < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :files_downloads, [:user_id], algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180412193906) do
+ActiveRecord::Schema.define(version: 20180516212947) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -87,6 +87,7 @@ ActiveRecord::Schema.define(version: 20180412193906) do
     t.datetime "updated_at", null: false
     t.datetime "requested_zip_at"
     t.index ["manifest_id", "user_id"], name: "index_files_downloads_on_manifest_id_and_user_id"
+    t.index ["user_id"], name: "index_files_downloads_on_user_id"
   end
 
   create_table "manifest_sources", force: :cascade do |t|


### PR DESCRIPTION
One possible solution to the increased load on efolder's database is to add an index on the user_id column of files_download since we lookup by that column very frequently and the query that looks up by that column is a big problem child. Extended discussion in slack https://dsva.slack.com/files/U7GARLGMB/FAQSJNS0L/image.png