### PR TITLE
Avoid VBMS::FilenumberDoesNotExist unless we match zero file numbers

### DIFF
--- a/app/services/manifest_fetcher.rb
+++ b/app/services/manifest_fetcher.rb
@@ -26,6 +26,7 @@ class ManifestFetcher
     file_numbers_found = {}
     errors = []
     documents = file_numbers.map do |file_number|
+      break if file_numbers_found.keys.any? # abort loop if first succeeded
       begin
         docs = manifest_source.service.v2_fetch_documents_for(file_number)
         file_numbers_found[file_number] = true
@@ -34,7 +35,7 @@ class ManifestFetcher
         errors << error
         []
       end
-    end.flatten
+    end.flatten.uniq
     if file_numbers_found.empty?
       fail errors.first # don't care if there is more than one.
     end

--- a/app/services/manifest_fetcher.rb
+++ b/app/services/manifest_fetcher.rb
@@ -26,7 +26,6 @@ class ManifestFetcher
     file_numbers_found = {}
     errors = []
     documents = file_numbers.map do |file_number|
-      break if file_numbers_found.keys.any? # abort loop if first succeeded
       begin
         docs = manifest_source.service.v2_fetch_documents_for(file_number)
         file_numbers_found[file_number] = true

--- a/app/services/manifest_fetcher.rb
+++ b/app/services/manifest_fetcher.rb
@@ -27,10 +27,12 @@ class ManifestFetcher
     errors = []
     documents = file_numbers.map do |file_number|
       begin
-        manifest_source.service.v2_fetch_documents_for(file_number)
+        docs = manifest_source.service.v2_fetch_documents_for(file_number)
         file_numbers_found[file_number] = true
+        docs
       rescue VBMS::FilenumberDoesNotExist => error
         errors << error
+        []
       end
     end.flatten
     if file_numbers_found.empty?

--- a/app/services/manifest_fetcher.rb
+++ b/app/services/manifest_fetcher.rb
@@ -21,14 +21,37 @@ class ManifestFetcher
 
   def fetch_documents
     # fetch documents for all the "file numbers" known for this veteran
-    file_numbers.map do |file_number|
-      manifest_source.service.v2_fetch_documents_for(file_number)
+    # it's possible that BGS reports a FN that VBMS does not know about.
+    # so do not report the error if at least one FN works.
+    file_numbers_found = {}
+    errors = []
+    documents = file_numbers.map do |file_number|
+      begin
+        manifest_source.service.v2_fetch_documents_for(file_number)
+        file_numbers_found[file_number] = true
+      rescue VBMS::FilenumberDoesNotExist => error
+        errors << error
+      end
     end.flatten
+    if file_numbers_found.empty?
+      fail errors.first # don't care if there is more than one.
+    end
+    documents
   end
 
   def file_numbers
-    vet_finder = VeteranFinder.new(bgs: BGSService.new(client: bgs_client))
-    [manifest_source.file_number, vet_finder.find_uniq_file_numbers(manifest_source.file_number)].flatten.uniq
+    @file_numbers ||= [
+      manifest_source.file_number,
+      vet_finder.find_uniq_file_numbers(manifest_source.file_number)
+    ].flatten.uniq
+  end
+
+  def vet_finder
+    @vet_finder ||= VeteranFinder.new(bgs: bgs)
+  end
+
+  def bgs
+    @bgs ||= BGSService.new(client: bgs_client)
   end
 
   def bgs_client


### PR DESCRIPTION
https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/8396/events/e25bd75fe3e04e6b9fe28c2dcb54463d/

If there are multiple file numbers, do not throw an exception if only one of them fails to be found.