### PR TITLE
Power of Attorney rules (part 1)

### DIFF
--- a/app/models/css_authentication_session.rb
+++ b/app/models/css_authentication_session.rb
@@ -2,7 +2,7 @@ class CssAuthenticationSession
   include ActiveModel::Model
   include ActiveModel::Serializers::JSON
 
-  attr_accessor :id, :name, :roles, :station_id, :first_name, :last_name
+  attr_accessor :id, :name, :roles, :station_id, :first_name, :last_name, :participant_id
   attr_reader :css_id, :email
 
   class BadCssAuthorization < StandardError; end
@@ -44,6 +44,7 @@ class CssAuthenticationSession
         id: username,
         css_id: user_info[:css_id],
         email: user_info[:email],
+        participant_id: user_info[:participant_id],
         first_name: user_info[:first_name],
         last_name: user_info[:last_name],
         roles: user_info[:roles],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,7 +55,7 @@ class User < ApplicationRecord
       # There could be other values in the session that CssAuthenticationSession doesn't accept
       # as attributes so delete them
       sesh = CssAuthenticationSession.new(
-        session["user"].symbolize_keys.slice(:id, :name, :roles, :station_id, :css_id, :email)
+        session["user"].symbolize_keys.slice(:id, :name, :roles, :station_id, :css_id, :email, :participant_id)
       )
       return nil unless sesh.css_id && sesh.station_id
 
@@ -64,6 +64,7 @@ class User < ApplicationRecord
         u.email = sesh.email
         u.roles = sesh.roles
         u.ip_address = request.remote_ip
+        u.participant_id = sesh.participant_id
         u.save
       end
     end

--- a/app/services/bgs_service.rb
+++ b/app/services/bgs_service.rb
@@ -1,5 +1,0 @@
-class BGSService
-  def self.new(args = {})
-    !BaseController.dependencies_faked? ? ExternalApi::BGSService.new(args) : Fakes::BGSService.new(args)
-  end
-end

--- a/app/services/concerns/poa_mapper.rb
+++ b/app/services/concerns/poa_mapper.rb
@@ -1,0 +1,29 @@
+module POAMapper
+  extend ActiveSupport::Concern
+
+  # used by fetch_poas_by_participant_ids (for Claimants)
+  # and fetch_poa_by_file_number
+  def get_claimant_poa_from_bgs_poa(bgs_record = {})
+    return {} unless bgs_record.dig(:power_of_attorney)
+
+    bgs_rep = bgs_record[:power_of_attorney]
+    {
+      representative_type: bgs_rep[:org_type_nm],
+      representative_name: bgs_rep[:nm],
+      # Used to find the POA address
+      participant_id: bgs_rep[:ptcpnt_id],
+      # pass through other attrs
+      authzn_change_clmant_addrs_ind: bgs_rep[:authzn_change_clmant_addrs_ind],
+      authzn_poa_access_ind: bgs_rep[:authzn_poa_access_ind],
+      legacy_poa_cd: bgs_rep[:legacy_poa_cd],
+      file_number: bgs_record[:file_number],
+      claimant_participant_id: bgs_record[:ptcpnt_id]
+    }
+  end
+
+  def get_hash_of_poa_from_bgs_poas(bgs_resp)
+    [bgs_resp].flatten.each_with_object({}) do |poa, hsh|
+      hsh[poa[:ptcpnt_id]] = get_claimant_poa_from_bgs_poa(poa)
+    end
+  end
+end

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -20,6 +20,7 @@ class ExternalApi::BGSService
       "veteran_first_name" => veteran_data[:first_name],
       "veteran_last_name" => veteran_data[:last_name],
       "veteran_last_four_ssn" => last_four_ssn,
+      "participant_id" => veteran_data[:ptcpnt_id],
       "return_message" => veteran_data[:return_message]
     }
   end
@@ -56,6 +57,34 @@ class ExternalApi::BGSService
 
     # Avoid passing nil
     get_hash_of_poa_from_bgs_poas(bgs_poas || [])
+  end
+
+  def fetch_person_info(participant_id)
+    bgs_info = MetricsService.record("BGS: fetch person info by participant id: #{participant_id}",
+                                     service: :bgs,
+                                     name: "people.find_person_by_ptcpnt_id") do
+      client.people.find_person_by_ptcpnt_id(participant_id)
+    end
+
+    return {} unless bgs_info
+
+    {
+      first_name: bgs_info[:first_nm],
+      last_name: bgs_info[:last_nm],
+      middle_name: bgs_info[:middle_nm],
+      name_suffix: bgs_info[:suffix_nm],
+      birth_date: bgs_info[:brthdy_dt],
+      email_address: bgs_info[:email_addr],
+      file_number: bgs_info[:file_nbr]
+    }
+  end
+
+  def fetch_person_by_ssn(ssn)
+    MetricsService.record("BGS: fetch person by ssn: #{ssn}",
+                          service: :bgs,
+                          name: "people.find_by_ssn") do
+        client.people.find_by_ssn(ssn)
+    end
   end
 
   def check_sensitivity(file_number)

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -93,6 +93,22 @@ class ExternalApi::BGSService
 
     return {} unless bgs_info
 
+    parse_person_info(bgs_info)
+  end
+
+  def fetch_person_by_ssn(ssn)
+    bgs_info = MetricsService.record("BGS: fetch person by ssn: #{ssn}",
+                                     service: :bgs,
+                                     name: "people.find_by_ssn") do
+      client.people.find_by_ssn(ssn)
+    end
+
+    return {} unless bgs_info
+
+    parse_person_info(bgs_info)
+  end
+
+  def parse_person_info(bgs_info)
     {
       first_name: bgs_info[:first_nm],
       last_name: bgs_info[:last_nm],
@@ -102,14 +118,6 @@ class ExternalApi::BGSService
       email_address: bgs_info[:email_addr],
       file_number: bgs_info[:file_nbr]
     }
-  end
-
-  def fetch_person_by_ssn(ssn)
-    MetricsService.record("BGS: fetch person by ssn: #{ssn}",
-                          service: :bgs,
-                          name: "people.find_by_ssn") do
-        client.people.find_by_ssn(ssn)
-    end
   end
 
   def check_sensitivity(file_number)

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -20,7 +20,7 @@ class ExternalApi::BGSService
       "veteran_first_name" => veteran_data[:first_name],
       "veteran_last_name" => veteran_data[:last_name],
       "veteran_last_four_ssn" => last_four_ssn,
-      "participant_id" => veteran_data[:ptcpnt_id],
+      participant_id: veteran_data[:ptcpnt_id], # key is symbol not string
       "return_message" => veteran_data[:return_message]
     }
   end

--- a/app/services/manifest_fetcher.rb
+++ b/app/services/manifest_fetcher.rb
@@ -27,7 +27,13 @@ class ManifestFetcher
   end
 
   def file_numbers
-    vet_finder = VeteranFinder.new
+    vet_finder = VeteranFinder.new(bgs: BGSService.new(client: bgs_client))
     [manifest_source.file_number, vet_finder.find_uniq_file_numbers(manifest_source.file_number)].flatten.uniq
+  end
+
+  def bgs_client
+    # always use system user so authz is not a question.
+    # the authz checks are performed before this class is invoked.
+    BGSService.init_client(username: User.system_user.css_id, station_id: User.system_user.station_id)
   end
 end

--- a/config/initializers/bgs.rb
+++ b/config/initializers/bgs.rb
@@ -1,0 +1,1 @@
+BGSService = (!BaseController.dependencies_faked? ? ExternalApi::BGSService : Fakes::BGSService)

--- a/db/migrate/20200504163452_add_user_participant_id.rb
+++ b/db/migrate/20200504163452_add_user_participant_id.rb
@@ -1,5 +1,5 @@
 class AddUserParticipantId < ActiveRecord::Migration[5.2]
   def change
-    add_column :users, :participant_id, :string
+    add_column :users, :participant_id, :string, comment: "the user BGS participant_id"
   end
 end

--- a/db/migrate/20200504163452_add_user_participant_id.rb
+++ b/db/migrate/20200504163452_add_user_participant_id.rb
@@ -1,0 +1,5 @@
+class AddUserParticipantId < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :participant_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190508135156) do
+ActiveRecord::Schema.define(version: 2020_05_04_163452) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -154,6 +154,7 @@ ActiveRecord::Schema.define(version: 20190508135156) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "vva_coachmarks_view_count", default: 0
+    t.string "participant_id"
     t.index ["css_id", "station_id"], name: "index_users_on_css_id_and_station_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -154,7 +154,7 @@ ActiveRecord::Schema.define(version: 2020_05_04_163452) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "vva_coachmarks_view_count", default: 0
-    t.string "participant_id"
+    t.string "participant_id", comment: "the user BGS participant_id"
     t.index ["css_id", "station_id"], name: "index_users_on_css_id_and_station_id"
   end
 

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -5,6 +5,11 @@ class Fakes::BGSService
 
   attr_accessor :client
 
+  class << self
+    def init_client(username: true, station_id: true)
+    end
+  end
+
   def fetch_user_info(username, station_id = nil)
     fail "Must define current_user" unless RequestStore[:current_user] # mock what real service requires
 

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -114,4 +114,12 @@ class Fakes::BGSService
   def veteran_info; end
 
   def sensitive_files; end
+
+  def fetch_person_info; end
+
+  def fetch_person_by_ssn; end
+
+  def fetch_poa_by_file_number; end
+
+  def fetch_poas_by_participant_ids; end
 end


### PR DESCRIPTION
connects #1218 

* Add BGS service endpoints for PID and Person services. This will allow us to begin implementing POA rules based on the same endpoints that Caseflow uses.
* Add `participant_id` to the `User` model so we can look up POA matches more easily for the `current_user`.
* Start re-orienting the authorization model to check permissions at the boundaries for BGS calls.