### PR TITLE
Demonstrate linear increase of db connections per record in efolder

### DIFF
--- a/lib/fakes/document_service.rb
+++ b/lib/fakes/document_service.rb
@@ -46,6 +46,21 @@ class Fakes::DocumentService
       manifest_load: 4,
       num_docs: 10,
       max_file_load: 3
+    },
+    "DEMO10" => {
+      manifest_load: 1,
+      num_docs: 10,
+      max_file_load: 1
+    },
+    "DEMO100" => {
+      manifest_load: 1,
+      num_docs: 100,
+      max_file_load: 1
+    },
+    "DEMO1000" => {
+      manifest_load: 1,
+      num_docs: 1000,
+      max_file_load: 1
     }
   }.freeze
 


### PR DESCRIPTION
Connects #1018.

This is a demonstration only, not to be merged.

This branch shows that GET requests to efolder's `/api/v2/manifests/:id` result in a number of database transactions proportional to the number of records in the efolder we are fetching. Specifically, we make 2n + roughly a dozen discrete requests to the database where n = number of records in an efolder. If we are making this request for an efolder with 1,000 records we will make ~2,014 database requests.

## Reproduction steps
1. Run the efolder application locally and direct the statistics we gather to some output file: `efolder $> DB_LOG_OUT=~/Projects/efolder/tr_cnt.txt foreman start`
2. Watch this file throughout the process to monitor number of requests we make in different phases of the process for different numbers of records: `$> tail -f ~/Projects/efolder/tr_cnt.txt`
3. From the efolder home page search for `DEMO10` (a test efolder with 10 dummy records in it)
4. By viewing `tr_cnt.txt` notice that we make roughly 12 distinct requests to the database for these requests as we are waiting for both manifest source fetches to complete. Once the manifest source fetches complete we will send a final response to the frontend whose lifetime makes ~32 db requests (2 * 10 + 12).
5. Click "Start retrieving efolder" to kick of the download files job and notice that the rails application is still making ~32 db requests for every HTTP request it receives from the frontend.
6. Repeat this behaviour with DEMO100 (100 records) and DEMO1000 (1000 records) to demonstrate that the number of database requests scales linearly (2n + ~12) with the number of records.