### PR TITLE
Use the POA org pid to compare, not the POA user pid

### DIFF
--- a/app/services/concerns/poa_mapper.rb
+++ b/app/services/concerns/poa_mapper.rb
@@ -1,7 +1,7 @@
 module POAMapper
   extend ActiveSupport::Concern
 
-  # used by fetch_poas_by_participant_ids (for Claimants)
+  # used by bgs.client.org
   def get_claimant_poa_from_bgs_poa(bgs_record = {})
     bgs_record ||= {}
     return {} unless bgs_record.dig(:power_of_attorney)
@@ -10,9 +10,7 @@ module POAMapper
     {
       representative_type: bgs_rep[:org_type_nm],
       representative_name: bgs_rep[:nm],
-      # Used to find the POA address
       participant_id: bgs_rep[:ptcpnt_id],
-      # pass through other attrs
       authzn_change_clmant_addrs_ind: bgs_rep[:authzn_change_clmant_addrs_ind],
       authzn_poa_access_ind: bgs_rep[:authzn_poa_access_ind],
       legacy_poa_cd: bgs_rep[:legacy_poa_cd],
@@ -21,7 +19,7 @@ module POAMapper
     }
   end
 
-  # used by fetch_poa_by_file_number
+  # used by fetch_poa_by_file_number (bgs.client.claimants)
   def get_claimant_poa_from_bgs_claimants_poa(bgs_record = {})
     bgs_record ||= {}
     return {} unless bgs_record.dig(:relationship_name)
@@ -40,5 +38,16 @@ module POAMapper
     [bgs_resp].flatten.each_with_object({}) do |poa, hsh|
       hsh[poa[:ptcpnt_id]] = get_claimant_poa_from_bgs_poa(poa)
     end
+  end
+
+  # used by fetch_poa_user_record (bgs.client.org)
+  def get_poa_from_bgs_poa(bgs_rep = {})
+    return {} unless bgs_rep&.dig(:org_type_nm)
+
+    {
+      representative_type: bgs_rep[:org_type_nm],
+      representative_name: bgs_rep[:nm],
+      participant_id: bgs_rep[:ptcpnt_id]
+    }
   end
 end

--- a/app/services/concerns/poa_mapper.rb
+++ b/app/services/concerns/poa_mapper.rb
@@ -40,8 +40,8 @@ module POAMapper
     end
   end
 
-  # used by fetch_poa_user_record (bgs.client.org)
-  def get_poa_from_bgs_poa(bgs_rep = {})
+  # used by fetch_poa_org_record (bgs.client.org)
+  def get_poa_from_bgs_org_poa(bgs_rep = {})
     return {} unless bgs_rep&.dig(:org_type_nm)
 
     {

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -84,6 +84,16 @@ class ExternalApi::BGSService
     get_claimant_poa_from_bgs_claimants_poa(bgs_poa)
   end
 
+  # Fetch the POA User's org record
+  def fetch_poa_user_record(poa_participant_id)
+    bgs_poa = MetricsService.record("BGS: fetch record for POA participant id: #{poa_participant_id}",
+                                    service: :bgs,
+                                    name: "org.find_poa_by_participant_id") do
+      client.org.find_poas_by_ptcpnt_id(poa_participant_id)
+    end
+    get_poa_from_bgs_poa(bgs_poa)
+  end
+
   # The participant IDs here are for Claimants.
   # I.e. returns the list of POAs that represent the Claimants.
   def fetch_poas_by_participant_ids(participant_ids)

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -85,13 +85,13 @@ class ExternalApi::BGSService
   end
 
   # Fetch the POA User's org record
-  def fetch_poa_user_record(poa_participant_id)
-    bgs_poa = MetricsService.record("BGS: fetch record for POA participant id: #{poa_participant_id}",
+  def fetch_poa_org_record(participant_id)
+    bgs_poa = MetricsService.record("BGS: fetch record for POA participant id: #{participant_id}",
                                     service: :bgs,
-                                    name: "org.find_poa_by_participant_id") do
-      client.org.find_poas_by_ptcpnt_id(poa_participant_id)
+                                    name: "org.find_poas_by_ptcpnt_id") do
+      client.org.find_poas_by_ptcpnt_id(participant_id)
     end
-    get_poa_from_bgs_poa(bgs_poa)
+    get_poa_from_bgs_org_poa(bgs_poa)
   end
 
   # The participant IDs here are for Claimants.

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -86,12 +86,12 @@ class ExternalApi::BGSService
 
   # Fetch the POA User's org record
   def fetch_poa_org_record(participant_id)
-    bgs_poa = MetricsService.record("BGS: fetch record for POA participant id: #{participant_id}",
-                                    service: :bgs,
-                                    name: "org.find_poas_by_ptcpnt_id") do
+    bgs_poas = MetricsService.record("BGS: fetch record for POA participant id: #{participant_id}",
+                                     service: :bgs,
+                                     name: "org.find_poas_by_ptcpnt_id") do
       client.org.find_poas_by_ptcpnt_id(participant_id)
     end
-    get_poa_from_bgs_org_poa(bgs_poa)
+    [bgs_poas].flatten.compact.map { |poa| get_poa_from_bgs_org_poa(poa) }
   end
 
   # The participant IDs here are for Claimants.

--- a/app/services/pdf_service.rb
+++ b/app/services/pdf_service.rb
@@ -14,7 +14,7 @@ class PdfService
 
     # pdftk will crash on corrupt PDFs with the "Error: Unable to find file";
     # if this happens, write the file without attributes
-    unless stderr.empty?
+    unless stderr.blank?
       # contents might come back as nil
       Rails.logger.warn("cannot write pdf of size #{contents.try(:size).to_i} via #{command}: #{stderr}")
       File.open(filename, "wb") do |f|

--- a/app/services/user_authorizer.rb
+++ b/app/services/user_authorizer.rb
@@ -3,6 +3,13 @@
 # determine authorization rules for whether a User can view
 # an efolder for file number.
 #
+# The POA lookup dance with BGS API follows this pattern:
+#
+# 1. Find the participant id of the current user (user.participant_id)
+# 2. Find the POA org participant id with the user's participant id (org_poa_participant_id).
+# 3. Compare the POA org participant id to the POA record
+#    returned for the file number (file_number_poa_participant_id).
+#
 # The rules for POA for deceased veteran that VBMS uses:
 #
 # 1. Find if the vet is represented by the POA
@@ -43,16 +50,16 @@ class UserAuthorizer
   end
 
   def veteran_poa?
-    return false if poa_participant_id.blank?
+    return false if file_number_poa_participant_id.blank?
 
-    poa_participant_id.to_s == user.participant_id.to_s
+    file_number_poa_participant_id.to_s == org_poa_participant_id.to_s
   end
 
   def claimant_poa?
     return false unless veteran_deceased?
 
     veteran_claimants.any? do |claim|
-      claim[:poa].dig(:participant_id).to_s == user.participant_id.to_s
+      claim[:poa].dig(:participant_id).to_s == org_poa_participant_id.to_s
     end
   end
 
@@ -78,6 +85,13 @@ class UserAuthorizer
   private
 
   attr_accessor :sensitive_file, :poa_denied
+
+  # the PID on the user record can be used to look up the POA record for the User's org,
+  # which has the PID used to reference POA relationships
+  def org_poa_participant_id
+    @user_poa_record ||= bgs.fetch_poa_user_record(user.participant_id)
+    @user_poa_record.dig(:participant_id)
+  end
 
   def veteran_claimants
     @veteran_claimants ||= build_veteran_claimants
@@ -113,7 +127,7 @@ class UserAuthorizer
     raise err
   end
 
-  def poa_participant_id
+  def file_number_poa_participant_id
     file_number_poa&.dig(:participant_id)
   end
 

--- a/app/services/user_authorizer.rb
+++ b/app/services/user_authorizer.rb
@@ -89,8 +89,8 @@ class UserAuthorizer
   # the PID on the user record can be used to look up the POA record for the User's org,
   # which has the PID used to reference POA relationships
   def org_poa_participant_id
-    @user_poa_record ||= bgs.fetch_poa_user_record(user.participant_id)
-    @user_poa_record.dig(:participant_id)
+    @org_poa_record ||= bgs.fetch_poa_org_record(user.participant_id)
+    @org_poa_record.dig(:participant_id)
   end
 
   def veteran_claimants

--- a/app/services/user_authorizer.rb
+++ b/app/services/user_authorizer.rb
@@ -8,7 +8,7 @@
 # 1. Find the participant id of the current user (user.participant_id)
 # 2. Find the POA org participant id with the user's participant id (org_poa_participant_id).
 # 3. Compare the POA org participant id to the POA record
-#    returned for the file number (file_number_poa_participant_id).
+#    returned for the file number (participant_id_for_poa_by_file_number)
 #
 # The rules for POA for deceased veteran that VBMS uses:
 #
@@ -50,9 +50,9 @@ class UserAuthorizer
   end
 
   def veteran_poa?
-    return false if file_number_poa_participant_id.blank?
+    return false if participant_id_for_poa_by_file_number.blank?
 
-    file_number_poa_participant_id.to_s == org_poa_participant_id.to_s
+    participant_id_for_poa_by_file_number.to_s == org_poa_participant_id.to_s
   end
 
   def claimant_poa?
@@ -127,12 +127,12 @@ class UserAuthorizer
     raise err
   end
 
-  def file_number_poa_participant_id
-    file_number_poa&.dig(:participant_id)
+  def participant_id_for_poa_by_file_number
+    poa_by_file_number&.dig(:participant_id)
   end
 
-  def file_number_poa
-    @file_number_poa ||= bgs.fetch_poa_by_file_number(file_number)
+  def poa_by_file_number
+    @poa_by_file_number ||= bgs.fetch_poa_by_file_number(file_number)
   end
 
   def bgs

--- a/app/services/zipfile_creator.rb
+++ b/app/services/zipfile_creator.rb
@@ -7,7 +7,7 @@ class ZipfileCreator
 
   def process
     records = manifest.records
-    return if records.empty?
+    return if records.blank?
 
     t = Tempfile.new
     write_to_tempfile(t, records)

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -136,4 +136,6 @@ class Fakes::BGSService
   def fetch_poa_by_participant_id(pid); end
 
   def fetch_claims_for_file_number(fn); end
+
+  def fetch_poa_user_record(pid); end
 end

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -137,5 +137,5 @@ class Fakes::BGSService
 
   def fetch_claims_for_file_number(fn); end
 
-  def fetch_poa_user_record(pid); end
+  def fetch_poa_org_record(pid); end
 end

--- a/spec/controllers/api_v2_application_controller_spec.rb
+++ b/spec/controllers/api_v2_application_controller_spec.rb
@@ -34,12 +34,20 @@ describe Api::V2::ApplicationController do
   let(:veteran_participant_id) { "123" }
   let(:poa_participant_id) { "345" }
   let(:claimant_participant_id) { "456" }
+  let(:org_poa_participant_id) { "999" }
   let(:claimants_poa_response) do
     {
       representative_name: "A Lawyer",
-      participant_id: poa_participant_id,
+      participant_id: org_poa_participant_id,
       representative_type: "POA Attorney",
       veteran_participant_id: veteran_participant_id
+    }
+  end
+  let(:org_poa_response) do
+    {
+      representative_name: "A Lawyer",
+      participant_id: org_poa_participant_id,
+      representative_type: "POA Attorney"
     }
   end
   let(:benefit_claims_response) do
@@ -113,6 +121,8 @@ describe Api::V2::ApplicationController do
                 .with(claimant_participant_id) { claimants_poa_response }
               allow_any_instance_of(BGSService).to receive(:fetch_claims_for_file_number)
                 .with(veteran_id) { benefit_claims_response }
+              allow_any_instance_of(BGSService).to receive(:fetch_poa_user_record)
+                .with(poa_participant_id) { org_poa_response }
             end
 
             it "responds with success" do
@@ -150,6 +160,8 @@ describe Api::V2::ApplicationController do
           end
           allow_any_instance_of(BGSService).to receive(:fetch_poa_by_file_number)
             .with(veteran_id) { claimants_poa_response }
+          allow_any_instance_of(BGSService).to receive(:fetch_poa_user_record)
+            .with(poa_participant_id) { org_poa_response }
         end
 
         it "responds with success" do

--- a/spec/controllers/api_v2_application_controller_spec.rb
+++ b/spec/controllers/api_v2_application_controller_spec.rb
@@ -44,11 +44,13 @@ describe Api::V2::ApplicationController do
     }
   end
   let(:org_poa_response) do
-    {
-      representative_name: "A Lawyer",
-      participant_id: org_poa_participant_id,
-      representative_type: "POA Attorney"
-    }
+    [
+      {
+        representative_name: "A Lawyer",
+        participant_id: org_poa_participant_id,
+        representative_type: "POA Attorney"
+      }
+    ]
   end
   let(:benefit_claims_response) do
     [

--- a/spec/controllers/api_v2_application_controller_spec.rb
+++ b/spec/controllers/api_v2_application_controller_spec.rb
@@ -121,7 +121,7 @@ describe Api::V2::ApplicationController do
                 .with(claimant_participant_id) { claimants_poa_response }
               allow_any_instance_of(BGSService).to receive(:fetch_claims_for_file_number)
                 .with(veteran_id) { benefit_claims_response }
-              allow_any_instance_of(BGSService).to receive(:fetch_poa_user_record)
+              allow_any_instance_of(BGSService).to receive(:fetch_poa_org_record)
                 .with(poa_participant_id) { org_poa_response }
             end
 
@@ -160,7 +160,7 @@ describe Api::V2::ApplicationController do
           end
           allow_any_instance_of(BGSService).to receive(:fetch_poa_by_file_number)
             .with(veteran_id) { claimants_poa_response }
-          allow_any_instance_of(BGSService).to receive(:fetch_poa_user_record)
+          allow_any_instance_of(BGSService).to receive(:fetch_poa_org_record)
             .with(poa_participant_id) { org_poa_response }
         end
 

--- a/spec/requests/api/v2/manifests_spec.rb
+++ b/spec/requests/api/v2/manifests_spec.rb
@@ -341,11 +341,13 @@ describe "Manifests API v2", type: :request do
       ]
     end
     let(:org_poa_response) do
-      {
-        representative_name: "A Lawyer",
-        participant_id: org_poa_participant_id,
-        representative_type: "POA Attorney"
-      }
+      [
+        {
+          representative_name: "A Lawyer",
+          participant_id: org_poa_participant_id,
+          representative_type: "POA Attorney"
+        }
+      ]
     end
 
     let(:body) { JSON.parse(response.body, symbolize_names: true) }

--- a/spec/requests/api/v2/manifests_spec.rb
+++ b/spec/requests/api/v2/manifests_spec.rb
@@ -318,10 +318,11 @@ describe "Manifests API v2", type: :request do
     let(:veteran_participant_id) { "123" }
     let(:poa_participant_id) { "345" }
     let(:claimant_participant_id) { "456" }
+    let(:org_poa_participant_id) { "999" }
     let(:claimants_poa_response) do
       {
         representative_name: "A Lawyer",
-        participant_id: poa_participant_id,
+        participant_id: org_poa_participant_id,
         representative_type: "POA Attorney",
         veteran_participant_id: veteran_participant_id
       }
@@ -338,6 +339,13 @@ describe "Manifests API v2", type: :request do
           status_type_nm: "Cleared"
         }
       ]
+    end
+    let(:org_poa_response) do
+      {
+        representative_name: "A Lawyer",
+        participant_id: org_poa_participant_id,
+        representative_type: "POA Attorney"
+      }
     end
 
     let(:body) { JSON.parse(response.body, symbolize_names: true) }
@@ -377,6 +385,8 @@ describe "Manifests API v2", type: :request do
                 .with(claimant_participant_id) { claimants_poa_response }
               allow_any_instance_of(BGSService).to receive(:fetch_claims_for_file_number)
                 .with(veteran_id) { benefit_claims_response }
+              allow_any_instance_of(BGSService).to receive(:fetch_poa_org_record)
+                .with(poa_participant_id) { org_poa_response }
             end
 
             it "responds with success" do
@@ -415,6 +425,8 @@ describe "Manifests API v2", type: :request do
           end
           allow_any_instance_of(BGSService).to receive(:fetch_poa_by_file_number)
             .with(veteran_id) { claimants_poa_response }
+          allow_any_instance_of(BGSService).to receive(:fetch_poa_org_record)
+            .with(poa_participant_id) { org_poa_response }
         end
 
         it "responds with success" do


### PR DESCRIPTION
We were missing one key piece in the user authorization logic model, which is that the PID of the user is not the same PID referenced by the bgs.claimants POA responses. As the field name suggests the BGS response has `person_org_ptcpnt_id` which means we must look up the `org` participant id and use that to compare.