### PR TITLE
Make current user info available to DownloadManifestJob

### DIFF
--- a/app/jobs/v2/download_manifest_job.rb
+++ b/app/jobs/v2/download_manifest_job.rb
@@ -1,12 +1,13 @@
 class V2::DownloadManifestJob < ActiveJob::Base
   queue_as :high_priority
 
-  def perform(manifest_source, ui_user)
+  def perform(manifest_source, user = nil)
     return if manifest_source.current?
+    RequestStore.store[:current_user] = user if user
 
     documents = ManifestFetcher.new(manifest_source: manifest_source).process
 
-    V2::SaveFilesInS3Job.perform_later(manifest_source) if documents.present? && !ui_user
+    V2::SaveFilesInS3Job.perform_later(manifest_source) if documents.present? && !ApplicationController.helpers.ui_user?
   rescue StandardError => e
     manifest_source.update!(status: :failed)
     raise e

--- a/app/models/manifest_source.rb
+++ b/app/models/manifest_source.rb
@@ -29,7 +29,7 @@ class ManifestSource < ApplicationRecord
     end
 
     begin
-      V2::DownloadManifestJob.perform_later(self, ui_user?)
+      V2::DownloadManifestJob.perform_later(self, RequestStore[:current_user])
     rescue StandardError
       update(status: :initialized)
 


### PR DESCRIPTION
When calling BGS service from DownloadManifestJob active job, RequestStore[:current_user] is not available since it's stored only within the main process. This PR fixes that.  