### PR TITLE
Fix regressions in bgs client and veteran de-duping

### DIFF
--- a/app/services/bgs_service.rb
+++ b/app/services/bgs_service.rb
@@ -1,5 +1,5 @@
 class BGSService
-  def self.new
-    !BaseController.dependencies_faked? ? ExternalApi::BGSService.new : Fakes::BGSService.new
+  def self.new(args)
+    !BaseController.dependencies_faked? ? ExternalApi::BGSService.new(args) : Fakes::BGSService.new(args)
   end
 end

--- a/app/services/bgs_service.rb
+++ b/app/services/bgs_service.rb
@@ -1,5 +1,5 @@
 class BGSService
-  def self.new(args)
+  def self.new(args = {})
     !BaseController.dependencies_faked? ? ExternalApi::BGSService.new(args) : Fakes::BGSService.new(args)
   end
 end

--- a/app/services/veteran_finder.rb
+++ b/app/services/veteran_finder.rb
@@ -33,6 +33,8 @@ class VeteranFinder
     # common enough in missing BGS data that we just return nil
     return if bgs_rec_numbers[:file].blank?
 
+    return if bgs_rec_numbers[:ssn].blank?
+
     if bgs_rec_numbers[:claim].present? && bgs_rec_numbers[:file].to_s == bgs_rec_numbers[:ssn].to_s
       # look again by claim number
       bgs_record_for(bgs_rec_numbers[:claim])

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -3,6 +3,8 @@ require 'bgs_errors'
 class Fakes::BGSService
   include ActiveModel::Model
 
+  attr_accessor :client
+
   def fetch_user_info(username, station_id = nil)
     fail "Must define current_user" unless RequestStore[:current_user] # mock what real service requires
 


### PR DESCRIPTION
Fixes 2 regressions found in recent changes to how we initialize BGSService and how we de-duplicate Veteran records.