### PR TITLE
Add VeteranFinder, prefer bgs :file_number

### DIFF
--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -12,15 +12,19 @@ class Veteran
     self
   end
 
-  def self.bgs
-    @bgs_service ||= BGSService.new
-  end
-
   def found?
     bgs_record != :not_found
   end
 
+  def bgs_record
+    @bgs_record ||= (fetch_bgs_record || :not_found)
+  end
+
   private
+
+  def bgs
+    @bgs ||= BGSService.new
+  end
 
   # TODO: mimic what we have in Caseflow
   def set_attrs_from_bgs_record
@@ -29,11 +33,7 @@ class Veteran
     self.last_four_ssn = bgs_record["veteran_last_four_ssn"]
   end
 
-  def bgs_record
-    @bgs_record ||= (fetch_bgs_record || :not_found)
-  end
-
   def fetch_bgs_record
-    self.class.bgs.fetch_veteran_info(file_number)
+    bgs.fetch_veteran_info(file_number)
   end
 end

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -13,7 +13,7 @@ class ExternalApi::BGSService
     ssn = veteran_data[:ssn] ? veteran_data[:ssn] : veteran_data[:soc_sec_number]
     last_four_ssn = ssn ? ssn[ssn.length - 4..ssn.length] : nil
     {
-      "file_number" => veteran_data[:claim_number],
+      "file_number" => veteran_data[:file_number],
       "veteran_first_name" => veteran_data[:first_name],
       "veteran_last_name" => veteran_data[:last_name],
       "veteran_last_four_ssn" => last_four_ssn,
@@ -21,13 +21,14 @@ class ExternalApi::BGSService
     }
   end
 
-  def fetch_veteran_info(file_number)
+  def fetch_veteran_info(file_number, parsed: true)
     veteran_data =
       MetricsService.record("BGS: fetch veteran info for vbms id: #{file_number}",
                             service: :bgs,
                             name: "veteran.find_by_file_number") do
         client.veteran.find_by_file_number(file_number)
       end
+    return veteran_data unless parsed
     parse_veteran_info(veteran_data) if veteran_data
   end
 

--- a/app/services/veteran_finder.rb
+++ b/app/services/veteran_finder.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# return all the BGS record data for a file number.
+# this may return multiple BGS records, uniquely identified by participant_id
+
+class VeteranFinder
+  def find(file_number)
+    bgs_rec = bgs_record_for(file_number)
+
+    return unless bgs_rec
+
+    bgs_rec_numbers = bgs_numbers(bgs_rec)
+    bgs_rec2 = find_duplicate_bgs_rec(bgs_rec_numbers)
+
+    return [bgs_rec_numbers, bgs_numbers(bgs_rec2)] if bgs_rec2
+
+    [bgs_rec_numbers]
+  end
+
+  private
+
+  def find_duplicate_bgs_rec(bgs_rec_numbers)
+    if bgs_rec_numbers[:file].to_s == bgs_rec_numbers[:ssn].to_s
+      # look again by claim number
+      bgs_record_for(bgs_rec_numbers[:claim])
+    elsif bgs_rec_numbers[:file].to_s == bgs_rec_numbers[:claim].to_s
+      # look again by ssn
+      bgs_record_for(bgs_rec_numbers[:ssn])
+    else
+      fail "Found BGS file_number not equal to SSN or claim number: #{bgs_rec_numbers[:file]}"
+    end
+  end
+
+  def bgs_numbers(bgs_rec)
+    {
+      ssn: bgs_rec[:soc_sec_number] || bgs_rec[:ssn],
+      claim: bgs_rec[:claim_number],
+      file: bgs_rec[:file_number],
+      participant_id: bgs_rec[:ptcpnt_id]
+    }.merge(bgs.parse_veteran_info(bgs_rec))
+  end
+
+  def bgs_record_for(file_number)
+    bgs.fetch_veteran_info(file_number, parsed: false)
+  end
+
+  def bgs
+    @bgs ||= BGSService.new
+  end
+end


### PR DESCRIPTION
connects #1137 

### Description

Adds `VeteranFinder` service class to search all possible combinations of ssn/claim/file numbers within BGS.

Previously, we assumed BGS `claim_number` was always the `file_number`. That is not true. SSN or claim number may legitimately be used as the file number.

Search for all VBMS efolders by file_number reported for all found BGS records.