### PR TITLE
No authorization needed for home page (authn only)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,8 +7,6 @@ class ApplicationController < BaseController
   before_action :set_raven_user
 
   def serve_single_page_app
-     redirect_to("/unauthorized") unless user_is_authorized?
-
      render("gui/single_page_app", layout: false)
   end
 


### PR DESCRIPTION
Removing v1 code revealed that authorization checks were not being applied in react-land.