### PR TITLE
In race condition rescue ActiveRecord::RecordNotUnique

### DIFF
--- a/app/services/document_creator.rb
+++ b/app/services/document_creator.rb
@@ -42,6 +42,14 @@ class DocumentCreator
         Record.create_from_external_document(manifest_source, document)
       end
     end
+  rescue ActiveRecord::RecordNotUnique
+    # This can happen when two jobs are run simultaneously. Both jobs delete the records
+    # then the first job adds all the records and finishes its transaction. The records are
+    # committed so when the second job then tries to add the same documents, it encounters
+    # the unique constraint on the table and an error is raised.
+    #
+    # We can ignore this exception because the race condition that causes it
+    # means that another thread just created these records.
   end
 
   # Override the getter to return only non-restricted documents

--- a/app/services/document_creator.rb
+++ b/app/services/document_creator.rb
@@ -50,6 +50,7 @@ class DocumentCreator
     #
     # We can ignore this exception because the race condition that causes it
     # means that another thread just created these records.
+    Rails.logger.info "ActiveRecord::RecordNotUnique thrown for ManifestSource #{manifest_source.id}"
   end
 
   # Override the getter to return only non-restricted documents


### PR DESCRIPTION
If a download manifest job is run twice simultaneously (as can happen with SQS at least once delivery) we can get a race condition where we try to create records in a transaction that have already been created. In this case it should be safe to catch the error, as the other thread that won the race should have already written the records.