### PR TITLE
Make current user info available to DownloadManifestJob

### DIFF
--- a/app/jobs/v2/download_manifest_job.rb
+++ b/app/jobs/v2/download_manifest_job.rb
@@ -1,12 +1,13 @@
 class V2::DownloadManifestJob < ActiveJob::Base
   queue_as :high_priority
 
-  def perform(manifest_source, ui_user)
+  def perform(manifest_source, user = nil)
     return if manifest_source.current?
+    RequestStore.store[:current_user] = user if user
 
     documents = ManifestFetcher.new(manifest_source: manifest_source).process
 
-    V2::SaveFilesInS3Job.perform_later(manifest_source) if documents.present? && !ui_user
+    V2::SaveFilesInS3Job.perform_later(manifest_source) if documents.present? && !ApplicationController.helpers.ui_user?
   rescue StandardError => e
     manifest_source.update!(status: :failed)
     raise e

--- a/app/models/manifest_source.rb
+++ b/app/models/manifest_source.rb
@@ -29,7 +29,7 @@ class ManifestSource < ApplicationRecord
     end
 
     begin
-      V2::DownloadManifestJob.perform_later(self, ui_user?)
+      V2::DownloadManifestJob.perform_later(self, RequestStore[:current_user])
     rescue StandardError
       update(status: :initialized)
 

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -13,14 +13,17 @@ class ExternalApi::BGSService
   end
 
   def fetch_veteran_info(file_number)
-    @bgs_client ||= init_client
-    veteran_data ||=
-      MetricsService.record("BGS: fetch veteran info for vbms id: #{file_number}",
-                            service: :bgs,
-                            name: "veteran.find_by_file_number") do
-        @bgs_client.veteran.find_by_file_number(file_number)
-      end
+    veteran_data = fetch_veteran_data(file_number)
     parse_veteran_info(veteran_data) if veteran_data
+  end
+
+  def fetch_veteran_data(file_number)
+    @bgs_client ||= init_client
+    MetricsService.record("BGS: fetch veteran info for vbms id: #{file_number}",
+                          service: :bgs,
+                          name: "veteran.find_by_file_number") do
+      @bgs_client.veteran.find_by_file_number(file_number)
+    end
   end
 
   def check_sensitivity(file_number)

--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -38,7 +38,7 @@ class ExternalApi::VBMSService
     rescue VBMS::HTTPError => e
       raise unless e.body.include?("File Number does not exist within the system.")
 
-      alternative_file_number = ExternalApi::BGSService.new.fetch_veteran_info(veteran_file_number)[:claim_number]
+      alternative_file_number = ExternalApi::BGSService.new.fetch_veteran_data(veteran_file_number)[:claim_number]
 
       raise if alternative_file_number == veteran_file_number
 

--- a/spec/jobs/v2/download_manifest_job_spec.rb
+++ b/spec/jobs/v2/download_manifest_job_spec.rb
@@ -56,7 +56,9 @@ describe V2::DownloadManifestJob do
       end
 
       context "when user is a UI user" do
-        let(:ui_user) { true }
+        before do
+          allow(ApplicationController.helpers).to receive(:ui_user?).and_return(true)
+        end
 
         it "creates document records and does not start caching files in s3" do
           subject


### PR DESCRIPTION
Connects to #1052 

When calling BGS service from DownloadManifestJob active job, RequestStore[:current_user] is not available since it's stored only within the main process. This PR fixes that.

To test:
Run app locally connected to external dependencies.
Search for record that has C file claim number by ssn number and make sure it returns VBMS document list.  