### PR TITLE
Remove user_authorizer feature toggle

### DIFF
--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -41,15 +41,11 @@ class Veteran
   def fetch_bgs_record
     return bgs.fetch_veteran_info(file_number) unless user
 
-    if FeatureToggle.enabled?(:user_authorizer, user: user)
-      if authorizer.can_read_efolder? && authorizer.veteran_record_found?
-        # use .system_veteran_record in case we are POA and .veteran_record is nil
-        authorizer.system_veteran_record
-      else
-        raise BGS::ShareError, "Cannot access Veteran record"
-      end
+    if authorizer.can_read_efolder? && authorizer.veteran_record_found?
+      # use .system_veteran_record in case we are POA and .veteran_record is nil
+      authorizer.system_veteran_record
     else
-      bgs.fetch_veteran_info(file_number)
+      raise BGS::ShareError, "Cannot access Veteran record"
     end
   end
 end

--- a/spec/controllers/api_v2_application_controller_spec.rb
+++ b/spec/controllers/api_v2_application_controller_spec.rb
@@ -68,14 +68,6 @@ describe Api::V2::ApplicationController do
 
   let(:body) { JSON.parse(response.body, symbolize_names: true) }
 
-  before do
-    FeatureToggle.enable!(:user_authorizer)
-  end
-
-  after do
-    FeatureToggle.disable!(:user_authorizer)
-  end
- 
   describe "veteran file number access" do
     before do
       request.headers.merge!(headers)

--- a/spec/features/user_error_flows_spec.rb
+++ b/spec/features/user_error_flows_spec.rb
@@ -121,10 +121,7 @@ RSpec.feature "User Error Flows" do
     end
   end
 
-  context "user_authorizer feature toggle on" do
-    before { FeatureToggle.enable!(:user_authorizer) }
-    after { FeatureToggle.disable!(:user_authorizer) }
-
+  context "UserAuthorizer" do
     let(:veteran_participant_id) { "123" }
     let(:poa_participant_id) { "345" }
 

--- a/spec/features/user_error_flows_spec.rb
+++ b/spec/features/user_error_flows_spec.rb
@@ -100,27 +100,6 @@ RSpec.feature "User Error Flows" do
     end
   end
 
-  context "When veteran id has high sensitivity" do
-    scenario "Cannot access it" do
-      allow_any_instance_of(Fakes::BGSService).to receive(:fetch_veteran_info).and_raise("Sensitive File - Access Violation")
-      visit "/"
-      fill_in "Search for a Veteran ID number below to get started.", with: veteran_id
-      click_button "Search"
-
-      expect(page).to have_content("This efolder contains sensitive information")
-    end
-
-    scenario "VSO cannot access it" do
-      allow_any_instance_of(Fakes::BGSService).to receive(:fetch_veteran_info)
-        .and_raise("Power of Attorney of Folder is '071'. Access to this record is denied.")
-      visit "/"
-      fill_in "Search for a Veteran ID number below to get started.", with: veteran_id
-      click_button "Search"
-
-      expect(page).to have_content("This efolder belongs to a Veteran you do not represent")
-    end
-  end
-
   context "UserAuthorizer" do
     let(:veteran_participant_id) { "123" }
     let(:poa_participant_id) { "345" }

--- a/spec/requests/api/v2/manifests_spec.rb
+++ b/spec/requests/api/v2/manifests_spec.rb
@@ -298,9 +298,6 @@ describe "Manifests API v2", type: :request do
   end
 
   context "POA" do
-    before { FeatureToggle.enable!(:user_authorizer) }
-    after { FeatureToggle.disable!(:user_authorizer) }
-
     subject { post "/api/v2/manifests/", params: nil, headers: headers }
 
     let(:veteran_info) do


### PR DESCRIPTION
connects #1218 

Removes the `user_authorizer` feature toggle now that it has been running for [all users in production](https://github.com/department-of-veterans-affairs/appeals-deployment/pull/2740) for a couple weeks.