### PR TITLE
Include packages via github not npm

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@department-of-veterans-affairs/caseflow-frontend-toolkit": "^2.2.0",
+    "@department-of-veterans-affairs/caseflow-frontend-toolkit": "https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#a05abe6",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
@@ -37,7 +37,7 @@
     "webpack": "^3.11.0"
   },
   "devDependencies": {
-    "@department-of-veterans-affairs/eslint-config-appeals": "^1.0.2",
+    "@department-of-veterans-affairs/eslint-config-appeals": "https://github.com/department-of-veterans-affairs/eslint-config-appeals#f50522e",
     "eslint": "^4.15.0"
   }
 }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -54,9 +54,9 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@department-of-veterans-affairs/caseflow-frontend-toolkit@^2.2.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/caseflow-frontend-toolkit/-/caseflow-frontend-toolkit-2.4.0.tgz#bce96f46155637a0c5f175adb213d4dd6a3a2c37"
+"@department-of-veterans-affairs/caseflow-frontend-toolkit@https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#a05abe6":
+  version "2.5.8"
+  resolved "https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#a05abe6c805c75e29ce9cfdf7811f976657f9507"
   dependencies:
     classnames "^2.2.5"
     glamor "^2.20.40"
@@ -67,9 +67,9 @@
     redux-perf-middleware "^1.2.2"
     redux-thunk "^2.2.0"
 
-"@department-of-veterans-affairs/eslint-config-appeals@^1.0.2":
+"@department-of-veterans-affairs/eslint-config-appeals@https://github.com/department-of-veterans-affairs/eslint-config-appeals#f50522e":
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/eslint-config-appeals/-/eslint-config-appeals-1.0.2.tgz#9996dae98052e5a767d763823ded5561676ffdb9"
+  resolved "https://github.com/department-of-veterans-affairs/eslint-config-appeals#f50522eefd81342a5a75cf13d02eb856ba23399c"
   dependencies:
     babel-eslint "^8.0.2"
     eslint-plugin-import "^2.8.0"


### PR DESCRIPTION
Reduces the chance of a security vulnerability in case someone access our NPM tokens.