### PR TITLE
Do not cache VVA client as class object

### DIFF
--- a/app/services/external_api/vva_service.rb
+++ b/app/services/external_api/vva_service.rb
@@ -3,7 +3,7 @@ require "vva"
 # Thin interface to talk to Virtual VA
 class ExternalApi::VVAService
   def self.fetch_documents_for(download)
-    @vva_client ||= init_client
+    @vva_client = init_client
     documents ||= MetricsService.record("VVA: get document list for: #{download.file_number}",
                                         service: :vva,
                                         name: "document_list.get_by_claim_number") do
@@ -14,7 +14,7 @@ class ExternalApi::VVAService
   end
 
   def self.v2_fetch_documents_for(file_number)
-    @vva_client ||= init_client
+    @vva_client = init_client
     documents ||= MetricsService.record("VVA: get document list for: #{file_number}",
                                         service: :vva,
                                         name: "document_list.get_by_claim_number") do
@@ -25,7 +25,7 @@ class ExternalApi::VVAService
   end
 
   def self.fetch_document_file(document)
-    @vva_client ||= init_client
+    @vva_client = init_client
     result ||= MetricsService.record("VVA: fetch document content for: #{document.document_id}",
                                      service: :vva,
                                      name: "document_content.get_by_document_id") do

--- a/app/services/external_api/vva_service.rb
+++ b/app/services/external_api/vva_service.rb
@@ -3,33 +3,33 @@ require "vva"
 # Thin interface to talk to Virtual VA
 class ExternalApi::VVAService
   def self.fetch_documents_for(download)
-    @vva_client = init_client
+    vva_client = init_client
     documents ||= MetricsService.record("VVA: get document list for: #{download.file_number}",
                                         service: :vva,
                                         name: "document_list.get_by_claim_number") do
-      @vva_client.document_list.get_by_claim_number(download.file_number)
+      vva_client.document_list.get_by_claim_number(download.file_number)
     end
     Rails.logger.info("VVA Document list length: #{documents.length}")
     documents
   end
 
   def self.v2_fetch_documents_for(file_number)
-    @vva_client = init_client
+    vva_client = init_client
     documents ||= MetricsService.record("VVA: get document list for: #{file_number}",
                                         service: :vva,
                                         name: "document_list.get_by_claim_number") do
-      @vva_client.document_list.get_by_claim_number(file_number)
+      vva_client.document_list.get_by_claim_number(file_number)
     end
     Rails.logger.info("VVA Document list length: #{documents.length}")
     documents
   end
 
   def self.fetch_document_file(document)
-    @vva_client = init_client
+    vva_client = init_client
     result ||= MetricsService.record("VVA: fetch document content for: #{document.document_id}",
                                      service: :vva,
                                      name: "document_content.get_by_document_id") do
-      @vva_client.document_content.get_by_document_id(
+      vva_client.document_content.get_by_document_id(
         document_id: document.document_id,
         source: document.source,
         format: document.preferred_extension,


### PR DESCRIPTION
Caching at the class level means app must be restarted to change config.