### PR TITLE
Remove recentDownloads from initial react data

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,7 +48,6 @@ class ApplicationController < BaseController
       dropdownUrls: dropdown_urls,
       efolderAccessImagePath: ActionController::Base.helpers.image_path("help/efolder-access.png"),
       feedbackUrl: feedback_url,
-      recentDownloads: ActiveModelSerializers::SerializableResource.new(current_user.recent_downloads, each_serializer: Serializers::V2::HistorySerializer),
       referenceGuidePath: ActionController::Base.helpers.asset_path("reference_guide.pdf"),
       trainingGuidePath: ActionController::Base.helpers.asset_path("training_guide.pdf"),
       userDisplayName: current_user.try(:display_name),


### PR DESCRIPTION
Connected to #1042 

To test:
1. Run app in dev environment
2. Search for 'DEMO1' and download file
3. Restart the server, clear the cookies and login as the same user from steps 1 and 2
4. Make sure recent download shows on home page
5. Make sure server log does not show loading of FilesDownloads as part of DownloadsController#new step 

<img width="1432" alt="screen shot 2018-11-02 at 1 21 02 pm" src="https://user-images.githubusercontent.com/4960030/47932875-3b44bd00-dea9-11e8-9d15-00301abd1a32.png">
