### PR TITLE
parity with Caseflow migrate targets

### DIFF
--- a/Makefile.example
+++ b/Makefile.example
@@ -51,6 +51,10 @@ db:	## Connect with psql
 c:	## Start Rails console
 	bundle exec rails console
 
+db-migrate: migrate
+
+etl-migrate: migrate
+
 migrate:	## Run pending migrations
 	bundle exec rake db:migrate
 


### PR DESCRIPTION
New deployment code assumes a `make etl-migrate db-migrate` set of targets.

Those targets are Caseflow-specific, so these stubs just create parity.