### PR TITLE
Make CI steps separate to make lint failures more obvious

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,9 +69,19 @@ jobs:
             ~/project/ci-bin/capture-log "RAILS_ENV=test bundle exec rake db:schema:load"
 
       - run:
-          name: Rake
+          name: RSpec
           command: |
-            ~/project/ci-bin/capture-log "bundle exec rake"
+            ~/project/ci-bin/capture-log "make -f Makefile.example test"
+
+      - run:
+          name: Lint
+          command: |
+            ~/project/ci-bin/capture-log "make -f Makefile.example lint jslint"
+
+      - run:
+          name: Security
+          command: |
+            ~/project/ci-bin/capture-log "make -f Makefile.example security"
 
 
 workflows:

--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,4 @@
 --color
 --require spec_helper
 --require rails_helper
---format progress
+--format documentation

--- a/Makefile.example
+++ b/Makefile.example
@@ -20,7 +20,6 @@ test: clean	## Run the rspec suite
 	bundle exec rspec
 
 clean:	## Remove old files
-	rm -f log/vacols.log
 	rm -f log/test.log
 	rm -f app/assets/javascripts/*webpack*
 	rm -rf tmp/capybara
@@ -34,7 +33,7 @@ jslint:	## Run the js linter
 security:	## Run security task
 	bundle exec rake security
 
-check: test lint
+check: test lint jslint
 
 logs:	## Follow the Docker logs
 	docker-compose logs -f
@@ -60,14 +59,8 @@ install:	## bundle/yarn install dependencies
 
 update: fresh install migrate
 
-client-test:	## Run js tests
-	cd client && yarn run build:test
-
-karma:	## Start client karma server
-	cd client && node_modules/.bin/karma start
-
 # Self-documented makefile from https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help:  ## Shows help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: test run clean lint check logs db update one-test client-test security build ready
+.PHONY: test run clean lint jslint check logs db update security install reset migrate rollback c

--- a/Makefile.example
+++ b/Makefile.example
@@ -17,7 +17,7 @@ run: up	## Start Rails
 	foreman start
 
 test: clean	## Run the rspec suite
-	bundle exec rake
+	bundle exec rspec
 
 clean:	## Remove old files
 	rm -f log/vacols.log

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -1,4 +1,0 @@
-desc "Runs the continuous integration scripts"
-task ci: ["efolder:lint", "security", "efolder:bundle_javascript", "spec"]
-
-task default: :ci


### PR DESCRIPTION
CircleCI config only.

Breaks out lint and security steps from tests, and uses Makefile.example to verify we have targets defined correctly.