### PR TITLE
Include exception class name in matching message string

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "active_model_serializers"
 gem "activejob_dj_overrides"
 gem "activerecord-jdbcpostgresql-adapter", platforms: :jruby
 gem "aws-sdk", "~> 2"
-gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: "fc4d89559799f60b34dc7407f8659c7961105548"
+gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: "e94aff758739c499978041953e6d50fe58057e89"
 gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "8dde00d67b7c629e4b871f8dcb3617bfe989b3db"
 gem "coffee-rails", "> 4.1.0"
 gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "dddc821c2335c7de234a5454e4b4874e3f658420"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,12 +51,13 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/ruby-bgs.git
-  revision: fc4d89559799f60b34dc7407f8659c7961105548
-  ref: fc4d89559799f60b34dc7407f8659c7961105548
+  revision: e94aff758739c499978041953e6d50fe58057e89
+  ref: e94aff758739c499978041953e6d50fe58057e89
   specs:
     bgs (0.2)
+      httpclient
       nokogiri (~> 1.10)
-      savon (~> 2.11)
+      savon (~> 2.12)
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/sniffybara.git

--- a/app/exceptions/dependency_error.rb
+++ b/app/exceptions/dependency_error.rb
@@ -32,7 +32,7 @@ class DependencyError < StandardError
             else
               error.message
             end
-      "#{error.class.to_s}: #{msg}"
+      "#{error.class}: #{msg}"
     end
   end
 end

--- a/app/exceptions/dependency_error.rb
+++ b/app/exceptions/dependency_error.rb
@@ -26,12 +26,13 @@ class DependencyError < StandardError
     private
 
     def extract_error_message(error)
-      if error.try(:body)
-        # https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3124/
-        error.body.encode("UTF-8", invalid: :replace, undef: :replace, replace: "")
-      else
-        error.message
-      end
+      msg = if error.try(:body)
+              # https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3124/
+              error.body.encode("UTF-8", invalid: :replace, undef: :replace, replace: "")
+            else
+              error.message
+            end
+      "#{error.class.to_s}: #{msg}"
     end
   end
 end


### PR DESCRIPTION
Our string matching expects the original exception class name to match against.