### PR TITLE
Handle text and json requests in SPA root

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,11 @@ class ApplicationController < BaseController
   before_action :set_raven_user
 
   def serve_single_page_app
-     render("gui/single_page_app", layout: false)
+    respond_to do |format|
+      format.html { render("gui/single_page_app", layout: false) }
+      format.text { render plain: "Text not supported" }
+      format.json { render json: { error: "JSON not supported" } }
+    end
   end
 
   def authenticate

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,42 @@
+describe ApplicationController do
+  describe "#serve_single_page_app" do
+    render_views
+
+    let!(:user) { User.authenticate! }
+
+    subject { get :serve_single_page_app, as: request_format }
+
+    context "HTML" do
+      let(:request_format) { :html }
+
+      it "returns React bootstrap response" do
+        subject
+
+        expect(response).to be_successful
+        expect(response.body).to match(/efolderExpress.init/)
+      end
+    end
+
+    context "text" do
+      let(:request_format) { :text }
+
+      it "returns (mostly) empty response" do
+        subject
+
+        expect(response).to be_successful
+        expect(response.body).to eq "Text not supported"
+      end
+    end
+
+    context "JSON" do
+      let(:request_format) { :json }
+
+      it "returns JSON payload with error message" do
+        subject
+
+        expect(response).to be_successful
+        expect(JSON.parse(response.body)).to eq({ "error" => "JSON not supported" })
+      end
+    end
+  end
+end


### PR DESCRIPTION
IDT login flow assumes that a plain text MIME request will return 200 with a cookie. When we removed the v1 code, that stopped working.

This change returns a 200 response for GET requests to the root path for HTML, text and JSON, even if only HTML is actually supported.

See https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/10462/events/02e96652a7ee4918840084810635d350/