### PR TITLE
Prevent exception after semaphore failure

### DIFF
--- a/app/services/record_fetcher.rb
+++ b/app/services/record_fetcher.rb
@@ -17,7 +17,7 @@ class RecordFetcher
     Rails.logger.error("Caught #{error}")
     nil
   ensure
-    s.unlock
+    s&.unlock
   end
 
   private


### PR DESCRIPTION
Adding safe navigation to silence these [Sentry](https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/6906/) [alerts](https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/8277/) caused by an exception when creating the semaphore.

As far as I can tell, this happens when deploying/destroying efolder, and is pretty benign.