### PR TITLE
Workaround for rack 2.2.2 streaming bug

### DIFF
--- a/app/controllers/api/v2/files_downloads_controller.rb
+++ b/app/controllers/api/v2/files_downloads_controller.rb
@@ -30,6 +30,12 @@ class Api::V2::FilesDownloadsController < Api::V2::ApplicationController
     # see https://piotrmurach.com/articles/streaming-large-zip-files-in-rails/
     headers["X-Accel-Buffering"] = "no"
     headers["Cache-Control"] ||= "no-cache"
+
+    # Set this to prevent the Rack::ETag middleware from buffering the response.
+    # Note: Affects rack 2.2.2
+    #
+    # See: https://github.com/rack/rack/issues/1619#issuecomment-606315714
+    headers['Last-Modified'] = '0'
   end
 
   def json_files_downloads


### PR DESCRIPTION
See: 
  * https://github.com/rack/rack/issues/1619
  * https://github.com/rack/rack/issues/1628

## Description

Resolves a bug introduced in rack `2.2.2` with streaming data. The fix disables the `Rack::ETag` middleware for the downloads route to prevent it from buffering the S3 data before sending it to the client.

## Reproducing

To reproduce, edit `app/controllers/api/v2/files_downloads_controller.rb`:

1. Disable the manifest check

```ruby
#before_action :files_download_exists?
```

2. Stream dummy data back over 60 seconds

```ruby
  def zip
    streaming_headers
    self.response_body = Enumerator.new do |y|
      (0..60).each do
        y << 'test'
        sleep 1
      end
    end
  end
```

3. Remove headers that rely on the manifest

```ruby
  def streaming_headers
    headers["Content-Type"] = "application/zip"
    headers["Content-disposition"] = "attachment; filename=\"test\""
    headers.delete("Content-Length")
```

## Differences

### After: Disabling the Rack::ETag middleware

The file download starts immediately and the file size is increasing

![Screen Recording 2020-06-08 at 3 58 03 PM mov](https://user-images.githubusercontent.com/1298274/84074788-1bd51680-a9a1-11ea-90b6-e2154925f3ff.gif)

### Before:

The file download remains pending until the full 60 seconds has elapsed (the gif is cut prematurely)

![Screen Recording 2020-06-08 at 4 00 44 PM mov](https://user-images.githubusercontent.com/1298274/84075196-bcc3d180-a9a1-11ea-8cc9-58e8df59edb4.gif)


