### PR TITLE
Apply VeteranFinder to DocumentCounter

### DIFF
--- a/app/services/document_counter.rb
+++ b/app/services/document_counter.rb
@@ -18,6 +18,6 @@ class DocumentCounter
 
   def file_numbers
     vet_finder = VeteranFinder.new
-    vet_finder.find(veteran_file_number).map { |vn| vn[:file] }.compact.uniq
+    [veteran_file_number, vet_finder.find_uniq_file_numbers(veteran_file_number)].flatten.uniq
   end
 end

--- a/app/services/document_counter.rb
+++ b/app/services/document_counter.rb
@@ -4,11 +4,20 @@ class DocumentCounter
   attr_accessor :veteran_file_number
 
   def count
-    total = 0
-    [VBMSService, VVAService].each do |service|
-      documents = service.v2_fetch_documents_for(veteran_file_number)
-      total += DocumentFilter.new(documents: documents).filter.uniq(&:document_id).count
+    document_ids = []
+    file_numbers.each do |file_number|
+      [VBMSService, VVAService].each do |service|
+        documents = service.v2_fetch_documents_for(file_number)
+        document_ids << DocumentFilter.new(documents: documents).filter.map(&:document_id)
+      end
     end
-    total
+    document_ids.flatten.uniq.count
+  end
+
+  private
+
+  def file_numbers
+    vet_finder = VeteranFinder.new
+    vet_finder.find(veteran_file_number).map { |vn| vn[:file] }.compact.uniq
   end
 end

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -12,8 +12,9 @@ class ExternalApi::BGSService
   def parse_veteran_info(veteran_data)
     ssn = veteran_data[:ssn] ? veteran_data[:ssn] : veteran_data[:soc_sec_number]
     last_four_ssn = ssn ? ssn[ssn.length - 4..ssn.length] : nil
+    file_number = veteran_data[:file_number].present? ? veteran_data[:file_number] : veteran_data[:claim_number]
     {
-      "file_number" => veteran_data[:file_number],
+      "file_number" => file_number,
       "veteran_first_name" => veteran_data[:first_name],
       "veteran_last_name" => veteran_data[:last_name],
       "veteran_last_four_ssn" => last_four_ssn,

--- a/app/services/manifest_fetcher.rb
+++ b/app/services/manifest_fetcher.rb
@@ -28,6 +28,6 @@ class ManifestFetcher
 
   def file_numbers
     vet_finder = VeteranFinder.new
-    vet_finder.find(manifest_source.file_number).map { |vn| vn[:file] }.compact.uniq
+    [manifest_source.file_number, vet_finder.find_uniq_file_numbers(manifest_source.file_number)].flatten.uniq
   end
 end

--- a/app/services/veteran_finder.rb
+++ b/app/services/veteran_finder.rb
@@ -24,6 +24,13 @@ class VeteranFinder
   private
 
   def find_duplicate_bgs_rec(bgs_rec_numbers)
+    if bgs_rec_numbers[:file].blank?
+      # log sentry
+      error = StandardError.new("Missing :file number in #{bgs_rec_numbers}")
+      Raven.capture_exception(error)
+      return
+    end
+
     if bgs_rec_numbers[:file].to_s == bgs_rec_numbers[:ssn].to_s
       # look again by claim number
       bgs_record_for(bgs_rec_numbers[:claim])

--- a/app/services/veteran_finder.rb
+++ b/app/services/veteran_finder.rb
@@ -21,6 +21,10 @@ class VeteranFinder
     [bgs_rec_numbers]
   end
 
+  def find_uniq_file_numbers(file_number)
+    find(file_number).map { |vn| vn[:file].present? ? vn[:file] : vn["file_number"] }.compact.uniq
+  end
+
   private
 
   def find_duplicate_bgs_rec(bgs_rec_numbers)

--- a/spec/requests/api/v2/document_counts_spec.rb
+++ b/spec/requests/api/v2/document_counts_spec.rb
@@ -24,6 +24,7 @@ describe "Document Counts API v2", type: :request do
   before do
     allow_any_instance_of(Fakes::BGSService).to receive(:sensitive_files).and_return(veteran_id.to_s => false)
     allow_any_instance_of(Fakes::BGSService).to receive(:record_found?).and_return(true)
+    allow_any_instance_of(VeteranFinder).to receive(:find) { [ { file: veteran_id } ] }
     Timecop.freeze(Time.utc(2015, 1, 1, 17, 0, 0))
   end
 

--- a/spec/services/document_counter_spec.rb
+++ b/spec/services/document_counter_spec.rb
@@ -9,6 +9,7 @@ describe DocumentCounter do
 
   before do
     allow(Fakes::VVAService).to receive(:v2_fetch_documents_for).and_return(vva_documents)
+    allow_any_instance_of(VeteranFinder).to receive(:find) { [ { file: "DEMOFAST" } ] }
   end
 
   describe "#count" do

--- a/spec/services/veteran_finder_spec.rb
+++ b/spec/services/veteran_finder_spec.rb
@@ -80,6 +80,27 @@ describe VeteranFinder do
       end
     end
 
+    context "BGS reports no :file_number" do
+      let(:veteran_info) { { veteran_ssn => veteran_record.merge(ptcpnt_id: "123", file_number: "") } }
+
+      it "logs exception and uses claim_number" do
+        expect(Raven).to receive(:capture_exception)
+        expect(subject).to eq([
+          {
+            ssn: veteran_ssn,
+            claim: veteran_claim_number,
+            file: "",
+            participant_id: "123",
+            "file_number" => veteran_claim_number,
+            "veteran_first_name" => veteran_record[:first_name],
+            "veteran_last_name"  => veteran_record[:last_name],
+            "veteran_last_four_ssn" => veteran_ssn[-4..-1],
+            "return_message" => veteran_record[:return_message]
+          }
+        ])
+      end
+    end
+
     context "one veteran found" do
       let(:veteran_info) { { veteran_ssn => veteran_record.merge(ptcpnt_id: "123", file_number: veteran_ssn) } }
 


### PR DESCRIPTION
Follow on to #1188 and #1192 

Apply the same multiple-file-numbers logic to getting document count.

Tested in production with monkeypatch console on same details as #1137 