### PR TITLE
Doesn't prevent login when app is out of service

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ In a separate terminal, watch for webpack changes:
 
 > $ cd client && yarn run build --watch
 
-And in another seperate terminal, start a jobs worker
+And in another separate terminal, start a jobs worker
 
 > $ bundle exec shoryuken start -q efolder_development_high_priority efolder_development_low_priority efolder_development_med_priority -R
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Now start both the rails server,
 
 > $ rails s
 
-In a separate terminal, watch for webpack changes:
+In a separate terminal, watch for webpack changes
 
 > $ cd client && yarn run build --watch
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,11 @@ Now start both the rails server,
 
 > $ rails s
 
-And in a seperate terminal, start a jobs worker
+In a separate terminal, watch for webpack changes:
+
+> $ cd client && yarn run build --watch
+
+And in another seperate terminal, start a jobs worker
 
 > $ bundle exec shoryuken start -q efolder_development_high_priority efolder_development_low_priority efolder_development_med_priority -R
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < BaseController
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
-  before_action :check_out_of_service
+  before_action :check_out_of_service, except: :authenticate
   before_action :authenticate
   before_action :set_raven_user
   before_action :check_v2_app_access

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,5 @@
 class SessionsController < ApplicationController
+  skip_before_action :check_out_of_service
   skip_before_action :verify_authenticity_token, only: [:create]
   skip_before_action :authenticate, only: [:create]
   skip_before_action :check_v2_app_access

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -16,14 +16,11 @@ Rails.application.configure do
   if Rails.root.join('tmp/caching-dev.txt').exist?
     config.action_controller.perform_caching = true
 
-    config.cache_store = :memory_store
     config.public_file_server.headers = {
       'Cache-Control' => "public, max-age=#{2.days.seconds.to_i}"
     }
   else
     config.action_controller.perform_caching = false
-
-    config.cache_store = :null_store
   end
 
   # Don't care if the mailer can't send.


### PR DESCRIPTION
Connects https://github.com/department-of-veterans-affairs/caseflow-efolder/issues/1029

# Testing
- Check out the master branch and start the app connected to Redis as the cache 
- Log out
- Run `Rails.cache.write("out_of_service", true)`
- Attempt to log in
- Log in will fail
- Check out this branch
- Attempt to log in
- User will be successfully logged in, and "Technical Difficulties" page will be displayed

