### PR TITLE
Remove unused env vars

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem "redis-namespace"
 gem "redis-rails", "~> 5.0.2"
 gem "redis-semaphore"
 gem "request_store"
-gem "rubyzip", "~> 1.2.2"
+gem "rubyzip", ">= 1.3.0"
 gem "sass-rails", "~> 5.0"
 gem "sdoc", "~> 0.4.0", group: :doc
 gem "sentry-raven"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,7 +368,7 @@ GEM
     ruby_dep (1.5.0)
     ruby_parser (3.7.3)
       sexp_processor (~> 4.1)
-    rubyzip (1.2.2)
+    rubyzip (1.3.0)
     safe_yaml (1.0.4)
     sass (3.5.5)
       sass-listen (~> 4.0.0)
@@ -514,7 +514,7 @@ DEPENDENCIES
   rspec
   rspec-rails
   rubocop (~> 0.52.1)
-  rubyzip (~> 1.2.2)
+  rubyzip (>= 1.3.0)
   sass-rails (~> 5.0)
   scss_lint
   sdoc (~> 0.4.0)

--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ Add this to a `.env` file in your application root directory:
 ```
 POSTGRES_PORT=15432
 REDIS_URL_CACHE=redis://localhost:16379/0/cache/
-REDIS_URL_SIDEKIQ=redis://localhost:16379
 ```
 
 Then to run the test suite:

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -53,9 +53,6 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  ENV["METRICS_USERNAME"] = "caseflow"
-  ENV["METRICS_PASSWORD"] = "caseflow"
-
   config.sqs_create_queues = true
   config.sqs_endpoint = 'http://localhost:14576'
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -49,9 +49,6 @@ Rails.application.configure do
   config.sqs_create_queues = true
   config.sqs_endpoint = 'http://localhost:4576'
 
-  ENV["METRICS_USERNAME"] = "caseflow"
-  ENV["METRICS_PASSWORD"] = "caseflow"
-
   # Allow health check to pushgateway
   ENV["ENABLE_PUSHGATEWAY_HEALTHCHECK"] = "true"
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -18,7 +18,6 @@
 development:
   secret_key_base: 8c6b64e47fa8d523a9ea3d7e7658dbd5ee916003785039b14ffdd076fae644afaedc04eb683fc705c47f6f07020184c8cf3a30e79f2258521a45b861ab8e7862
   redis_url_cache: <%= ENV["REDIS_URL_CACHE"] || "redis://localhost:16379/0/cache/" %>
-  redis_url: <%= ENV["REDIS_URL_SIDEKIQ"] || "redis://localhost:16379" %>
   vbms:
     url: https://filenet.uat.vbms.aide.oit.va.gov/vbmsp2-cms/streaming/eDocumentService-v4
     env_dir: ../deployment/decrypted_creds/uat_creds
@@ -32,7 +31,6 @@ development:
 staging:
   secret_key_base: 8c6b64e47fa8d523a9ea3d7e7658dbd5ee916003785039b14ffdd076fae644afaedc04eb683fc705c47f6f07020184c8cf3a30e79f2258521a45b861ab8e7862
   redis_url_cache: <%= ENV["REDIS_URL_CACHE"] || "redis://localhost:6379/0/cache/" %>
-  redis_url: <%= ENV["REDIS_URL_SIDEKIQ"] || "redis://localhost:6379" %>
   vbms:
     env: uat
     url: https://filenet.uat.vbms.aide.oit.va.gov/vbmsp2-cms/streaming/eDocumentService-v4
@@ -47,13 +45,10 @@ staging:
 demo:
   secret_key_base: 8c6b64e47fa8d523a9ea3d7e7658dbd5ee916003785039b14ffdd076fae644afaedc04eb683fc705c47f6f07020184c8cf3a30e79f2258521a45b861ab8e7862
   redis_url_cache: <%= ENV["REDIS_URL_CACHE"] || "redis://localhost:6379/0/cache/" %>
-  redis_url: <%= ENV["REDIS_URL_SIDEKIQ"] || "redis://localhost:6379" %>
-
 
 test:
   secret_key_base: 35cf2535cc790c92a07bcab48a5f21bbd132a7071984947e8cc92d2ce8e60d582c62022b7ddcfa6f0eca34319dfe1482fbf21d2c78e50c12e884be9ea5fea7e0
   redis_url_cache: <%= ENV["REDIS_URL_CACHE"] || "redis://localhost:6379/0/cache/" %>
-  redis_url: <%= ENV["REDIS_URL_SIDEKIQ"] || "redis://localhost:6379" %>
 
 # Do not keep production secrets in the unencrypted secrets file.
 # Instead, either read values from the environment.
@@ -62,6 +57,5 @@ test:
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   redis_url_cache: <%= ENV["REDIS_URL_CACHE"] %>
-  redis_url: <%= ENV["REDIS_URL_SIDEKIQ"] %>
   vbms:
       env: true


### PR DESCRIPTION
* Removing sidekiq env variables as we no longer use sidekiq.
* Removing metrics password/username since these were used by Prometheus

Test plan: 
- [x] deploy to UAT, run any job from the rails console, make sure it works