### PR TITLE
 Move recent downloads to a separate page

### DIFF
--- a/client/src/containers/InitContainer.jsx
+++ b/client/src/containers/InitContainer.jsx
@@ -12,6 +12,7 @@ import OutOfServiceContainer from './OutOfServiceContainer';
 import PrivateRoute from './PrivateRoute';
 import UnauthorizedContainer from './UnauthorizedContainer';
 import WelcomeContainer from './WelcomeContainer';
+import RecentDownloadsContainer from './RecentDownloadsContainer';
 
 class InitContainer extends React.PureComponent {
   render() {
@@ -33,6 +34,7 @@ class InitContainer extends React.PureComponent {
               <Route exact path="/help" component={HelpContainer} />
               <Route exact path="/out-of-service" component={OutOfServiceContainer} />
               <Route exact path="/unauthorized" component={UnauthorizedContainer} />
+              <Route exact path="/recent-downloads" component={RecentDownloadsContainer} />
               <Route component={NotFoundMessage} />
             </Switch>
           </main>

--- a/client/src/containers/RecentDownloadsContainer.jsx
+++ b/client/src/containers/RecentDownloadsContainer.jsx
@@ -58,6 +58,7 @@ class RecentDownloadsContainer extends React.PureComponent {
           )}
         </tbody>
       </table>
+      <Link to="/">Back to search</Link>
     </div>;
   }
 }

--- a/client/src/containers/RecentDownloadsContainer.jsx
+++ b/client/src/containers/RecentDownloadsContainer.jsx
@@ -7,6 +7,9 @@ import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/comp
 import { MANIFEST_DOWNLOAD_STATE } from '../Constants';
 import { getDownloadHistory } from '../apiActions';
 import { AlertIcon } from '../components/Icons';
+import StatusMessage from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/StatusMessage';
+
+
 
 const linkText = (status, failedDocCount) => {
   const icon = failedDocCount ? <AlertIcon /> : null;
@@ -22,7 +25,11 @@ class RecentDownloadsContainer extends React.PureComponent {
 
   render() {
     if (!this.props.recentDownloads.length) {
-      return null;
+      return <StatusMessage>
+        No recent downloads.
+        <br />
+      <Link to="/">Back to search</Link>
+    </StatusMessage>;
     }
 
     return <div>

--- a/client/src/containers/RecentDownloadsContainer.jsx
+++ b/client/src/containers/RecentDownloadsContainer.jsx
@@ -9,8 +9,6 @@ import { getDownloadHistory } from '../apiActions';
 import { AlertIcon } from '../components/Icons';
 import StatusMessage from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/StatusMessage';
 
-
-
 const linkText = (status, failedDocCount) => {
   const icon = failedDocCount ? <AlertIcon /> : null;
   const text = status === MANIFEST_DOWNLOAD_STATE.IN_PROGRESS ? 'progress' : 'results';
@@ -28,8 +26,8 @@ class RecentDownloadsContainer extends React.PureComponent {
       return <StatusMessage>
         No recent downloads.
         <br />
-      <Link to="/">Back to search</Link>
-    </StatusMessage>;
+        <Link to="/">Back to search</Link>
+      </StatusMessage>;
     }
 
     return <div>

--- a/client/src/containers/WelcomeContainer.jsx
+++ b/client/src/containers/WelcomeContainer.jsx
@@ -14,7 +14,6 @@ import {
 } from '../actions';
 import { startManifestFetch } from '../apiActions';
 import AlertBanner from '../components/AlertBanner';
-import RecentDownloadsContainer from './RecentDownloadsContainer';
 
 const searchBarNoteTextStyling = css({
   fontStyle: 'italic',

--- a/client/src/containers/WelcomeContainer.jsx
+++ b/client/src/containers/WelcomeContainer.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
+import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
 
 import {
   clearErrorMessage,
@@ -78,7 +79,7 @@ Note: eFolder Express now includes Virtual VA documents from the Legacy Content 
         </p>
       </div>
 
-      <RecentDownloadsContainer />
+      <Link to="/recent-downloads">{ 'Recent downloads...' }</Link>
     </AppSegment>;
   }
 }

--- a/client/src/containers/WelcomeContainer.jsx
+++ b/client/src/containers/WelcomeContainer.jsx
@@ -78,7 +78,7 @@ Note: eFolder Express now includes Virtual VA documents from the Legacy Content 
         </p>
       </div>
 
-      <Link to="/recent-downloads">{ 'Recent downloads...' }</Link>
+      <Link to="/recent-downloads">Recent downloads...</Link>
     </AppSegment>;
   }
 }

--- a/spec/features/backend_error_flows_spec.rb
+++ b/spec/features/backend_error_flows_spec.rb
@@ -159,6 +159,8 @@ RSpec.feature "Backend Error Flows" do
 
         click_on "Start over"
 
+        click_on "Recent downloads"
+
         history_row = "#download-1"
 
         expect(find(history_row)).to have_content(veteran_id)

--- a/spec/features/react_download_spec.rb
+++ b/spec/features/react_download_spec.rb
@@ -116,6 +116,7 @@ RSpec.feature "React Downloads" do
       expect(DownloadHelpers.download).to include("Lee, Stan - 2222")
 
       click_on "Start over"
+      click_on "Recent downloads"
 
       history_row = "#download-1"
       expect(find(history_row)).to have_content(claim_number)
@@ -239,6 +240,7 @@ RSpec.feature "React Downloads" do
       click_on "Start over"
 
       history_row = "#download-1"
+      click_on "Recent downloads"
 
       expect(find(history_row)).to have_content(veteran_id)
       expect(find(history_row)).to have_css(".cf-icon-alert")


### PR DESCRIPTION
<img width="1128" alt="Screen Shot 2019-04-03 at 3 51 26 PM" src="https://user-images.githubusercontent.com/4960030/55509169-7f3f1800-5629-11e9-8e12-43d8212e48d7.png">
<img width="1202" alt="Screen Shot 2019-04-03 at 3 52 15 PM" src="https://user-images.githubusercontent.com/4960030/55509168-7f3f1800-5629-11e9-9e54-64e1bc119654.png">
<img width="1151" alt="Screen Shot 2019-04-03 at 3 51 34 PM" src="https://user-images.githubusercontent.com/4960030/55509170-7f3f1800-5629-11e9-91b8-7bfdf8336b3c.png">




On home page load - Before: 
<img width="1440" alt="Screen Shot 2019-04-03 at 3 55 46 PM" src="https://user-images.githubusercontent.com/4960030/55509060-3d15d680-5629-11e9-9fe3-44b2663de3ad.png">

On home page load - After:
<img width="1434" alt="Screen Shot 2019-04-03 at 3 54 19 PM" src="https://user-images.githubusercontent.com/4960030/55509064-42732100-5629-11e9-8e3d-9675718539d6.png">
