### PR TITLE
BGS often missing :file_number, so not an error

### DIFF
--- a/app/services/veteran_finder.rb
+++ b/app/services/veteran_finder.rb
@@ -30,12 +30,8 @@ class VeteranFinder
   private
 
   def find_duplicate_bgs_rec(bgs_rec_numbers)
-    if bgs_rec_numbers[:file].blank?
-      # log sentry
-      error = MissingNumber.new("Missing :file number in #{bgs_rec_numbers}")
-      Raven.capture_exception(error)
-      return
-    end
+    # common enough in missing BGS data that we just return nil
+    return if bgs_rec_numbers[:file].blank?
 
     if bgs_rec_numbers[:claim].present? && bgs_rec_numbers[:file].to_s == bgs_rec_numbers[:ssn].to_s
       # look again by claim number

--- a/spec/services/veteran_finder_spec.rb
+++ b/spec/services/veteran_finder_spec.rb
@@ -83,8 +83,7 @@ describe VeteranFinder do
     context "BGS reports no :file_number" do
       let(:veteran_info) { { veteran_ssn => veteran_record.merge(ptcpnt_id: "123", file_number: "") } }
 
-      it "logs exception and uses claim_number" do
-        expect(Raven).to receive(:capture_exception)
+      it "uses claim_number" do
         expect(subject).to eq([
           {
             ssn: veteran_ssn,


### PR DESCRIPTION
Stop logging to Sentry since this is a common enough, non-actionable scenario.