### PR TITLE
Revert "Fix not unique error on find_or_create manifest and retry"

### DIFF
--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -129,14 +129,7 @@ class Manifest < ApplicationRecord
   end
 
   def self.find_or_create_by_user(user:, file_number:)
-    manifest = nil
-    begin
-      Manifest.transaction(requires_new: true) do
-        manifest = Manifest.find_or_create_by!(file_number: file_number)
-      end
-    rescue ActiveRecord::RecordNotUnique
-      retry
-    end
+    manifest = Manifest.find_or_create_by!(file_number: file_number)
     manifest.files_downloads.find_or_create_by!(user: user)
     manifest
   end

--- a/db/migrate/20190307025848_remove_index_files_downloads_on_manifest_id_and_user_id.rb
+++ b/db/migrate/20190307025848_remove_index_files_downloads_on_manifest_id_and_user_id.rb
@@ -1,5 +1,0 @@
-class RemoveIndexFilesDownloadsOnManifestIdAndUserId < ActiveRecord::Migration[5.1]
-  def change
-    remove_index :files_downloads, ["manifest_id", "user_id"]
-  end
-end

--- a/db/migrate/20190307034524_add_index_to_files_downloads.rb
+++ b/db/migrate/20190307034524_add_index_to_files_downloads.rb
@@ -1,7 +1,0 @@
-class AddIndexToFilesDownloads < ActiveRecord::Migration[5.1]
-  disable_ddl_transaction!
-
-  def change
-    add_index :files_downloads, ["manifest_id", "user_id"], unique: true, algorithm: :concurrently
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190307034524) do
+ActiveRecord::Schema.define(version: 20180717182835) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 20190307034524) do
     t.integer "size"
     t.integer "conversion_status"
     t.index ["completed_at"], name: "index_documents_on_completed_at"
+    t.index ["download_id", "document_id"], name: "index_documents_on_download_id_and_document_id"
     t.index ["download_status"], name: "index_documents_on_download_status"
   end
 
@@ -85,7 +86,7 @@ ActiveRecord::Schema.define(version: 20190307034524) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "requested_zip_at"
-    t.index ["manifest_id", "user_id"], name: "index_files_downloads_on_manifest_id_and_user_id", unique: true
+    t.index ["manifest_id", "user_id"], name: "index_files_downloads_on_manifest_id_and_user_id"
     t.index ["user_id"], name: "index_files_downloads_on_user_id"
   end
 

--- a/spec/requests/api/v2/manifests_spec.rb
+++ b/spec/requests/api/v2/manifests_spec.rb
@@ -35,10 +35,10 @@ describe "Manifests API v2", type: :request do
   end
 
   context "View download history" do
-    let(:manifest1) { Manifest.find_or_create_by!(file_number: "123C") }
-    let(:manifest2) { Manifest.find_or_create_by!(file_number: "567C") }
-    let(:manifest3) { Manifest.find_or_create_by!(file_number: "897C") }
-    let(:manifest4) { Manifest.find_or_create_by!(file_number: "935C") }
+    let(:manifest1) { Manifest.find_or_create_by_user(user: user, file_number: "123C") }
+    let(:manifest2) { Manifest.find_or_create_by_user(user: user, file_number: "567C") }
+    let(:manifest3) { Manifest.find_or_create_by_user(user: user, file_number: "897C") }
+    let(:manifest4) { Manifest.find_or_create_by_user(user: user, file_number: "935C") }
 
     let(:another_user) { User.create(css_id: "123C", station_id: "123") }
     let!(:files_download1) { FilesDownload.create(manifest: manifest1, user: user, requested_zip_at: 2.days.ago) }


### PR DESCRIPTION
Reverts department-of-veterans-affairs/caseflow-efolder#1068

It turns out that FilesDownload table has already duplicate errors on manifest_id and user_id. 