### PR TITLE
Apply per-user authorization at the Veteran model level

### DIFF
--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -123,10 +123,6 @@ class Manifest < ApplicationRecord
     end
   end
 
-  def downloaded_by?(user)
-    users.include?(user)
-  end
-
   def veteran
     @veteran ||= fetch_veteran
   end

--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -24,6 +24,9 @@ class Manifest < ApplicationRecord
 
   SECONDS_TO_AUTO_UNLOCK = 5
 
+  # single user for authorization on an instance - not persisted
+  attr_accessor :user
+
   def start!
     # Reset stale manifests.
     update!(fetched_files_status: :initialized) if stale?
@@ -125,7 +128,7 @@ class Manifest < ApplicationRecord
   end
 
   def veteran
-    @veteran ||= Veteran.new(file_number: file_number).load_bgs_record!
+    @veteran ||= fetch_veteran
   end
 
   def self.find_or_create_by_user(user:, file_number:)
@@ -145,10 +148,15 @@ class Manifest < ApplicationRecord
     rescue ActiveRecord::RecordNotUnique
       retry
     end
+    manifest.user = user
     manifest
   end
 
   private
+
+  def fetch_veteran
+    Veteran.new(user: user, file_number: file_number).load_bgs_record!
+  end
 
   def file_download
     files_downloads.find_by(user: RequestStore[:current_user])

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -63,7 +63,7 @@ class Record < ApplicationRecord
   end
 
   def accessible_by?(user)
-    user && manifest.downloaded_by?(user)
+    user && manifest.users.include?(user)
   end
 
   def self.create_from_external_document(manifest_source, document)

--- a/app/services/user_authorizer.rb
+++ b/app/services/user_authorizer.rb
@@ -70,14 +70,14 @@ class UserAuthorizer
     bgs.record_found?(system_veteran_record)
   end
 
-  private
-
-  attr_accessor :sensitive_file, :poa_denied
-
   def system_veteran_record
     # if there is a veteran_record, save ourselves a trip to BGS.
     @system_veteran_record ||= veteran_record.present? ? veteran_record : fetch_veteran_record_as_system_user
   end
+
+  private
+
+  attr_accessor :sensitive_file, :poa_denied
 
   def veteran_claimants
     @veteran_claimants ||= build_veteran_claimants

--- a/spec/requests/api/v2/manifests_spec.rb
+++ b/spec/requests/api/v2/manifests_spec.rb
@@ -296,4 +296,153 @@ describe "Manifests API v2", type: :request do
       end
     end
   end
+
+  context "POA" do
+    before { FeatureToggle.enable!(:user_authorizer) }
+    after { FeatureToggle.disable!(:user_authorizer) }
+
+    subject { post "/api/v2/manifests/", params: nil, headers: headers }
+
+    let(:veteran_info) do
+      {
+        first_name: "Bob",
+        last_name: "Marley",
+        ssn: "666001234",
+        return_message: "hello world",
+        date_of_death: veteran_date_of_death,
+        file_number: veteran_id,
+        ptcpnt_id: veteran_participant_id
+      }
+    end
+    let(:veteran_date_of_death) { "" }
+    let(:veteran_participant_id) { "123" }
+    let(:poa_participant_id) { "345" }
+    let(:claimant_participant_id) { "456" }
+    let(:claimants_poa_response) do
+      {
+        representative_name: "A Lawyer",
+        participant_id: poa_participant_id,
+        representative_type: "POA Attorney",
+        veteran_participant_id: veteran_participant_id
+      }
+    end
+    let(:benefit_claims_response) do
+      [
+        {
+          payee_type_cd: "10",
+          payee_type_nm: "Spouse",
+          pgm_type_cd: "CPD",
+          pgm_type_nm: "Compensation-Pension Death",
+          ptcpnt_clmant_id: claimant_participant_id,
+          ptcpnt_vet_id: veteran_participant_id,
+          status_type_nm: "Cleared"
+        }
+      ]
+    end
+
+    let(:body) { JSON.parse(response.body, symbolize_names: true) }
+
+    context "user is VSO" do
+      let!(:user) do
+        user = User.create(css_id: "VSO", station_id: "283", participant_id: poa_participant_id)
+        RequestStore.store[:current_user] = user
+      end
+
+      context "user does not have POA for Veteran" do
+        before do
+          allow_any_instance_of(BGSService).to receive(:fetch_veteran_info).with(veteran_id) do |bgs|
+            if bgs.client.css_id == User.system_user.css_id
+              bgs.parse_veteran_info(veteran_info)
+            else
+              raise BGS::ShareError.new("Power of Attorney of Folder is none")
+            end
+          end
+          allow_any_instance_of(BGSService).to receive(:fetch_poa_by_file_number)
+            .with(veteran_id) { nil }
+        end
+
+        it "responds with error" do
+          subject
+
+          expect(response).to_not be_successful
+          expect(body[:status]).to include("This efolder belongs to a Veteran you do not represent")
+        end
+
+        context "Veteran is deceased" do
+          let(:veteran_date_of_death) { "2020/03/29" }
+
+          context "user has POA for Claimant" do
+            before do
+              allow_any_instance_of(BGSService).to receive(:fetch_poa_by_participant_id)
+                .with(claimant_participant_id) { claimants_poa_response }
+              allow_any_instance_of(BGSService).to receive(:fetch_claims_for_file_number)
+                .with(veteran_id) { benefit_claims_response }
+            end
+
+            it "responds with success" do
+              subject
+
+              expect(response).to be_successful
+              expect(body[:data]).to_not be_nil
+              expect(body.dig(:data, :attributes, :veteran_last_name)).to eq veteran_info[:last_name]
+            end
+          end
+
+          context "user does not have POA for Claimant" do
+            before do
+              allow_any_instance_of(BGSService).to receive(:fetch_poa_by_participant_id)
+                .with(claimant_participant_id) { nil }
+            end
+
+            it "responds with error" do
+              subject
+
+              expect(response).to_not be_successful
+              expect(body[:status]).to include("This efolder belongs to a Veteran you do not represent")
+            end
+          end
+        end
+      end
+
+      context "user does not have POA for Veteran record but does have POA via BGS claimants" do
+        before do
+          allow_any_instance_of(BGSService).to receive(:fetch_veteran_info).with(veteran_id) do |bgs|
+            if bgs.client.css_id == User.system_user.css_id
+              bgs.parse_veteran_info(veteran_info)
+            else
+              raise BGS::ShareError.new("Power of Attorney of Folder is none")
+            end
+          end
+          allow_any_instance_of(BGSService).to receive(:fetch_poa_by_file_number)
+            .with(veteran_id) { claimants_poa_response }
+        end
+
+        it "responds with success" do
+          subject
+
+          expect(response).to be_successful
+          expect(body.dig(:data)).to_not be_nil
+        end
+      end
+
+      context "Veteran record is sensitive" do
+        before do
+          allow_any_instance_of(BGSService).to receive(:fetch_veteran_info).with(veteran_id) do |bgs|
+            if bgs.client.css_id == User.system_user.css_id
+              bgs.parse_veteran_info(veteran_info)
+            else
+              raise BGS::ShareError.new("Sensitive File - Access Violation")
+            end
+          end
+        end
+
+        it "responds with error" do
+          subject
+
+          expect(response).to_not be_successful
+          expect(body[:status]).to include("This efolder contains sensitive information")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Previously we were applying user authorization at the controller level for initial request, but the serialization level makes a subsequent call to BGS which was not getting the same authorization rules applied.