### PR TITLE
Catch POA access error, return error message and add spec test

### DIFF
--- a/app/controllers/api/v2/manifests_controller.rb
+++ b/app/controllers/api/v2/manifests_controller.rb
@@ -11,6 +11,7 @@ class Api::V2::ManifestsController < Api::V1::ApplicationController
       veteran_info = bgs_service.fetch_veteran_info(file_number)
     rescue StandardError => e
       return sensitive_record if e.message.include?("Sensitive File - Access Violation")
+      return vso_denied_record if e.message.include?("Power of Attorney of Folder is '071'. Access to this record is denied.")
       raise e
     end
 
@@ -62,6 +63,10 @@ class Api::V2::ManifestsController < Api::V1::ApplicationController
 
   def veteran_not_found(file_number)
     render json: { status: "eFolder Express could not find an eFolder with the Veteran ID #{file_number}. Check to make sure you entered the ID correctly and try again." }, status: 400
+  end
+
+  def vso_denied_record
+    forbidden("This efolder belongs to a Veteran you do not represent. Please contact your supervisor.")
   end
 
   def invalid_file_number

--- a/app/controllers/api/v2/manifests_controller.rb
+++ b/app/controllers/api/v2/manifests_controller.rb
@@ -12,7 +12,7 @@ class Api::V2::ManifestsController < Api::V1::ApplicationController
       veteran_info = bgs_service.fetch_veteran_info(file_number)
     rescue StandardError => e
       return sensitive_record if e.message.include?("Sensitive File - Access Violation")
-      return vso_denied_record if e.message.include?("Power of Attorney of Folder is '071'. Access to this record is denied.")
+      return vso_denied_record if e.message.include?("Power of Attorney of Folder is")
       raise e
     end
 

--- a/app/controllers/api/v2/manifests_controller.rb
+++ b/app/controllers/api/v2/manifests_controller.rb
@@ -1,5 +1,6 @@
 # TODO: create Api::V2::ApplicationController
 # rubocop:disable Metrics/CyclomaticComplexity
+# rubocop:disable Metrics/PerceivedComplexity
 class Api::V2::ManifestsController < Api::V1::ApplicationController
   def start
     file_number = request.headers["HTTP_FILE_NUMBER"]
@@ -74,3 +75,4 @@ class Api::V2::ManifestsController < Api::V1::ApplicationController
   end
 end
 # rubocop:enable Metrics/CyclomaticComplexity
+# rubocop:enable Metrics/PerceivedComplexity

--- a/spec/features/user_error_flows_spec.rb
+++ b/spec/features/user_error_flows_spec.rb
@@ -107,7 +107,6 @@ RSpec.feature "User Error Flows" do
   end
 
   context "When veteran id has high sensitivity" do
-   
     scenario "Cannot access it" do
       allow_any_instance_of(Fakes::BGSService).to receive(:fetch_veteran_info).and_raise("Sensitive File - Access Violation")
       visit "/"
@@ -118,17 +117,15 @@ RSpec.feature "User Error Flows" do
     end
 
     scenario "VSO cannot access it" do
-      allow_any_instance_of(Fakes::BGSService).to receive(:fetch_veteran_info).
-        and_raise("Power of Attorney of Folder is '071'. Access to this record is denied.")
+      allow_any_instance_of(Fakes::BGSService).to receive(:fetch_veteran_info)
+        .and_raise("Power of Attorney of Folder is '071'. Access to this record is denied.")
       visit "/"
       fill_in "Search for a Veteran ID number below to get started.", with: veteran_id
       click_button "Search"
 
       expect(page).to have_content("This efolder belongs to a Veteran you do not represent")
     end
-
   end
-
 
   context "When veteran case folder has no documents" do
     before do

--- a/spec/features/user_error_flows_spec.rb
+++ b/spec/features/user_error_flows_spec.rb
@@ -107,18 +107,28 @@ RSpec.feature "User Error Flows" do
   end
 
   context "When veteran id has high sensitivity" do
-    before do
-      allow_any_instance_of(Fakes::BGSService).to receive(:fetch_veteran_info).and_raise("Sensitive File - Access Violation")
-    end
-
+   
     scenario "Cannot access it" do
+      allow_any_instance_of(Fakes::BGSService).to receive(:fetch_veteran_info).and_raise("Sensitive File - Access Violation")
       visit "/"
       fill_in "Search for a Veteran ID number below to get started.", with: veteran_id
       click_button "Search"
 
-      expect(page).to have_content("contains sensitive information")
+      expect(page).to have_content("This efolder contains sensitive information")
     end
+
+    scenario "VSO cannot access it" do
+      allow_any_instance_of(Fakes::BGSService).to receive(:fetch_veteran_info).
+        and_raise("Power of Attorney of Folder is '071'. Access to this record is denied.")
+      visit "/"
+      fill_in "Search for a Veteran ID number below to get started.", with: veteran_id
+      click_button "Search"
+
+      expect(page).to have_content("This efolder belongs to a Veteran you do not represent")
+    end
+
   end
+
 
   context "When veteran case folder has no documents" do
     before do


### PR DESCRIPTION
Connected to #1064 

To test this, run app locally connected to external dependencies and search for arbitrary file number. 
To ease the pain:
On VA network (VPN)
cd ~/workspace/caseflow-efolder
git checkout nemo/poa-error
git cherry-pick bb35873c14a69a97720aa525061524df9e922760
source ~/workspace/appeals-deployment/decrypted/prod/env.sh
RAILS_ENV=staging bundle exec rails s 
(in another tab)
cd caseflow-efolder
source ~/workspace/appeals-deployment/decrypted/prod/env.sh
RAILS_ENV=staging bundle exec shoryuken start -q efolder_staging_high_priority efolder_staging_low_priority efolder_staging_med_priority -R
Docker and webpack should be running as well. 
Make sure you login with the right css_id and station_id (or change current user configuration for external services) 
