### PR TITLE
Remove unused env vars and make sure semaphore uses Redis cache

### DIFF
--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -34,7 +34,7 @@ class Manifest < ApplicationRecord
 
   def download_and_package_files!
     s = Redis::Semaphore.new("package_files_#{id}".to_s,
-                             url: Rails.application.secrets.redis_url,
+                             url: Rails.application.secrets.redis_url_cache,
                              expiration: SECONDS_TO_AUTO_UNLOCK)
     s.lock(SECONDS_TO_AUTO_UNLOCK) do
       return if pending?

--- a/app/models/manifest_source.rb
+++ b/app/models/manifest_source.rb
@@ -20,8 +20,9 @@ class ManifestSource < ApplicationRecord
   SECONDS_TO_AUTO_UNLOCK = 5
 
   def start!
+    binding.pry
     s = Redis::Semaphore.new("download_manifest_source_#{id}".to_s,
-                             url: Rails.application.secrets.redis_url,
+                             url: Rails.application.secrets.redis_url_cache,
                              expiration: SECONDS_TO_AUTO_UNLOCK)
     s.lock(SECONDS_TO_AUTO_UNLOCK) do
       return if current? || pending?

--- a/app/models/manifest_source.rb
+++ b/app/models/manifest_source.rb
@@ -20,7 +20,6 @@ class ManifestSource < ApplicationRecord
   SECONDS_TO_AUTO_UNLOCK = 5
 
   def start!
-    binding.pry
     s = Redis::Semaphore.new("download_manifest_source_#{id}".to_s,
                              url: Rails.application.secrets.redis_url_cache,
                              expiration: SECONDS_TO_AUTO_UNLOCK)

--- a/app/services/record_fetcher.rb
+++ b/app/services/record_fetcher.rb
@@ -8,7 +8,7 @@ class RecordFetcher
 
   def process
     s = Redis::Semaphore.new("record_#{record.id}".to_s,
-                             url: Rails.application.secrets.redis_url,
+                             url: Rails.application.secrets.redis_url_cache,
                              expiration: SECONDS_TO_AUTO_UNLOCK)
     s.lock(SECONDS_TO_AUTO_UNLOCK)
     content_from_s3 || content_from_vbms

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -53,9 +53,6 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  ENV["METRICS_USERNAME"] = "caseflow"
-  ENV["METRICS_PASSWORD"] = "caseflow"
-
   config.sqs_create_queues = true
   config.sqs_endpoint = 'http://localhost:14576'
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -49,9 +49,6 @@ Rails.application.configure do
   config.sqs_create_queues = true
   config.sqs_endpoint = 'http://localhost:4576'
 
-  ENV["METRICS_USERNAME"] = "caseflow"
-  ENV["METRICS_PASSWORD"] = "caseflow"
-
   # Allow health check to pushgateway
   ENV["ENABLE_PUSHGATEWAY_HEALTHCHECK"] = "true"
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -18,7 +18,6 @@
 development:
   secret_key_base: 8c6b64e47fa8d523a9ea3d7e7658dbd5ee916003785039b14ffdd076fae644afaedc04eb683fc705c47f6f07020184c8cf3a30e79f2258521a45b861ab8e7862
   redis_url_cache: <%= ENV["REDIS_URL_CACHE"] || "redis://localhost:16379/0/cache/" %>
-  redis_url: <%= ENV["REDIS_URL_SIDEKIQ"] || "redis://localhost:16379" %>
   vbms:
     url: https://filenet.uat.vbms.aide.oit.va.gov/vbmsp2-cms/streaming/eDocumentService-v4
     env_dir: ../deployment/decrypted_creds/uat_creds
@@ -32,7 +31,6 @@ development:
 staging:
   secret_key_base: 8c6b64e47fa8d523a9ea3d7e7658dbd5ee916003785039b14ffdd076fae644afaedc04eb683fc705c47f6f07020184c8cf3a30e79f2258521a45b861ab8e7862
   redis_url_cache: <%= ENV["REDIS_URL_CACHE"] || "redis://localhost:6379/0/cache/" %>
-  redis_url: <%= ENV["REDIS_URL_SIDEKIQ"] || "redis://localhost:6379" %>
   vbms:
     env: uat
     url: https://filenet.uat.vbms.aide.oit.va.gov/vbmsp2-cms/streaming/eDocumentService-v4
@@ -47,13 +45,10 @@ staging:
 demo:
   secret_key_base: 8c6b64e47fa8d523a9ea3d7e7658dbd5ee916003785039b14ffdd076fae644afaedc04eb683fc705c47f6f07020184c8cf3a30e79f2258521a45b861ab8e7862
   redis_url_cache: <%= ENV["REDIS_URL_CACHE"] || "redis://localhost:6379/0/cache/" %>
-  redis_url: <%= ENV["REDIS_URL_SIDEKIQ"] || "redis://localhost:6379" %>
-
 
 test:
   secret_key_base: 35cf2535cc790c92a07bcab48a5f21bbd132a7071984947e8cc92d2ce8e60d582c62022b7ddcfa6f0eca34319dfe1482fbf21d2c78e50c12e884be9ea5fea7e0
   redis_url_cache: <%= ENV["REDIS_URL_CACHE"] || "redis://localhost:6379/0/cache/" %>
-  redis_url: <%= ENV["REDIS_URL_SIDEKIQ"] || "redis://localhost:6379" %>
 
 # Do not keep production secrets in the unencrypted secrets file.
 # Instead, either read values from the environment.
@@ -62,6 +57,5 @@ test:
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   redis_url_cache: <%= ENV["REDIS_URL_CACHE"] %>
-  redis_url: <%= ENV["REDIS_URL_SIDEKIQ"] %>
   vbms:
       env: true


### PR DESCRIPTION
1. Remove metrics env vars since we are longer using Prometheus
2. Move Redis semaphore to use the same Redis cache url as the rest of the app 

To test:
- [x] Deploy to UAT and ensure UI is working is working fine
- [x] Instantiate Redis semaphore through the rails console and ensure it is pointing to the redis cache url. 