### PR TITLE
Refactor/add error classes

### DIFF
--- a/app/exceptions/bgs_error.rb
+++ b/app/exceptions/bgs_error.rb
@@ -4,37 +4,36 @@
 class BGSError < DependencyError
   KNOWN_ERRORS = {
     # Example: https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/3156/
-    /Connection timed out - connect\(2\) for "bepprod\.vba\.va\.gov" port 443/ => "TransientBGSError",
+    /Connection timed out - connect\(2\) for "bepprod\.vba\.va\.gov" port 443/ => "BGSError::Transient",
 
     # Example: https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/3153/
-    /Connection refused - connect\(2\) for "bepprod\.vba\.va\.gov" port 443/ => "TransientBGSError",
+    /Connection refused - connect\(2\) for "bepprod\.vba\.va\.gov" port 443/ => "BGSError::Transient",
 
     # BGS kills connection
     #
     # Example: https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/3158/
-    /HTTPClient::KeepAliveDisconnected: Connection reset by peer/ => "TransientBGSError",
+    /HTTPClient::KeepAliveDisconnected: Connection reset by peer/ => "BGSError::Transient",
 
     # Example: https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/3621/
-    /Connection reset by peer/ => "TransientBGSError",
+    /Connection reset by peer/ => "BGSError::Transient",
 
     # Examples: https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/3170/
-    /Unable to find SOAP operation:/ => "TransientBGSError",
+    /Unable to find SOAP operation:/ => "BGSError::Transient",
 
     # Transient failure when, for example, a WSDL is unavailable.
     # Example: https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/3167/
-    /HTTP error \(504\): upstream request timeout/ => "TransientBGSError",
+    /HTTP error \(504\): upstream request timeout/ => "BGSError::Transient",
 
     # Like above
     #
     # Example: https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/667/
-    /HTTP error \(503\): upstream connect error/ => "TransientBGSError",
+    /HTTP error \(503\): upstream connect error/ => "BGSError::Transient",
 
     # Example: https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3188/
-    /TUX-20306 - An unexpected error was encountered/ => "TransientBGSError"
+    /TUX-20306 - An unexpected error was encountered/ => "BGSError::Transient"
   }.freeze
 end
 # Many BGS calls fail in off-hours because BGS has maintenance time. These errors are classified
 # as transient errors and we ignore them in our reporting tools.
 
-class TransientBGSError < BGSError
-end
+class BGSError::Transient < BGSError; end

--- a/app/exceptions/vbms_error.rb
+++ b/app/exceptions/vbms_error.rb
@@ -4,8 +4,12 @@
 class VBMSError < DependencyError
   class Transient < VBMSError; end
   class DocumentNotFound < VBMSError; end
+  class ResultSetTooBig < VBMSError; end
 
   KNOWN_ERRORS = {
+    # https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/4812/events/314288/
+    /Requested result set exceeds acceptable size/ => "VBMSError::ResultSetTooBig",
+
     /Document not found/ => "VBMSError::DocumentNotFound",
 
     # Example: https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/2161/

--- a/app/exceptions/vbms_error.rb
+++ b/app/exceptions/vbms_error.rb
@@ -2,7 +2,12 @@
 
 # Wraps known VBMS errors so that we can better triage what gets reported in Sentry alerts.
 class VBMSError < DependencyError
+  class Transient < VBMSError; end
+  class DocumentNotFound < VBMSError; end
+
   KNOWN_ERRORS = {
+    /Document not found/ => "VBMSError::DocumentNotFound",
+
     # Example: https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/2161/
     /HTTPClient::ReceiveTimeoutError: execution expired/ => "VBMSError::Transient",
 
@@ -22,7 +27,3 @@ class VBMSError < DependencyError
     /Connection reset by peer - SSL_connect/ => "VBMSError::Transient"
   }.freeze
 end
-# Many VBMS calls fail in off-hours because VBMS has maintenance time. These errors are classified
-# as transient errors and we ignore them in our reporting tools.
-
-class VBMSError::Transient < VBMSError; end

--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -36,8 +36,6 @@ class ExternalApi::VBMSService
     documents = send_and_log_request(veteran_file_number, request)
     Rails.logger.info("VBMS Document list length: #{documents.length}")
     documents
-  rescue StandardError => e
-    raise ::VBMSError.from_dependency_error(e)
   end
 
   def self.fetch_document_file(document)
@@ -54,8 +52,6 @@ class ExternalApi::VBMSService
     request = VBMS::Requests::GetDocumentContent.new(document.document_id)
     result = send_and_log_request(document.document_id, request)
     result&.content
-  rescue StandardError => e
-    raise ::VBMSError.from_dependency_error(e)
   end
 
   def self.init_client

--- a/spec/exceptions/dependency_error_spec.rb
+++ b/spec/exceptions/dependency_error_spec.rb
@@ -24,13 +24,18 @@ describe DependencyError do
   describe ".from_dependency_error" do
     let(:bgs_error) { BGS::ShareError.new("Connection timed out - connect(2) for \"bepprod.vba.va.gov\" port 443") }
     let(:vbms_error) { VBMS::HTTPError.new(500, "HTTPClient::ReceiveTimeoutError: execution expired") }
+    let(:http_error) { HTTPClient::ReceiveTimeoutError.new("execution expired") }
 
     it "re-casts BGS exception" do
-      expect(BGSError.from_dependency_error(bgs_error)).to be_a(TransientBGSError)
+      expect(BGSError.from_dependency_error(bgs_error)).to be_a(BGSError::Transient)
     end
 
     it "re-casts VBMS exception" do
       expect(VBMSError.from_dependency_error(vbms_error)).to be_a(VBMSError::Transient)
+    end
+
+    it "re-casts HTTP exception" do
+      expect(VBMSError.from_dependency_error(http_error)).to be_a(VBMSError::Transient)
     end
   end
 end


### PR DESCRIPTION
Adds some new specific error classes, and fixes a bug where VBMSError was caught and re-thrown 2x, masking the original error in Sentry.