### PR TITLE
Update connect vbms - VBMS old service is removed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,7 @@ gem "mini_magick"
 gem "httpclient"
 
 gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: "3cab7050e942428724412dff1ccaa887a8190bf5"
-gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "08735e11cd9fc196c8f889093580b9054fd2f094"
+gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "dddc821c2335c7de234a5454e4b4874e3f658420"
 gem "connect_vva", git: "https://github.com/department-of-veterans-affairs/connect_vva.git", ref: "f6e3ca26211b28fb8acaab8aa76bddb118b6726e"
 
 # catch problematic migrations

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,14 +21,14 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vbms.git
-  revision: 08735e11cd9fc196c8f889093580b9054fd2f094
-  ref: 08735e11cd9fc196c8f889093580b9054fd2f094
+  revision: dddc821c2335c7de234a5454e4b4874e3f658420
+  ref: dddc821c2335c7de234a5454e4b4874e3f658420
   specs:
     connect_vbms (1.2.0)
       httpclient (~> 2.8.0)
       httpi (~> 2.4)
       mail
-      nokogiri (>= 1.8.2)
+      nokogiri (>= 1.8.4)
       nori
       xmldsig (~> 0.3.1)
       xmlenc
@@ -527,4 +527,4 @@ DEPENDENCIES
   zero_downtime_migrations
 
 BUNDLED WITH
-   1.17.1
+   1.17.2


### PR DESCRIPTION
Update connect VBMS version with the latest changes
1. VBMS old service endpoints were removed

Testing:
Tested efolder in UAT

See: https://github.com/department-of-veterans-affairs/connect_vbms/pull/212