### PR TITLE
Revert "Always use claim number as file_number... and other fixes"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,7 @@ gem "mini_magick"
 
 gem "httpclient"
 
-gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: "3cab7050e942428724412dff1ccaa887a8190bf5"
+gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", branch: "b8b6d0f918d855b61b31f03e01a39d802d587367"
 gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "08735e11cd9fc196c8f889093580b9054fd2f094"
 gem "connect_vva", git: "https://github.com/department-of-veterans-affairs/connect_vva.git", ref: "f6e3ca26211b28fb8acaab8aa76bddb118b6726e"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,8 +51,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/ruby-bgs.git
-  revision: 3cab7050e942428724412dff1ccaa887a8190bf5
-  ref: 3cab7050e942428724412dff1ccaa887a8190bf5
+  revision: b8b6d0f918d855b61b31f03e01a39d802d587367
+  branch: b8b6d0f918d855b61b31f03e01a39d802d587367
   specs:
     bgs (0.2)
       nokogiri (~> 1.8.2)
@@ -198,7 +198,7 @@ GEM
     hashie (3.5.7)
     highline (1.7.10)
     httpclient (2.8.3)
-    httpi (2.4.4)
+    httpi (2.4.3)
       rack
       socksify
     i18n (1.2.0)

--- a/app/controllers/api/v2/manifests_controller.rb
+++ b/app/controllers/api/v2/manifests_controller.rb
@@ -1,24 +1,15 @@
 # TODO: create Api::V2::ApplicationController
-# rubocop:disable Metrics/CyclomaticComplexity
 class Api::V2::ManifestsController < Api::V1::ApplicationController
   def start
     file_number = request.headers["HTTP_FILE_NUMBER"]
     return missing_header("File Number") unless file_number
 
     return invalid_file_number unless bgs_service.valid_file_number?(file_number)
+    return veteran_not_found(file_number) if bgs_service.fetch_veteran_info(file_number).nil?
+    return sensitive_record unless bgs_service.check_sensitivity(file_number)
 
-    begin
-      veteran_info = bgs_service.fetch_veteran_info(file_number)
-    rescue StandardError => e
-      return sensitive_record if e.message.include?("Sensitive File - Access Violation")
-      raise e
-    end
-
-    return veteran_not_found(file_number) unless bgs_service.record_found?(veteran_info)
-
-    file_number = veteran_info["file_number"] if veteran_info["file_number"]
-
-    manifest = Manifest.includes(:sources, :records).find_or_create_by_user(user: current_user, file_number: file_number)
+    manifest = Manifest.includes(:sources, :records)
+                       .find_or_create_by_user(user: current_user, file_number: file_number)
     manifest.start!
     render json: json_manifests(manifest)
   end
@@ -68,4 +59,3 @@ class Api::V2::ManifestsController < Api::V1::ApplicationController
     render json: { status: "File number is invalid. Veteran IDs must be 8 or more characters and contain only numbers." }, status: 400
   end
 end
-# rubocop:enable Metrics/CyclomaticComplexity

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -3,26 +3,27 @@ require "bgs"
 # Thin interface to all things BGS
 class ExternalApi::BGSService
   def parse_veteran_info(veteran_data)
-    ssn = veteran_data[:ssn] ? veteran_data[:ssn] : veteran_data[:soc_sec_number]
+    ssn = veteran_data[:ssn]
     last_four_ssn = ssn ? ssn[ssn.length - 4..ssn.length] : nil
     {
-      "file_number" => veteran_data[:claim_number],
       "veteran_first_name" => veteran_data[:first_name],
       "veteran_last_name" => veteran_data[:last_name],
-      "veteran_last_four_ssn" => last_four_ssn,
-      "return_message" => veteran_data[:return_message]
+      "veteran_last_four_ssn" => last_four_ssn
     }
   end
 
   def fetch_veteran_info(file_number)
-    @bgs_client ||= init_client
-    veteran_data =
-      MetricsService.record("BGS: fetch veteran info for vbms id: #{file_number}",
-                            service: :bgs,
-                            name: "veteran.find_by_file_number") do
-        @bgs_client.veteran.find_by_file_number(file_number)
-      end
+    veteran_data = fetch_veteran_data(file_number)
     parse_veteran_info(veteran_data) if veteran_data
+  end
+
+  def fetch_veteran_data(file_number)
+    @bgs_client ||= init_client
+    MetricsService.record("BGS: fetch veteran info for vbms id: #{file_number}",
+                          service: :bgs,
+                          name: "veteran.find_by_file_number") do
+      @bgs_client.veteran.find_by_file_number(file_number)
+    end
   end
 
   def check_sensitivity(file_number)
@@ -40,11 +41,6 @@ class ExternalApi::BGSService
     number = (file_number || "").strip
     return true if /^\d+$/ =~ number && number.length >= 8 && number.length <= 9
     false
-  end
-
-  def record_found?(veteran_info)
-    return false unless veteran_info && veteran_info["return_message"]
-    veteran_info["return_message"].include?("No BIRLS record found") ? false : true
   end
 
   private

--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -38,7 +38,7 @@ class ExternalApi::VBMSService
     rescue VBMS::HTTPError => e
       raise unless e.body.include?("File Number does not exist within the system.")
 
-      alternative_file_number = ExternalApi::BGSService.new.fetch_veteran_info(veteran_file_number)["file_number"]
+      alternative_file_number = ExternalApi::BGSService.new.fetch_veteran_data(veteran_file_number)[:claim_number]
 
       raise if alternative_file_number == veteran_file_number
 

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -5,22 +5,19 @@ class Fakes::BGSService
     !!(file_number =~ /^DEMO/)
   end
 
-  def demo_veteran_info(file_number)
+  def demo_veteran_info
     [
       {
-        "file_number" => file_number,
         "veteran_first_name" => "Joe",
         "veteran_last_name" => "Snuffy",
         "veteran_last_four_ssn" => "1234"
       },
       {
-        "file_number" => file_number,
         "veteran_first_name" => "Bob",
         "veteran_last_name" => "Marley",
         "veteran_last_four_ssn" => "3232"
       },
       {
-        "file_number" => file_number,
         "veteran_first_name" => "James",
         "veteran_last_name" => "Ross",
         "veteran_last_four_ssn" => "4221"
@@ -29,7 +26,7 @@ class Fakes::BGSService
   end
 
   def fetch_veteran_info(file_number)
-    return demo_veteran_info(file_number) if demo?(file_number)
+    return demo_veteran_info if demo?(file_number)
     (veteran_info || {})[file_number]
   end
 
@@ -39,11 +36,6 @@ class Fakes::BGSService
 
   def check_sensitivity(file_number)
     !(sensitive_files || {})[file_number]
-  end
-
-  def record_found?(veteran_info)
-    return false unless veteran_info && veteran_info["return_message"]
-    veteran_info["return_message"].include?("No BIRLS record found") ? false : true
   end
 
   # Methods to be stubbed out in tests:

--- a/spec/features/backend_error_flows_spec.rb
+++ b/spec/features/backend_error_flows_spec.rb
@@ -27,7 +27,6 @@ RSpec.feature "Backend Error Flows" do
   let(:veteran_id) { "12341234" }
   let(:veteran_info) do
     {
-      "file_number" => veteran_id,
       "veteran_first_name" => "Stan",
       "veteran_last_name" => "Lee",
       "veteran_last_four_ssn" => "2222"
@@ -43,7 +42,6 @@ RSpec.feature "Backend Error Flows" do
 
     allow_any_instance_of(Fakes::BGSService).to receive(:fetch_veteran_info).with(veteran_id).and_return(veteran_info)
     allow_any_instance_of(Fakes::BGSService).to receive(:valid_file_number?).with(veteran_id).and_return(true)
-    allow_any_instance_of(Fakes::BGSService).to receive(:record_found?).with(veteran_info).and_return(true)
 
     allow(Fakes::VBMSService).to receive(:v2_fetch_documents_for).and_return(documents)
     allow(Fakes::VVAService).to receive(:v2_fetch_documents_for).and_return([])

--- a/spec/features/react_download_spec.rb
+++ b/spec/features/react_download_spec.rb
@@ -32,9 +32,7 @@ RSpec.feature "React Downloads" do
     User.authenticate!
 
     allow_any_instance_of(Fakes::BGSService).to receive(:fetch_veteran_info).with(veteran_id).and_return(veteran_info)
-    allow_any_instance_of(Fakes::BGSService).to receive(:fetch_veteran_info).with(claim_number).and_return(veteran_info)
     allow_any_instance_of(Fakes::BGSService).to receive(:valid_file_number?).with(veteran_id).and_return(true)
-    allow_any_instance_of(Fakes::BGSService).to receive(:record_found?).with(veteran_info).and_return(true)
 
     allow(Fakes::VBMSService).to receive(:v2_fetch_documents_for).and_return(documents)
     allow(Fakes::VVAService).to receive(:v2_fetch_documents_for).and_return([])
@@ -51,11 +49,9 @@ RSpec.feature "React Downloads" do
     FeatureToggle.disable!(:efolder_react_app)
   end
 
-  let(:veteran_id) { "43214321" }
-  let(:claim_number) { "12341234" }
+  let(:veteran_id) { "12341234" }
   let(:veteran_info) do
     {
-      "file_number" => claim_number,
       "veteran_first_name" => "Stan",
       "veteran_last_name" => "Lee",
       "veteran_last_four_ssn" => "2222"
@@ -71,7 +67,8 @@ RSpec.feature "React Downloads" do
     fill_in "Search for a Veteran ID number below to get started.", with: veteran_id
 
     click_on "Search"
-    expect(page).to have_content "STAN LEE VETERAN ID #{claim_number}"
+
+    expect(page).to have_content "STAN LEE VETERAN ID #{veteran_id}"
     expect(page).to have_content "We are gathering the list of files in the eFolder now"
 
     manifest = Manifest.last
@@ -81,7 +78,6 @@ RSpec.feature "React Downloads" do
     expect(page).to have_current_path("/downloads/#{manifest.id}")
 
     expect(manifest).to_not be_nil
-    expect(manifest.file_number).to eq(claim_number)
     expect(manifest.veteran_first_name).to eq("Stan")
     expect(manifest.veteran_last_name).to eq("Lee")
     expect(manifest.veteran_last_four_ssn).to eq("2222")
@@ -94,7 +90,7 @@ RSpec.feature "React Downloads" do
 
       click_button "Search"
 
-      expect(page).to have_content "STAN LEE VETERAN ID #{claim_number}"
+      expect(page).to have_content "STAN LEE VETERAN ID #{veteran_id}"
       expect(page).to have_content "Start retrieving efolder"
 
       within(".cf-app-segment--alt") do
@@ -118,7 +114,7 @@ RSpec.feature "React Downloads" do
       click_on "Start over"
 
       history_row = "#download-1"
-      expect(find(history_row)).to have_content(claim_number)
+      expect(find(history_row)).to have_content(veteran_id)
       within(history_row) { click_on("View results") }
       expect(page).to have_content("Success!")
 
@@ -147,7 +143,7 @@ RSpec.feature "React Downloads" do
 
       click_button "Search"
 
-      expect(page).to have_content "STAN LEE VETERAN ID #{claim_number}"
+      expect(page).to have_content "STAN LEE VETERAN ID #{veteran_id}"
       expect(page).to have_content "Start retrieving efolder"
     end
 
@@ -166,7 +162,7 @@ RSpec.feature "React Downloads" do
 
       click_button "Search"
 
-      expect(page).to have_content "STAN LEE VETERAN ID #{claim_number}"
+      expect(page).to have_content "STAN LEE VETERAN ID #{veteran_id}"
       expect(page).to have_content "Start retrieving efolder"
     end
 
@@ -176,7 +172,7 @@ RSpec.feature "React Downloads" do
 
     click_on "eFolder Express home page."
 
-    expect(page.find("input#file_number").value).to_not eq(claim_number)
+    expect(page.find("input#file_number").value).to_not eq(veteran_id)
   end
 
   context "When manifest endpoint returns different statuses for different documents" do

--- a/spec/features/user_error_flows_spec.rb
+++ b/spec/features/user_error_flows_spec.rb
@@ -29,11 +29,9 @@ RSpec.feature "User Error Flows" do
   let(:veteran_id) { "12341234" }
   let(:veteran_info) do
     {
-      "file_number" => veteran_id,
       "veteran_first_name" => "Stan",
       "veteran_last_name" => "Lee",
-      "veteran_last_four_ssn" => "2222",
-      "return_message" => "BPNQ0301"
+      "veteran_last_four_ssn" => "2222"
     }
   end
 
@@ -84,17 +82,8 @@ RSpec.feature "User Error Flows" do
   end
 
   context "When veteran_id has no veteran info" do
-    let(:veteran_info) do
-      {
-        "file_number" => nil,
-        "veteran_first_name" => nil,
-        "veteran_last_name" => nil,
-        "veteran_last_four_ssn" => nil,
-        "return_message" => "No BIRLS record found"
-      }
-    end
     before do
-      allow_any_instance_of(Fakes::BGSService).to receive(:fetch_veteran_info).with(veteran_id).and_return(veteran_info)
+      allow_any_instance_of(Fakes::BGSService).to receive(:fetch_veteran_info).with(veteran_id).and_return(nil)
     end
 
     scenario "Requesting veteran_id returns cannot find eFolder" do
@@ -108,7 +97,7 @@ RSpec.feature "User Error Flows" do
 
   context "When veteran id has high sensitivity" do
     before do
-      allow_any_instance_of(Fakes::BGSService).to receive(:fetch_veteran_info).and_raise("Sensitive File - Access Violation")
+      allow_any_instance_of(Fakes::BGSService).to receive(:sensitive_files).and_return(veteran_id => true)
     end
 
     scenario "Cannot access it" do
@@ -124,7 +113,6 @@ RSpec.feature "User Error Flows" do
     before do
       allow(Fakes::VBMSService).to receive(:v2_fetch_documents_for).and_return([])
       allow(Fakes::VVAService).to receive(:v2_fetch_documents_for).and_return([])
-      allow_any_instance_of(Fakes::BGSService).to receive(:record_found?).with(veteran_info).and_return(true)
     end
 
     scenario "Download with no documents" do

--- a/spec/requests/api/v2/manifests_spec.rb
+++ b/spec/requests/api/v2/manifests_spec.rb
@@ -30,7 +30,6 @@ describe "Manifests API v2", type: :request do
 
   before do
     allow_any_instance_of(Fakes::BGSService).to receive(:sensitive_files).and_return(veteran_id.to_s => false)
-    allow_any_instance_of(Fakes::BGSService).to receive(:record_found?).and_return(true)
     Timecop.freeze(Time.utc(2015, 1, 1, 17, 0, 0))
   end
 
@@ -187,7 +186,7 @@ describe "Manifests API v2", type: :request do
     let(:veteran_id) { "DEMO456" }
 
     before do
-      allow_any_instance_of(Fakes::BGSService).to receive(:fetch_veteran_info).and_raise("Sensitive File - Access Violation")
+      allow_any_instance_of(Fakes::BGSService).to receive(:sensitive_files).and_return(veteran_id.to_s => true)
     end
 
     it "returns 403" do
@@ -201,7 +200,7 @@ describe "Manifests API v2", type: :request do
   context "When user does not exist in BGS" do
     let(:error_string) { "Logon ID VACOHSOLO Not Found in the Benefits Gateway Service (BGS). Contact your ISO if you need assistance gaining access to BGS." }
     before do
-      allow_any_instance_of(Fakes::BGSService).to receive(:fetch_veteran_info).and_raise(BGS::PublicError.new(error_string))
+      allow_any_instance_of(Fakes::BGSService).to receive(:check_sensitivity).and_raise(BGS::PublicError.new(error_string))
     end
 
     it "returns 403 forbidden response" do

--- a/spec/services/bgs_service_spec.rb
+++ b/spec/services/bgs_service_spec.rb
@@ -3,7 +3,7 @@ describe ExternalApi::BGSService do
 
   context "#parse_veteran_info" do
     before do
-      @veteran_data = {
+      @veteran_info = {
         ssn: "123-43-1111",
         first_name: "FirstName",
         last_name: "LastName"
@@ -11,26 +11,25 @@ describe ExternalApi::BGSService do
     end
 
     context "if bgs service returns a string ssn" do
-      subject { bgs_service.parse_veteran_info(@veteran_data)["veteran_last_four_ssn"] }
+      subject { bgs_service.parse_veteran_info(@veteran_info)["veteran_last_four_ssn"] }
       it { is_expected.to eq("1111") }
     end
 
-    context "if bgs service returns no ssn in VetBirlsRecod, but it does in vetCorpRecord" do
-      veteran_data = {
-        ssn: nil,
-        soc_sec_number: "43214321"
+    context "if bgs service returns no ssn" do
+      veteran_info = {
+        ssn_nbr: nil
       }
-      subject { bgs_service.parse_veteran_info(veteran_data)["veteran_last_four_ssn"] }
-      it { is_expected.to eq("4321") }
+      subject { bgs_service.parse_veteran_info(veteran_info)["veteran_last_four_ssn"] }
+      it { is_expected.to eq(nil) }
     end
 
     context "if bgs service returns last name" do
-      subject { bgs_service.parse_veteran_info(@veteran_data)["veteran_last_name"] }
+      subject { bgs_service.parse_veteran_info(@veteran_info)["veteran_last_name"] }
       it { is_expected.to eq("LastName") }
     end
 
     context "if bgs service returns first name" do
-      subject { bgs_service.parse_veteran_info(@veteran_data)["veteran_first_name"] }
+      subject { bgs_service.parse_veteran_info(@veteran_info)["veteran_first_name"] }
       it { is_expected.to eq("FirstName") }
     end
   end
@@ -55,20 +54,6 @@ describe ExternalApi::BGSService do
 
     context "when shorter than 8 char" do
       let(:file_number) { "456789" }
-      it { is_expected.to eq false }
-    end
-  end
-
-  context "#record_found?" do
-    subject { bgs_service.record_found?(veteran_info) }
-
-    context "when found" do
-      let(:veteran_info) { { "return_message" => "BPNQ0301" } }
-      it { is_expected.to eq true }
-    end
-
-    context "when not found" do
-      let(:veteran_info) { { "return_message" => "No BIRLS record found" } }
       it { is_expected.to eq false }
     end
   end


### PR DESCRIPTION
This commit broke production hence revert. 
Reverts department-of-veterans-affairs/caseflow-efolder#1060