### PR TITLE
Update nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,7 +243,7 @@ GEM
       thor (~> 0.19)
     newrelic_rpm (4.8.0.341)
     nio4r (2.2.0)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     nori (2.6.0)
     omniauth (1.8.1)


### PR DESCRIPTION
`bundle exec rake lint` (and entire build) should pass. 