### PR TITLE
[Privacy] Anonymize IP address in Google Analytics

### DIFF
--- a/app/views/gui/single_page_app.html.erb
+++ b/app/views/gui/single_page_app.html.erb
@@ -16,6 +16,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', '<%= Rails.configuration.analytics_account %>', 'auto');
+      ga('set', 'anonymizeIp', true)
       ga('send', 'pageview', '<%= current_ga_path %>');
 
       window.analyticsPageView = function(page) { ga('send', 'pageview', page) }


### PR DESCRIPTION
This change will request that Google mask the last octet of the IP address in memory before performing further processing.
https://support.google.com/analytics/answer/2763052?hl=en