### PR TITLE
Disable trailing comma in literal lint rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -84,3 +84,5 @@ Naming/HeredocDelimiterNaming:
 Rails/DynamicFindBy:
   Enabled: false
 
+Style/TrailingCommaInLiteral:
+  Enabled: false


### PR DESCRIPTION
I found this 7 year old thread in the [Ruby style guide](https://github.com/rubocop-hq/ruby-style-guide/issues/76) about this and though the Ruby community isn't necessarily fully on board, there seems to be healthy debate. I'm proposing disabling this rule anyways in order to preserve the blame on that line, and because it's a widely accepted practice outside of Ruby (what most of this team is used to).