### PR TITLE
Die if attempt to create FilesDownload object fails

### DIFF
--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -123,8 +123,8 @@ class Manifest < ApplicationRecord
   end
 
   def self.find_or_create_by_user(user:, file_number:)
-    manifest = Manifest.find_or_create_by(file_number: file_number)
-    manifest.files_downloads.find_or_create_by(user: user)
+    manifest = Manifest.find_or_create_by!(file_number: file_number)
+    manifest.files_downloads.find_or_create_by!(user: user)
     manifest
   end
 


### PR DESCRIPTION
Related to the `Caseflow::Error::ClientRequestError` we are seeing when Caseflow makes a request to `GET /api/v2/manifests/#{manifest_id}`: https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/1539/

On the caseflow side, we attempt to get a list of documents for some Veteran by making a request to `POST /api/v2/manifests` (with the Veteran ID in the request headers). We then poll the `GET /api/v2/manifests/#{manifest_id}` endpoint to determine if we have finished fetching the manifest from VVA/VBMS. In this case we failed to create both Manifest and FilesDownload records in `Manifest.find_or_create_by_user()` and the subsequent call to `ManifestsController.progress()` appropriately returned a 400.

The manifest-related actions available through the API rely on the existence of Manifest and FilesDownloads records, so this change causes the application to throw an exception if either of those create actions fail.