### PR TITLE
Revert login check for eFolder, for folks going to other apps

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,9 +7,7 @@ class ApplicationController < BaseController
   before_action :set_raven_user
 
   def serve_single_page_app
-     redirect_to("/unauthorized") unless user_is_authorized?
-
-     render("gui/single_page_app", layout: false)
+    can_access_react_app? ? render("gui/single_page_app", layout: false) : redirect_to("/unauthorized")
   end
 
   def authenticate

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,9 @@ class ApplicationController < BaseController
   before_action :set_raven_user
 
   def serve_single_page_app
-    can_access_react_app? ? render("gui/single_page_app", layout: false) : redirect_to("/unauthorized")
+    redirect_to("/unauthorized") unless can_access_react_app?
+
+    render("gui/single_page_app", layout: false)
   end
 
   def authenticate

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -76,6 +76,10 @@ class ApplicationController < BaseController
 
   private
 
+  def can_access_react_app?
+    FeatureToggle.enabled?(:efolder_react_app, user: current_user) || Rails.env.development?
+  end
+
   def user_is_authorized?
     return true if out_of_service?
 


### PR DESCRIPTION
This is in response to batteam request:
https://dsva.slack.com/archives/CHX8FMP28/p1590603820436400

The login rule was slightly changed in a recent PR, and it seems to be breaking for users that can't download eFolder, so reverting to the previous code.