### PR TITLE
Add DocumentCounter service and controller endpoint

### DIFF
--- a/app/controllers/api/v2/manifests_controller.rb
+++ b/app/controllers/api/v2/manifests_controller.rb
@@ -1,24 +1,8 @@
 # TODO: create Api::V2::ApplicationController
-# rubocop:disable Metrics/CyclomaticComplexity
-# rubocop:disable Metrics/PerceivedComplexity
 class Api::V2::ManifestsController < Api::V1::ApplicationController
   def start
-    file_number = request.headers["HTTP_FILE_NUMBER"]
-    return missing_header("File Number") unless file_number
-
-    return invalid_file_number unless bgs_service.valid_file_number?(file_number)
-
-    begin
-      veteran_info = bgs_service.fetch_veteran_info(file_number)
-    rescue StandardError => e
-      return sensitive_record if e.message.include?("Sensitive File - Access Violation")
-      return vso_denied_record if e.message.include?("Power of Attorney of Folder is")
-      raise e
-    end
-
-    return veteran_not_found(file_number) unless bgs_service.record_found?(veteran_info)
-
-    file_number = veteran_info["file_number"] if veteran_info["file_number"]
+    file_number = verify_veteran_file_number
+    return if performed?
 
     manifest = Manifest.includes(:sources, :records).find_or_create_by_user(user: current_user, file_number: file_number)
     manifest.start!
@@ -53,10 +37,10 @@ class Api::V2::ManifestsController < Api::V1::ApplicationController
     doc_count = Rails.cache.fetch(cache_key) do
       doc_counter = DocumentCounter.new(manifest: Manifest.find(manifest_id))
       doc_counter.count
-    rescue ActiveRecord::RecordNotFound
-      return record_not_found
     end
     render json: { documents: doc_count }
+  rescue ActiveRecord::RecordNotFound
+    return record_not_found
   end
 
   private
@@ -87,6 +71,27 @@ class Api::V2::ManifestsController < Api::V1::ApplicationController
   def invalid_file_number
     render json: { status: "File number is invalid. Veteran IDs must be 8 or more characters and contain only numbers." }, status: 400
   end
+
+  def verify_veteran_file_number
+    file_number = request.headers["HTTP_FILE_NUMBER"]
+    return missing_header("File Number") unless file_number
+
+    return invalid_file_number unless bgs_service.valid_file_number?(file_number)
+
+    fetch_veteran_by_file_number(file_number)
+  end
+
+  def fetch_veteran_by_file_number(file_number)
+    begin
+      veteran_info = bgs_service.fetch_veteran_info(file_number)
+    rescue StandardError => e
+      return sensitive_record if e.message.include?("Sensitive File - Access Violation")
+      return vso_denied_record if e.message.include?("Power of Attorney of Folder is")
+      raise e
+    end
+
+    return veteran_not_found(file_number) unless bgs_service.record_found?(veteran_info)
+
+    veteran_info["file_number"] || file_number
+  end
 end
-# rubocop:enable Metrics/CyclomaticComplexity
-# rubocop:enable Metrics/PerceivedComplexity

--- a/app/controllers/api/v2/manifests_controller.rb
+++ b/app/controllers/api/v2/manifests_controller.rb
@@ -34,7 +34,7 @@ class Api::V2::ManifestsController < Api::V1::ApplicationController
   def document_count
     manifest_id = params[:id]
     cache_key = "manifest-doc-count-#{manifest_id}"
-    doc_count = Rails.cache.fetch(cache_key) do
+    doc_count = Rails.cache.fetch(cache_key, 2.hours) do
       doc_counter = DocumentCounter.new(manifest: Manifest.find(manifest_id))
       doc_counter.count
     end

--- a/app/controllers/api/v2/manifests_controller.rb
+++ b/app/controllers/api/v2/manifests_controller.rb
@@ -34,7 +34,7 @@ class Api::V2::ManifestsController < Api::V1::ApplicationController
   def document_count
     manifest_id = params[:id]
     cache_key = "manifest-doc-count-#{manifest_id}"
-    doc_count = Rails.cache.fetch(cache_key, 2.hours) do
+    doc_count = Rails.cache.fetch(cache_key, expires_in: 2.hours) do
       doc_counter = DocumentCounter.new(manifest: Manifest.find(manifest_id))
       doc_counter.count
     end

--- a/app/controllers/api/v2/manifests_controller.rb
+++ b/app/controllers/api/v2/manifests_controller.rb
@@ -47,6 +47,11 @@ class Api::V2::ManifestsController < Api::V1::ApplicationController
     render json: recent_downloads, each_serializer: Serializers::V2::HistorySerializer
   end
 
+  def document_count
+    doc_counter = DocumentCounter.new(manifest: Manifest.find(params[:id]))
+    render json: { documents: doc_counter.count }
+  end
+
   private
 
   def json_manifests(manifest)

--- a/app/services/document_counter.rb
+++ b/app/services/document_counter.rb
@@ -1,0 +1,14 @@
+class DocumentCounter
+  include ActiveModel::Model
+
+  attr_accessor :manifest
+
+  def count
+    total = 0
+    manifest.sources.each do |source|
+      documents = ManifestFetcher.new(manifest_source: source).fetch_documents
+      total += DocumentCreator.new(external_documents: documents).external_documents.count
+    end
+    total
+  end
+end

--- a/app/services/document_counter.rb
+++ b/app/services/document_counter.rb
@@ -6,8 +6,8 @@ class DocumentCounter
   def count
     total = 0
     manifest.sources.each do |source|
-      documents = ManifestFetcher.new(manifest_source: source).fetch_documents
-      total += DocumentCreator.new(external_documents: documents).external_documents.count
+      documents = ManifestFetcher.new(manifest_source: source).documents
+      total += DocumentFilter.new(documents: documents).filter.count
     end
     total
   end

--- a/app/services/document_creator.rb
+++ b/app/services/document_creator.rb
@@ -4,34 +4,6 @@ class DocumentCreator
   attr_accessor :manifest_source
   attr_writer :external_documents
 
-  # C&P Exam (DBQ) sent back as both XML and PDF, ignore the XML 999981
-  IGNORED_DOC_TYPES = %w[999981].freeze
-
-  # documents of type Fiduciary should not be shown
-  FIDUCIARY_DOC_TYPES = %w[
-    552 600 607 601 602 546 603 604 545 605 606
-    608 609 575 543 452 547 610 611 445 574 458
-    535 612 614 442 595 644 615 616 541 540 456
-    403 617 618 620 619 715 621 622 623 624 716
-    625 626 628 629 630 631 443 632 633 634 635
-    636 439 440 438 441 551 550 637 638 639 596
-    640 642 643 511 402 538 645 646 647 648 544
-    649 650 536 539 537 576 457 455 421 422 424
-    594 425 426 169 404 454 128 429 430 431 432
-    433 434 435 436 437 657 651 542 444 548
-    549
-  ].freeze
-
-  # documents of types IRS/SSA, IVM and Financial Actions should not be shown
-  RESTRICTED_VVA_DOC_TYPES = %w[
-    804 807 808 809 810 811 812 813 814 815 816
-    817 818 819 821 822 823 824 825 826 830 722
-    723 724 725 726 727 728 729 752 753 831 832
-    880 881
-  ].freeze
-
-  RESTRICTED_TYPES = IGNORED_DOC_TYPES + FIDUCIARY_DOC_TYPES + RESTRICTED_VVA_DOC_TYPES
-
   def create
     ManifestSource.transaction do
       # Re-create documents each time in order to use the latest versions
@@ -55,6 +27,6 @@ class DocumentCreator
 
   # Override the getter to return only non-restricted documents
   def external_documents
-    (@external_documents || []).reject { |document| RESTRICTED_TYPES.include?(document.type_id) || document.try(:restricted) }
+    DocumentFilter.new(documents: @external_documents).filter
   end
 end

--- a/app/services/document_filter.rb
+++ b/app/services/document_filter.rb
@@ -32,6 +32,9 @@ class DocumentFilter
   RESTRICTED_TYPES = IGNORED_DOC_TYPES + FIDUCIARY_DOC_TYPES + RESTRICTED_VVA_DOC_TYPES
 
   def filter
-    (@documents || []).reject { |doc| RESTRICTED_TYPES.include?(doc.type_id) || doc.try(:restricted) }
+    (@documents || []).reject do |doc|
+      doc_type = doc.try(:doc_type) || doc.type_id
+      RESTRICTED_TYPES.include?(doc_type) || doc.try(:restricted)
+    end
   end
 end

--- a/app/services/document_filter.rb
+++ b/app/services/document_filter.rb
@@ -1,4 +1,4 @@
-class DocumentCreator
+class DocumentFilter
   include ActiveModel::Model
 
   attr_accessor :documents

--- a/app/services/document_filter.rb
+++ b/app/services/document_filter.rb
@@ -1,0 +1,37 @@
+class DocumentCreator
+  include ActiveModel::Model
+
+  attr_accessor :documents
+
+  # C&P Exam (DBQ) sent back as both XML and PDF, ignore the XML 999981
+  IGNORED_DOC_TYPES = %w[999981].freeze
+
+  # documents of type Fiduciary should not be shown
+  FIDUCIARY_DOC_TYPES = %w[
+    552 600 607 601 602 546 603 604 545 605 606
+    608 609 575 543 452 547 610 611 445 574 458
+    535 612 614 442 595 644 615 616 541 540 456
+    403 617 618 620 619 715 621 622 623 624 716
+    625 626 628 629 630 631 443 632 633 634 635
+    636 439 440 438 441 551 550 637 638 639 596
+    640 642 643 511 402 538 645 646 647 648 544
+    649 650 536 539 537 576 457 455 421 422 424
+    594 425 426 169 404 454 128 429 430 431 432
+    433 434 435 436 437 657 651 542 444 548
+    549
+  ].freeze
+
+  # documents of types IRS/SSA, IVM and Financial Actions should not be shown
+  RESTRICTED_VVA_DOC_TYPES = %w[
+    804 807 808 809 810 811 812 813 814 815 816
+    817 818 819 821 822 823 824 825 826 830 722
+    723 724 725 726 727 728 729 752 753 831 832
+    880 881
+  ].freeze
+
+  RESTRICTED_TYPES = IGNORED_DOC_TYPES + FIDUCIARY_DOC_TYPES + RESTRICTED_VVA_DOC_TYPES
+
+  def filter
+    (@documents || []).reject { |doc| RESTRICTED_TYPES.include?(doc.type_id) || doc.try(:restricted) }
+  end
+end

--- a/app/services/download_documents.rb
+++ b/app/services/download_documents.rb
@@ -5,35 +5,9 @@ require "zip"
 class DownloadDocuments
   include Caseflow::DocumentTypes
 
-  # C&P Exam (DBQ) sent back as both XML and PDF, ignore the XML 999981
-  IGNORED_DOC_TYPES = %w[999981].freeze
-
-  # documents of type Fiduciary should not be shown
-  FIDUCIARY_DOC_TYPES = %w[
-    552 600 607 601 602 546 603 604 545 605 606
-    608 609 575 543 452 547 610 611 445 574 458
-    535 612 614 442 595 644 615 616 541 540 456
-    403 617 618 620 619 715 621 622 623 624 716
-    625 626 628 629 630 631 443 632 633 634 635
-    636 439 440 438 441 551 550 637 638 639 596
-    640 642 643 511 402 538 645 646 647 648 544
-    649 650 536 539 537 576 457 455 421 422 424
-    594 425 426 169 404 454 128 429 430 431 432
-    433 434 435 436 437 657 651 542 444 548
-    549
-  ].freeze
-
-  # documents of types IRS/SSA, IVM and Financial Actions should not be shown
-  RESTRICTED_VVA_DOC_TYPES = %w[
-    804 807 808 809 810 811 812 813 814 815 816
-    817 818 819 821 822 823 824 825 826 830 722
-    723 724 725 726 727 728 729 752 753 831 832
-    880 881
-  ].freeze
-
   def initialize(opts = {})
     @download = opts[:download]
-    @external_documents = DownloadDocuments.filter_documents(opts[:external_documents] || [])
+    @external_documents = DocumentFilter.new(documents: opts[:external_documents]).filter
   end
 
   def create_documents
@@ -134,15 +108,6 @@ class DownloadDocuments
 
   def before_package_contents
     # Test hook for testing race conditions
-  end
-
-  def self.filter_documents(external_documents)
-    types_to_filter = IGNORED_DOC_TYPES + FIDUCIARY_DOC_TYPES + RESTRICTED_VVA_DOC_TYPES
-    external_documents.reject do |document|
-      type_id = document.try(:doc_type) || document.type_id
-      # filter based on the type id and restricted value
-      types_to_filter.include?(type_id) || document.try(:restricted)
-    end
   end
 
   private

--- a/app/services/manifest_fetcher.rb
+++ b/app/services/manifest_fetcher.rb
@@ -6,7 +6,7 @@ class ManifestFetcher
   EXCEPTIONS = [VBMS::ClientError, VVA::ClientError].freeze
 
   def process
-    documents = manifest_source.service.v2_fetch_documents_for(manifest_source)
+    documents = fetch_documents
 
     DocumentCreator.new(manifest_source: manifest_source, external_documents: documents).create
     manifest_source.update!(status: :success, fetched_at: Time.zone.now)
@@ -15,5 +15,9 @@ class ManifestFetcher
     manifest_source.update!(status: :failed)
     ExceptionLogger.capture(e)
     []
+  end
+
+  def fetch_documents
+    manifest_source.service.v2_fetch_documents_for(manifest_source)
   end
 end

--- a/app/services/manifest_fetcher.rb
+++ b/app/services/manifest_fetcher.rb
@@ -6,8 +6,6 @@ class ManifestFetcher
   EXCEPTIONS = [VBMS::ClientError, VVA::ClientError].freeze
 
   def process
-    documents = fetch_documents
-
     DocumentCreator.new(manifest_source: manifest_source, external_documents: documents).create
     manifest_source.update!(status: :success, fetched_at: Time.zone.now)
     documents
@@ -17,7 +15,7 @@ class ManifestFetcher
     []
   end
 
-  def fetch_documents
+  def documents
     manifest_source.service.v2_fetch_documents_for(manifest_source)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
         post "/:id", action: :refresh
         get :history
         get "/:id", action: :progress
+        get "/:id/doccount", action: :document_count
       end
       resources :manifests, only: [] do
         post :files_downloads, to: "files_downloads#start"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
         post "/:id", action: :refresh
         get :history
         get "/:id", action: :progress
-        get "/:id/doccount", action: :document_count
+        get "/:id/document_count", action: :document_count
       end
       resources :manifests, only: [] do
         post :files_downloads, to: "files_downloads#start"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -116,6 +116,15 @@ module RandomHelper
   end
 end
 
+# Wrap this around your test to run it many times and ensure that it passes consistently.
+# Note: do not merge to master like this, or the tests will be slow! Ha.
+def ensure_stable
+  repeat_count = ENV["TRAVIS"] ? 100 : 20
+  repeat_count.times do
+    yield
+  end
+end
+
 RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/spec/requests/api/v2/manifests_spec.rb
+++ b/spec/requests/api/v2/manifests_spec.rb
@@ -61,7 +61,7 @@ describe "Manifests API v2", type: :request do
 
   context "document count" do
     let(:manifest) { Manifest.find_or_create_by!(file_number: "123C") }
-    let(:api_url) { "/api/v2/manifests/#{manifest.id}/doccount" }
+    let(:api_url) { "/api/v2/manifests/#{manifest.id}/document_count" }
 
     context "manifest does not exist" do
       let(:manifest) { Manifest.new(id: 0) }

--- a/spec/requests/api/v2/manifests_spec.rb
+++ b/spec/requests/api/v2/manifests_spec.rb
@@ -108,7 +108,7 @@ describe "Manifests API v2", type: :request do
       allow(VVAService).to receive(:v2_fetch_documents_for).and_return([])
     end
 
-    let!(:response_body) do
+    let!(:expected_body) do
       {
         data: {
           id: manifest.id.to_s,
@@ -143,14 +143,20 @@ describe "Manifests API v2", type: :request do
             records: []
           }
         }
-      }.to_json
+      }
     end
 
     it "returns empty array" do
       perform_enqueued_jobs do
         post "/api/v2/manifests", params: nil, headers: headers
         expect(response.code).to eq("200")
-        expect(response.body).to eq(response_body)
+
+        got_body = JSON.parse(response.body, symbolize_names: true)
+        expected_sources = expected_body[:data][:attributes].delete(:sources)
+        got_sources = got_body[:data][:attributes].delete(:sources)
+
+        expect(got_body).to eq(expected_body)
+        expect(got_sources).to contain_exactly(*expected_sources)
       end
     end
   end

--- a/spec/requests/api/v2/manifests_spec.rb
+++ b/spec/requests/api/v2/manifests_spec.rb
@@ -59,6 +59,49 @@ describe "Manifests API v2", type: :request do
     end
   end
 
+  context "document count" do
+    let(:manifest) { Manifest.find_or_create_by!(file_number: "123C") }
+    let(:api_url) { "/api/v2/manifests/#{manifest.id}/doccount" }
+
+    context "manifest does not exist" do
+      let(:manifest) { Manifest.new(id: 0) }
+
+      it "returns 404" do
+        get api_url, headers: headers
+        expect(response.code).to eq("404")
+        body = JSON.parse(response.body)
+        expect(body["errors"][0]["detail"]).to match(/A record with that ID was not found in our systems/)
+      end
+    end
+
+    context "manifest has no records" do
+      it "returns 0" do
+        get api_url, headers: headers
+        expect(response.code).to eq("200")
+        expect(response.body).to eq({ documents: 0 }.to_json)
+      end
+    end
+
+    context "manifest has records" do
+      before do
+        allow_any_instance_of(DocumentCounter).to receive(:count).and_return(10)
+      end
+
+      it "returns count" do
+        get api_url, headers: headers
+        expect(response.code).to eq("200")
+        expect(response.body).to eq({ documents: 10 }.to_json)
+      end
+
+      it "caches result" do
+        cache_key = "manifest-doc-count-#{manifest.id}"
+        expect(Rails.cache.exist?(cache_key)).to eq(false)
+        get api_url, headers: headers
+        expect(Rails.cache.exist?(cache_key)).to eq(true)
+      end
+    end
+  end
+
   context "When the manifest has no records" do
     before do
       allow(VBMSService).to receive(:v2_fetch_documents_for).and_return([])

--- a/spec/requests/api/v2/manifests_spec.rb
+++ b/spec/requests/api/v2/manifests_spec.rb
@@ -146,7 +146,7 @@ describe "Manifests API v2", type: :request do
       }.to_json
     end
 
-    xit "returns empty array" do
+    it "returns empty array" do
       perform_enqueued_jobs do
         post "/api/v2/manifests", params: nil, headers: headers
         expect(response.code).to eq("200")

--- a/spec/services/document_counter_spec.rb
+++ b/spec/services/document_counter_spec.rb
@@ -18,8 +18,8 @@ describe DocumentCounter do
   let(:vbms_fetcher) { ManifestFetcher.new(manifest_source: vbms_source) }
 
   before do
-    allow(vva_fetcher).to receive(:fetch_documents).and_return(vva_documents)
-    allow(vbms_fetcher).to receive(:fetch_documents).and_return(vbms_documents)
+    allow(vva_fetcher).to receive(:documents).and_return(vva_documents)
+    allow(vbms_fetcher).to receive(:documents).and_return(vbms_documents)
     allow(ManifestFetcher).to receive(:new).with(manifest_source: vva_source).and_return(vva_fetcher)
     allow(ManifestFetcher).to receive(:new).with(manifest_source: vbms_source).and_return(vbms_fetcher)
   end

--- a/spec/services/document_counter_spec.rb
+++ b/spec/services/document_counter_spec.rb
@@ -1,0 +1,34 @@
+describe DocumentCounter do
+  let(:manifest) { Manifest.create(file_number: "1234") }
+  let(:vva_source) { ManifestSource.create(name: "VVA", manifest: manifest) }
+  let(:vbms_source) { ManifestSource.create(name: "VBMS", manifest: manifest) }
+  let(:vbms_documents) do
+    [
+      OpenStruct.new(document_id: "1", series_id: "3"),
+      OpenStruct.new(document_id: "2", series_id: "4", type_id: DocumentCreator::RESTRICTED_TYPES.sample)
+    ]
+  end
+  let(:vva_documents) do
+    [
+      OpenStruct.new(document_id: "11", series_id: "3"),
+      OpenStruct.new(document_id: "12", series_id: "4", type_id: DocumentCreator::RESTRICTED_TYPES.sample)
+    ]
+  end
+  let(:vva_fetcher) { ManifestFetcher.new(manifest_source: vva_source) }
+  let(:vbms_fetcher) { ManifestFetcher.new(manifest_source: vbms_source) }
+
+  before do
+    allow(vva_fetcher).to receive(:fetch_documents).and_return(vva_documents)
+    allow(vbms_fetcher).to receive(:fetch_documents).and_return(vbms_documents)
+    allow(ManifestFetcher).to receive(:new).with(manifest_source: vva_source).and_return(vva_fetcher)
+    allow(ManifestFetcher).to receive(:new).with(manifest_source: vbms_source).and_return(vbms_fetcher)
+  end
+
+  describe "#count" do
+    subject { described_class.new(manifest: manifest) }
+
+    it "returns total unrestricted document count for all sources" do
+      expect(subject.count).to eq(2)
+    end
+  end
+end

--- a/spec/services/document_counter_spec.rb
+++ b/spec/services/document_counter_spec.rb
@@ -5,13 +5,13 @@ describe DocumentCounter do
   let(:vbms_documents) do
     [
       OpenStruct.new(document_id: "1", series_id: "3"),
-      OpenStruct.new(document_id: "2", series_id: "4", type_id: DocumentCreator::RESTRICTED_TYPES.sample)
+      OpenStruct.new(document_id: "2", series_id: "4", type_id: DocumentFilter::RESTRICTED_TYPES.sample)
     ]
   end
   let(:vva_documents) do
     [
       OpenStruct.new(document_id: "11", series_id: "3"),
-      OpenStruct.new(document_id: "12", series_id: "4", type_id: DocumentCreator::RESTRICTED_TYPES.sample)
+      OpenStruct.new(document_id: "12", series_id: "4", type_id: DocumentFilter::RESTRICTED_TYPES.sample)
     ]
   end
   let(:vva_fetcher) { ManifestFetcher.new(manifest_source: vva_source) }

--- a/spec/services/document_creator_spec.rb
+++ b/spec/services/document_creator_spec.rb
@@ -42,7 +42,7 @@ describe DocumentCreator do
     context "when there are restricted document types" do
       let(:documents) do
         [
-          OpenStruct.new(document_id: "1", series_id: "3", type_id: DocumentCreator::RESTRICTED_TYPES.sample),
+          OpenStruct.new(document_id: "1", series_id: "3", type_id: DocumentFilter::RESTRICTED_TYPES.sample),
           OpenStruct.new(document_id: "2", series_id: "4", type_id: "554")
         ]
       end


### PR DESCRIPTION
**Why**: Caseflow Queue needs only a document count for display purposes. We should not have to wait for the entire manifest's worth of documents to be downloaded and processed if all we need is the count that will eventually be downloaded.

This API endpoint should provide a very fast count of what the manifest will eventually contain.