### PR TITLE
Update bgs (and nokogiri)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "active_model_serializers"
 gem "activejob_dj_overrides"
 gem "activerecord-jdbcpostgresql-adapter", platforms: :jruby
 gem "aws-sdk", "~> 2"
-gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: "3cab7050e942428724412dff1ccaa887a8190bf5"
+gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: "fc4d89559799f60b34dc7407f8659c7961105548"
 gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "8dde00d67b7c629e4b871f8dcb3617bfe989b3db"
 gem "coffee-rails", "> 4.1.0"
 gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "dddc821c2335c7de234a5454e4b4874e3f658420"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,11 +51,11 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/ruby-bgs.git
-  revision: 3cab7050e942428724412dff1ccaa887a8190bf5
-  ref: 3cab7050e942428724412dff1ccaa887a8190bf5
+  revision: fc4d89559799f60b34dc7407f8659c7961105548
+  ref: fc4d89559799f60b34dc7407f8659c7961105548
   specs:
     bgs (0.2)
-      nokogiri (~> 1.8.2)
+      nokogiri (~> 1.10)
       savon (~> 2.11)
 
 GIT
@@ -231,7 +231,7 @@ GEM
     mime-types-data (3.2016.0521)
     mini_magick (4.8.0)
     mini_mime (1.0.1)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     minitest (5.11.3)
     moment_timezone-rails (0.5.0)
     momentjs-rails (2.20.1)
@@ -243,8 +243,8 @@ GEM
       thor (~> 0.19)
     newrelic_rpm (4.8.0.341)
     nio4r (2.3.1)
-    nokogiri (1.8.5)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.10.3)
+      mini_portile2 (~> 2.4.0)
     nori (2.6.0)
     omniauth (1.8.1)
       hashie (>= 3.4.6, < 3.6.0)
@@ -268,7 +268,7 @@ GEM
     public_suffix (3.0.2)
     puma (3.11.3)
     quantile (0.2.0)
-    rack (2.0.6)
+    rack (2.0.7)
     rack-cors (1.0.2)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)


### PR DESCRIPTION
```Name: nokogiri
Version: 1.8.5
Advisory: CVE-2019-11068
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/issues/1892
Title: Nokogiri gem, via libxslt, is affected by improper access control vulnerability
Solution: upgrade to >= 1.10.3```
