### PR TITLE
Add user table indices

### DIFF
--- a/db/migrate/20200526162945_user_css_id_unique.rb
+++ b/db/migrate/20200526162945_user_css_id_unique.rb
@@ -1,0 +1,11 @@
+class UserCssIdUnique < Efolder::Migration
+  def up
+    safety_assured { execute "create unique index index_users_unique_css_id on users using btree (upper(css_id))" }
+    add_safe_index :users, [:last_login_at]
+  end
+
+  def down
+    safety_assured { execute "drop index index_users_unique_css_id" }
+    remove_index :users, [:last_login_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_26_161628) do
+ActiveRecord::Schema.define(version: 2020_05_26_162945) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -79,7 +79,9 @@ ActiveRecord::Schema.define(version: 2020_05_26_161628) do
     t.integer "vva_coachmarks_view_count", default: 0
     t.string "participant_id", comment: "the user BGS participant_id"
     t.datetime "last_login_at"
+    t.index "upper((css_id)::text)", name: "index_users_unique_css_id", unique: true
     t.index ["css_id", "station_id"], name: "index_users_on_css_id_and_station_id"
+    t.index ["last_login_at"], name: "index_users_on_last_login_at"
   end
 
 end

--- a/spec/features/react_download_spec.rb
+++ b/spec/features/react_download_spec.rb
@@ -312,7 +312,6 @@ RSpec.feature "React Downloads" do
         # Fast forward time so that the manifest becomes "stale" relative to the new time.
         Timecop.travel(Time.zone.now + 50.days)
         # Assign manifest to a different user (since different session is not possible)
-        @user = User.create(css_id: "123123", station_id: "116")
         FilesDownload.last.update!(user_id: @user.id)
 
         # Search for the same efolder and expect to see the search results page instead of the download page.


### PR DESCRIPTION
connects #1135 

CSS_ID is now enforced to be unique. See https://github.com/department-of-veterans-affairs/caseflow/pull/10188

`last_login_at` added for performance.

All duplicate CSS_ID records have been resolved in production.