### PR TITLE
[Privacy] Anonymize IP address in Google Analytics

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,6 +53,7 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
     ga('create', '<%= Rails.configuration.analytics_account %>', 'auto');
+    ga('set', 'anonymizeIp', true);
     ga('send', 'pageview', '<%= current_ga_path %>');
   </script>
 


### PR DESCRIPTION
This change will request that Google mask the last octet of the IP address in memory before performing further processing.
https://support.google.com/analytics/answer/2763052?hl=en