### PR TITLE
DocumentCounter can use Veteran or Manifest

### DIFF
--- a/app/controllers/api/v2/application_controller.rb
+++ b/app/controllers/api/v2/application_controller.rb
@@ -1,0 +1,42 @@
+class Api::V2::ApplicationController < Api::V1::ApplicationController
+  private
+
+  def bgs_service
+    @bgs_service ||= BGSService.new
+  end
+
+  def veteran_not_found(file_number)
+    render json: { status: "eFolder Express could not find an eFolder with the Veteran ID #{file_number}. Check to make sure you entered the ID correctly and try again." }, status: 400
+  end
+
+  def vso_denied_record
+    forbidden("This efolder belongs to a Veteran you do not represent. Please contact your supervisor.")
+  end
+
+  def invalid_file_number
+    render json: { status: "File number is invalid. Veteran IDs must be 8 or more characters and contain only numbers." }, status: 400
+  end
+
+  def verify_veteran_file_number
+    file_number = request.headers["HTTP_FILE_NUMBER"]
+    return missing_header("File Number") unless file_number
+
+    return invalid_file_number unless bgs_service.valid_file_number?(file_number)
+
+    fetch_veteran_by_file_number(file_number)
+  end
+
+  def fetch_veteran_by_file_number(file_number)
+    begin
+      veteran_info = bgs_service.fetch_veteran_info(file_number)
+    rescue StandardError => e
+      return sensitive_record if e.message.include?("Sensitive File - Access Violation")
+      return vso_denied_record if e.message.include?("Power of Attorney of Folder is")
+      raise e
+    end
+
+    return veteran_not_found(file_number) unless bgs_service.record_found?(veteran_info)
+
+    veteran_info["file_number"] || file_number
+  end
+end

--- a/app/controllers/api/v2/files_downloads_controller.rb
+++ b/app/controllers/api/v2/files_downloads_controller.rb
@@ -1,4 +1,4 @@
-class Api::V2::FilesDownloadsController < Api::V1::ApplicationController
+class Api::V2::FilesDownloadsController < Api::V2::ApplicationController
   before_action :files_download_exists?
 
   def start

--- a/app/controllers/api/v2/manifests_controller.rb
+++ b/app/controllers/api/v2/manifests_controller.rb
@@ -1,5 +1,4 @@
-# TODO: create Api::V2::ApplicationController
-class Api::V2::ManifestsController < Api::V1::ApplicationController
+class Api::V2::ManifestsController < Api::V2::ApplicationController
   def start
     file_number = verify_veteran_file_number
     return if performed?
@@ -54,44 +53,5 @@ class Api::V2::ManifestsController < Api::V1::ApplicationController
 
   def recent_downloads
     @recent_downloads ||= distribute_reads { current_user.recent_downloads.to_a }
-  end
-
-  def bgs_service
-    @bgs_service ||= BGSService.new
-  end
-
-  def veteran_not_found(file_number)
-    render json: { status: "eFolder Express could not find an eFolder with the Veteran ID #{file_number}. Check to make sure you entered the ID correctly and try again." }, status: 400
-  end
-
-  def vso_denied_record
-    forbidden("This efolder belongs to a Veteran you do not represent. Please contact your supervisor.")
-  end
-
-  def invalid_file_number
-    render json: { status: "File number is invalid. Veteran IDs must be 8 or more characters and contain only numbers." }, status: 400
-  end
-
-  def verify_veteran_file_number
-    file_number = request.headers["HTTP_FILE_NUMBER"]
-    return missing_header("File Number") unless file_number
-
-    return invalid_file_number unless bgs_service.valid_file_number?(file_number)
-
-    fetch_veteran_by_file_number(file_number)
-  end
-
-  def fetch_veteran_by_file_number(file_number)
-    begin
-      veteran_info = bgs_service.fetch_veteran_info(file_number)
-    rescue StandardError => e
-      return sensitive_record if e.message.include?("Sensitive File - Access Violation")
-      return vso_denied_record if e.message.include?("Power of Attorney of Folder is")
-      raise e
-    end
-
-    return veteran_not_found(file_number) unless bgs_service.record_found?(veteran_info)
-
-    veteran_info["file_number"] || file_number
   end
 end

--- a/app/controllers/api/v2/manifests_controller.rb
+++ b/app/controllers/api/v2/manifests_controller.rb
@@ -30,18 +30,6 @@ class Api::V2::ManifestsController < Api::V2::ApplicationController
     render json: recent_downloads, each_serializer: Serializers::V2::HistorySerializer
   end
 
-  def document_count
-    manifest_id = params[:id]
-    cache_key = "manifest-doc-count-#{manifest_id}"
-    doc_count = Rails.cache.fetch(cache_key, expires_in: 2.hours) do
-      doc_counter = DocumentCounter.new(manifest: Manifest.find(manifest_id))
-      doc_counter.count
-    end
-    render json: { documents: doc_count }
-  rescue ActiveRecord::RecordNotFound
-    return record_not_found
-  end
-
   private
 
   def json_manifests(manifest)

--- a/app/controllers/api/v2/records_controller.rb
+++ b/app/controllers/api/v2/records_controller.rb
@@ -1,4 +1,4 @@
-class Api::V2::RecordsController < Api::V1::ApplicationController
+class Api::V2::RecordsController < Api::V2::ApplicationController
   before_action :validate_access
 
   def show

--- a/app/controllers/api/v2/veterans_controller.rb
+++ b/app/controllers/api/v2/veterans_controller.rb
@@ -4,9 +4,8 @@ class Api::V2::VeteransController < Api::V2::ApplicationController
     return if performed?
 
     cache_key = "veteran-doc-count-#{file_number}"
-    veteran = Veteran.new(file_number: file_number)
     doc_count = Rails.cache.fetch(cache_key, expires_in: 2.hours) do
-      doc_counter = DocumentCounter.new(veteran: veteran)
+      doc_counter = DocumentCounter.new(veteran_file_number: file_number)
       doc_counter.count
     end
     render json: { documents: doc_count }

--- a/app/controllers/api/v2/veterans_controller.rb
+++ b/app/controllers/api/v2/veterans_controller.rb
@@ -1,9 +1,9 @@
 class Api::V2::VeteransController < Api::V2::ApplicationController
-  def show
+  def index
     file_number = verify_veteran_file_number
     return if performed?
 
-    cache_key = "manifest-doc-count-#{file_number}"
+    cache_key = "veteran-doc-count-#{file_number}"
     veteran = Veteran.new(file_number: file_number)
     doc_count = Rails.cache.fetch(cache_key, expires_in: 2.hours) do
       doc_counter = DocumentCounter.new(veteran: veteran)

--- a/app/controllers/api/v2/veterans_controller.rb
+++ b/app/controllers/api/v2/veterans_controller.rb
@@ -1,0 +1,16 @@
+class Api::V2::VeteransController < Api::V2::ApplicationController
+  def show
+    file_number = verify_veteran_file_number
+    return if performed?
+
+    cache_key = "manifest-doc-count-#{file_number}"
+    veteran = Veteran.new(file_number: file_number)
+    doc_count = Rails.cache.fetch(cache_key, expires_in: 2.hours) do
+      doc_counter = DocumentCounter.new(veteran: veteran)
+      doc_counter.count
+    end
+    render json: { documents: doc_count }
+  rescue ActiveRecord::RecordNotFound
+    return record_not_found
+  end
+end

--- a/app/services/document_counter.rb
+++ b/app/services/document_counter.rb
@@ -1,14 +1,22 @@
 class DocumentCounter
   include ActiveModel::Model
 
-  attr_accessor :manifest
+  attr_accessor :manifest, :veteran
 
   def count
     total = 0
-    manifest.sources.each do |source|
-      documents = ManifestFetcher.new(manifest_source: source).documents
+    services.each do |service|
+      documents = service.v2_fetch_documents_for(manifest || veteran)
       total += DocumentFilter.new(documents: documents).filter.count
     end
     total
+  end
+
+  private
+
+  def services
+    return manifest.sources.map(&:service) if manifest
+    return [VBMSService, VVAService] if veteran
+    []
   end
 end

--- a/app/services/document_counter.rb
+++ b/app/services/document_counter.rb
@@ -1,22 +1,15 @@
 class DocumentCounter
   include ActiveModel::Model
 
-  attr_accessor :manifest, :veteran
+  attr_accessor :veteran_file_number
 
   def count
     total = 0
-    services.each do |service|
-      documents = service.v2_fetch_documents_for(manifest || veteran)
+    [VBMSService, VVAService].each do |service|
+      source = OpenStruct.new(file_number: veteran_file_number)
+      documents = service.v2_fetch_documents_for(source)
       total += DocumentFilter.new(documents: documents).filter.count
     end
     total
-  end
-
-  private
-
-  def services
-    return manifest.sources.map(&:service) if manifest
-    return [VBMSService, VVAService] if veteran
-    []
   end
 end

--- a/app/services/document_counter.rb
+++ b/app/services/document_counter.rb
@@ -6,8 +6,7 @@ class DocumentCounter
   def count
     total = 0
     [VBMSService, VVAService].each do |service|
-      source = OpenStruct.new(file_number: veteran_file_number)
-      documents = service.v2_fetch_documents_for(source)
+      documents = service.v2_fetch_documents_for(veteran_file_number)
       total += DocumentFilter.new(documents: documents).filter.count
     end
     total

--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -27,10 +27,9 @@ class ExternalApi::VBMSService
     documents
   end
 
-  def self.v2_fetch_documents_for(source)
+  def self.v2_fetch_documents_for(veteran_file_number)
     @vbms_client ||= init_client
 
-    veteran_file_number = source.file_number
     request = VBMS::Requests::FindDocumentVersionReference.new(veteran_file_number)
 
     documents = send_and_log_request(veteran_file_number, request)

--- a/app/services/external_api/vva_service.rb
+++ b/app/services/external_api/vva_service.rb
@@ -13,12 +13,12 @@ class ExternalApi::VVAService
     documents
   end
 
-  def self.v2_fetch_documents_for(source)
+  def self.v2_fetch_documents_for(file_number)
     @vva_client ||= init_client
-    documents ||= MetricsService.record("VVA: get document list for: #{source.file_number}",
+    documents ||= MetricsService.record("VVA: get document list for: #{file_number}",
                                         service: :vva,
                                         name: "document_list.get_by_claim_number") do
-      @vva_client.document_list.get_by_claim_number(source.file_number)
+      @vva_client.document_list.get_by_claim_number(file_number)
     end
     Rails.logger.info("VVA Document list length: #{documents.length}")
     documents

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
         get :zip, to: "files_downloads#zip"
       end
       resources :records, only: :show, param: :version_id
+      resources :veterans, only: :index
     end
   end
 

--- a/lib/fakes/document_service.rb
+++ b/lib/fakes/document_service.rb
@@ -46,6 +46,11 @@ class Fakes::DocumentService
       manifest_load: 4,
       num_docs: 10,
       max_file_load: 3
+    },
+    "DEMOFAST" => {
+      manifest_load: 0,
+      num_docs: 10,
+      max_file_load: 1
     }
   }.freeze
 
@@ -54,7 +59,7 @@ class Fakes::DocumentService
     demo = DEMOS[source.file_number] || DEMOS["DEMODEFAULT"]
     return [] if !demo || demo[:num_docs] <= 0
 
-    sleep_and_check_for_error(demo, source.name)
+    sleep_and_check_for_error(demo, source.try(:name) || source.try(:id))
 
     (1..(demo[:num_docs] || 0)).to_a.map do |i|
       create_document(i)
@@ -132,7 +137,7 @@ class Fakes::DocumentService
 
     OpenStruct.new(
       vbms_filename: "happy-thursday-#{SecureRandom.hex}.#{type[:ext]}",
-      type_id: Document::TYPES.keys.sample,
+      type_id: (11..20).to_a.sample,
       document_id: "{#{SecureRandom.hex(4).upcase}-#{SecureRandom.hex(2).upcase}-#{SecureRandom.hex(2).upcase}-#{SecureRandom.hex(2).upcase}-#{SecureRandom.hex(6).upcase}}",
       version_id: "{#{SecureRandom.hex(4).upcase}-#{SecureRandom.hex(2).upcase}-#{SecureRandom.hex(2).upcase}-#{SecureRandom.hex(2).upcase}-#{SecureRandom.hex(6).upcase}}",
       series_id: "{#{SecureRandom.hex(4).upcase}-#{SecureRandom.hex(2).upcase}-#{SecureRandom.hex(2).upcase}-#{SecureRandom.hex(2).upcase}-#{SecureRandom.hex(6).upcase}}",

--- a/lib/fakes/document_service.rb
+++ b/lib/fakes/document_service.rb
@@ -55,11 +55,11 @@ class Fakes::DocumentService
   }.freeze
 
   ### Fakes v2 START
-  def self.v2_fetch_documents_for(source)
-    demo = DEMOS[source.file_number] || DEMOS["DEMODEFAULT"]
+  def self.v2_fetch_documents_for(file_number)
+    demo = DEMOS[file_number] || DEMOS["DEMODEFAULT"]
     return [] if !demo || demo[:num_docs] <= 0
 
-    sleep_and_check_for_error(demo, source.try(:name) || source.try(:id))
+    sleep_and_check_for_error(demo, file_number)
 
     (1..(demo[:num_docs] || 0)).to_a.map do |i|
       create_document(i)

--- a/spec/requests/api/v2/manifests_spec.rb
+++ b/spec/requests/api/v2/manifests_spec.rb
@@ -59,49 +59,6 @@ describe "Manifests API v2", type: :request do
     end
   end
 
-  context "document count" do
-    let(:manifest) { Manifest.find_or_create_by!(file_number: "123C") }
-    let(:api_url) { "/api/v2/manifests/#{manifest.id}/document_count" }
-
-    context "manifest does not exist" do
-      let(:manifest) { Manifest.new(id: 0) }
-
-      it "returns 404" do
-        get api_url, headers: headers
-        expect(response.code).to eq("404")
-        body = JSON.parse(response.body)
-        expect(body["errors"][0]["detail"]).to match(/A record with that ID was not found in our systems/)
-      end
-    end
-
-    context "manifest has no records" do
-      it "returns 0" do
-        get api_url, headers: headers
-        expect(response.code).to eq("200")
-        expect(response.body).to eq({ documents: 0 }.to_json)
-      end
-    end
-
-    context "manifest has records" do
-      before do
-        allow_any_instance_of(DocumentCounter).to receive(:count).and_return(10)
-      end
-
-      it "returns count" do
-        get api_url, headers: headers
-        expect(response.code).to eq("200")
-        expect(response.body).to eq({ documents: 10 }.to_json)
-      end
-
-      it "caches result" do
-        cache_key = "manifest-doc-count-#{manifest.id}"
-        expect(Rails.cache.exist?(cache_key)).to eq(false)
-        get api_url, headers: headers
-        expect(Rails.cache.exist?(cache_key)).to eq(true)
-      end
-    end
-  end
-
   context "When the manifest has no records" do
     before do
       allow(VBMSService).to receive(:v2_fetch_documents_for).and_return([])

--- a/spec/requests/api/v2/veterans_spec.rb
+++ b/spec/requests/api/v2/veterans_spec.rb
@@ -1,0 +1,41 @@
+describe "Veterans API v2", type: :request do
+  include ActiveJob::TestHelper
+
+  let!(:current_user) do
+    User.authenticate!(roles: [])
+  end
+  let(:user) do
+    User.create(
+      css_id: "TEST_USER",
+      station_id: 283
+    )
+  end
+  let(:veteran_id) { "DEMOFAST" }
+  let(:token) { "token" }
+  let(:headers) do
+    {
+      "HTTP_FILE_NUMBER" => veteran_id,
+      "HTTP_CSS_ID" => user.css_id,
+      "HTTP_STATION_ID" => user.station_id,
+      "HTTP_AUTHORIZATION" => "Token token=#{token}"
+    }
+  end
+
+  before do
+    allow_any_instance_of(Fakes::BGSService).to receive(:sensitive_files).and_return(veteran_id.to_s => false)
+    allow_any_instance_of(Fakes::BGSService).to receive(:record_found?).and_return(true)
+    Timecop.freeze(Time.utc(2015, 1, 1, 17, 0, 0))
+  end
+
+  describe "#index" do
+    it "returns veteran document count" do
+      get "/api/v2/veterans", params: nil, headers: headers
+
+      expect(response.code).to eq("200")
+
+      body = JSON.parse(response.body, symbolize_names: true)
+
+      expect(body[:documents]).to eq(20)
+    end
+  end
+end

--- a/spec/services/document_counter_spec.rb
+++ b/spec/services/document_counter_spec.rb
@@ -1,34 +1,34 @@
 describe DocumentCounter do
-  let(:manifest) { Manifest.create(file_number: "1234") }
-  let(:vva_source) { ManifestSource.create(name: "VVA", manifest: manifest) }
-  let(:vbms_source) { ManifestSource.create(name: "VBMS", manifest: manifest) }
-  let(:vbms_documents) do
-    [
-      OpenStruct.new(document_id: "1", series_id: "3"),
-      OpenStruct.new(document_id: "2", series_id: "4", type_id: DocumentFilter::RESTRICTED_TYPES.sample)
-    ]
-  end
+  let(:manifest) { Manifest.create(file_number: "DEMOFAST") }
+  let!(:vva_source) { ManifestSource.create(name: "VVA", manifest: manifest) }
+  let!(:vbms_source) { ManifestSource.create(name: "VBMS", manifest: manifest) }
+  let(:veteran) { Veteran.new(file_number: "DEMOFAST") }
   let(:vva_documents) do
     [
       OpenStruct.new(document_id: "11", series_id: "3"),
       OpenStruct.new(document_id: "12", series_id: "4", type_id: DocumentFilter::RESTRICTED_TYPES.sample)
     ]
   end
-  let(:vva_fetcher) { ManifestFetcher.new(manifest_source: vva_source) }
-  let(:vbms_fetcher) { ManifestFetcher.new(manifest_source: vbms_source) }
 
   before do
-    allow(vva_fetcher).to receive(:documents).and_return(vva_documents)
-    allow(vbms_fetcher).to receive(:documents).and_return(vbms_documents)
-    allow(ManifestFetcher).to receive(:new).with(manifest_source: vva_source).and_return(vva_fetcher)
-    allow(ManifestFetcher).to receive(:new).with(manifest_source: vbms_source).and_return(vbms_fetcher)
+    allow(Fakes::VVAService).to receive(:v2_fetch_documents_for).and_return(vva_documents)
   end
 
   describe "#count" do
-    subject { described_class.new(manifest: manifest) }
+    context "with manifest" do
+      subject { described_class.new(manifest: manifest) }
 
-    it "returns total unrestricted document count for all sources" do
-      expect(subject.count).to eq(2)
+      it "returns total unrestricted document count for all sources" do
+        expect(subject.count).to eq(11)
+      end
+    end
+
+    context "with veteran" do
+      subject { described_class.new(veteran: veteran) }
+
+      it "returns total unrestricted document count for all sources" do
+        expect(subject.count).to eq(11)
+      end
     end
   end
 end

--- a/spec/services/document_counter_spec.rb
+++ b/spec/services/document_counter_spec.rb
@@ -1,8 +1,4 @@
 describe DocumentCounter do
-  let(:manifest) { Manifest.create(file_number: "DEMOFAST") }
-  let!(:vva_source) { ManifestSource.create(name: "VVA", manifest: manifest) }
-  let!(:vbms_source) { ManifestSource.create(name: "VBMS", manifest: manifest) }
-  let(:veteran) { Veteran.new(file_number: "DEMOFAST") }
   let(:vva_documents) do
     [
       OpenStruct.new(document_id: "11", series_id: "3"),
@@ -15,20 +11,10 @@ describe DocumentCounter do
   end
 
   describe "#count" do
-    context "with manifest" do
-      subject { described_class.new(manifest: manifest) }
+    subject { described_class.new(veteran_file_number: "DEMOFAST") }
 
-      it "returns total unrestricted document count for all sources" do
-        expect(subject.count).to eq(11)
-      end
-    end
-
-    context "with veteran" do
-      subject { described_class.new(veteran: veteran) }
-
-      it "returns total unrestricted document count for all sources" do
-        expect(subject.count).to eq(11)
-      end
+    it "returns total unrestricted document count for all sources" do
+      expect(subject.count).to eq(11) # 10 for DEMOFAST + 1 unrestricted vva_documents
     end
   end
 end


### PR DESCRIPTION
**Description**

Adds a new API endpoint `GET /api/v2/veterans` which will return the document count for the Veteran.

**Why**

No manifest required. Returns the total documents across all services for any Veteran.