### PR TITLE
fix localstack ports for sqs development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,10 +17,11 @@ services:
   appeals-localstack-aws:
     image: localstack/localstack
     ports:
-      - "14567-4583:14567-4583"
-      - "8083:${PORT_WEB_UI-8080}"
+      - "14567-14583:4567-4583"
+      - "${PORT_WEB_UI-8080}:${PORT_WEB_UI-8080}"
     environment:
       - SERVICES=sqs
+      - SQS_PORT_EXTERNAL=14576
     volumes:
       - ./local/sqs/conf:/conf
 


### PR DESCRIPTION
To run side-by-side with caseflow, we need the range of localstack ports in efolder to be 14561-14583 and map to 4561-4583 internally on the docker instance.