### PR TITLE
Verify veteran_info for "not found", do not rely only on BGS return_message

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           - POSTGRES_USER: root
       # This is the circleci provided Postgres container. We can
       # configure it via environment variables.
-      - image: circleci/postgres:9.5
+      - image: circleci/postgres:9.6
         environment:
           - POSTGRES_USER: root
             POSTGRES_DB: caseflow_efolder_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
       - image: circleci/postgres:9.6
         environment:
           - POSTGRES_USER: root
+            POSTGRES_PASSWORD: password
             POSTGRES_DB: caseflow_efolder_test
 
 

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -51,6 +51,10 @@ class ExternalApi::BGSService
 
   def record_found?(veteran_info)
     return false unless veteran_info && veteran_info["return_message"]
+
+    # sometimes a reality check is needed on data, regardless of return_message
+    return false unless veteran_info["file_number"].present? || veteran_info["veteran_last_four_ssn"].present?
+
     veteran_info["return_message"].include?("No BIRLS record found") ? false : true
   end
 

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -54,6 +54,10 @@ class Fakes::BGSService
     !!(file_number =~ /^DEMO/)
   end
 
+  def not_found?(file_number)
+    !!(file_number =~ /^404/)
+  end
+
   def demo_veteran_info(file_number)
     [
       {
@@ -92,6 +96,7 @@ class Fakes::BGSService
 
   def valid_file_number?(file_number)
     return true if demo?(file_number.strip)
+    return true if not_found?(file_number.strip)
   end
 
   def check_sensitivity(file_number)
@@ -100,6 +105,10 @@ class Fakes::BGSService
 
   def record_found?(veteran_info)
     return false unless veteran_info && veteran_info["return_message"]
+
+    # sometimes a reality check is needed on data, regardless of return_message
+    return false unless veteran_info["file_number"].present? || veteran_info["veteran_last_four_ssn"].present?
+
     veteran_info["return_message"].include?("No BIRLS record found") ? false : true
   end
 

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -104,12 +104,8 @@ class Fakes::BGSService
   end
 
   def record_found?(veteran_info)
-    return false unless veteran_info && veteran_info["return_message"]
-
-    # sometimes a reality check is needed on data, regardless of return_message
-    return false unless veteran_info["file_number"].present? || veteran_info["veteran_last_four_ssn"].present?
-
-    veteran_info["return_message"].include?("No BIRLS record found") ? false : true
+    # call through with dummy client
+    ExternalApi::BGSService.new(client: true).record_found?(veteran_info)
   end
 
   # Methods to be stubbed out in tests:

--- a/spec/requests/api/v2/manifests_spec.rb
+++ b/spec/requests/api/v2/manifests_spec.rb
@@ -30,7 +30,6 @@ describe "Manifests API v2", type: :request do
 
   before do
     allow_any_instance_of(Fakes::BGSService).to receive(:sensitive_files).and_return(veteran_id.to_s => false)
-    allow_any_instance_of(Fakes::BGSService).to receive(:record_found?).and_return(true)
     Timecop.freeze(Time.utc(2015, 1, 1, 17, 0, 0))
   end
 
@@ -281,6 +280,20 @@ describe "Manifests API v2", type: :request do
       expect(response.code).to eq("403")
       body = JSON.parse(response.body)
       expect(body["status"]).to eq(error_string)
+    end
+  end
+
+  context "When file number is not found in BGS" do
+    let(:veteran_id) { "40400000" }
+    let(:error_string) { "eFolder Express could not find an eFolder with the Veteran ID 40400000. Check to make sure you entered the ID correctly and try again." }
+
+    it "returns a 400 with not found message" do
+      perform_enqueued_jobs do
+        post "/api/v2/manifests", params: nil, headers: headers
+        expect(response.code).to eq("400")
+        body = JSON.parse(response.body)
+        expect(body["status"]).to eq(error_string)
+      end
     end
   end
 end

--- a/spec/services/bgs_service_spec.rb
+++ b/spec/services/bgs_service_spec.rb
@@ -66,8 +66,18 @@ describe ExternalApi::BGSService do
   context "#record_found?" do
     subject { bgs_service.record_found?(veteran_info) }
 
-    context "when found" do
+    context "when found with no file/claim/ssn" do
       let(:veteran_info) { { "return_message" => "BPNQ0301" } }
+      it { is_expected.to eq false }
+    end
+
+    context "when found with file or claim" do
+      let(:veteran_info) { { "return_message" => "BPNQ0301", "file_number" => "1234" } }
+      it { is_expected.to eq true }
+    end
+
+    context "when found with ssn" do
+      let(:veteran_info) { { "return_message" => "BPNQ0301", "veteran_last_four_ssn" => "1234" } }
       it { is_expected.to eq true }
     end
 


### PR DESCRIPTION
e.g. https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/8396/

Fixes VBMS::FilenumberDoesNotExist -- we were trusting too much in the preflight BGS return message value.

connects https://github.com/department-of-veterans-affairs/caseflow/issues/10732 and https://github.com/department-of-veterans-affairs/caseflow/issues/6680

This PR also adds local support for testing. If the file number supplied starts with `404` then it can be tested for "validity" as well as "not found".

<img width="934" alt="Screen Shot 2020-02-14 at 11 10 20 AM" src="https://user-images.githubusercontent.com/1205061/74552710-71317780-4f1b-11ea-98a8-16716062455f.png">
