### PR TITLE
Exclude serialization of manifest sources and records when requesting home page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,7 +48,7 @@ class ApplicationController < BaseController
       dropdownUrls: dropdown_urls,
       efolderAccessImagePath: ActionController::Base.helpers.image_path("help/efolder-access.png"),
       feedbackUrl: feedback_url,
-      recentDownloads: ActiveModelSerializers::SerializableResource.new(current_user.recent_downloads, each_serializer: Serializers::V2::ManifestSerializer),
+      recentDownloads: ActiveModelSerializers::SerializableResource.new(current_user.recent_downloads, each_serializer: Serializers::V2::HistorySerializer),
       referenceGuidePath: ActionController::Base.helpers.asset_path("reference_guide.pdf"),
       trainingGuidePath: ActionController::Base.helpers.asset_path("training_guide.pdf"),
       userDisplayName: current_user.try(:display_name),


### PR DESCRIPTION
Connects to #1045 
department-of-veterans-affairs/appeals-support#3189
department-of-veterans-affairs/appeals-support#3192

To test locally: 
1. Seed local database with 50 "recent" manifests and around 50 records for each manifest/manifest sources.
2. Load the home page logged in as the same user from step 1. 
3. Home page should load relatively quickly
4. Make sure `ManifestSource Load` does NOT show up in server log