### PR TITLE
Add User.system_user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,5 +72,27 @@ class User < ApplicationRecord
       sesh = CssAuthenticationSession.new(css_id: css_id, station_id: station_id)
       find_or_create_by(css_id: sesh.css_id, station_id: sesh.station_id)
     end
+
+    def system_user
+      @system_user ||= begin
+        private_method_name = "#{Rails.current_env}_system_user".to_sym
+        send(private_method_name)
+      end
+    end
+
+    private
+
+    def prod_system_user
+      find_or_initialize_by(station_id: "283", css_id: "CSFLOW")
+    end
+
+    alias preprod_system_user prod_system_user
+
+    def uat_system_user
+      find_or_initialize_by(station_id: "317", css_id: "CASEFLOW1")
+    end
+
+    alias test_system_user uat_system_user
+    alias development_system_user uat_system_user
   end
 end


### PR DESCRIPTION
Configure static system user accounts for admin maintenance. These are identical to the settings in Caseflow since they are used by VBMS/BGS.

Common usage in AWS env:

```
irb> RequestStore[:current_user] = User.system_user
```