### PR TITLE
correctly handle return of a single hash when fetching claims

### DIFF
--- a/app/services/user_authorizer.rb
+++ b/app/services/user_authorizer.rb
@@ -98,7 +98,7 @@ class UserAuthorizer
   end
 
   def build_veteran_claimants
-    Array(bgs.fetch_claims_for_file_number(file_number)).flatten.map do |claim|
+    [bgs.fetch_claims_for_file_number(file_number)].flatten.map do |claim|
       {
         claimant_participant_id: claim[:ptcpnt_clmant_id],
         veteran_participant_id: claim[:ptcpnt_vet_id],

--- a/app/services/user_authorizer.rb
+++ b/app/services/user_authorizer.rb
@@ -98,7 +98,7 @@ class UserAuthorizer
   end
 
   def build_veteran_claimants
-    [bgs.fetch_claims_for_file_number(file_number)].flatten.map do |claim|
+    [bgs.fetch_claims_for_file_number(file_number)].flatten.compact.map do |claim|
       {
         claimant_participant_id: claim[:ptcpnt_clmant_id],
         veteran_participant_id: claim[:ptcpnt_vet_id],


### PR DESCRIPTION
The `ExternalApi::BGSService.fetch_claims_for_file_number` method may return a single `Hash`, or an `Array` of hashes. This PR fixes a bug where a single returned `Hash` was being split into an array of all its keys & values rather than converted into an array containing a single hash, as intended.

given:
```ruby
hash_input = {one: "one", two: "two", three: "three"}
array_input = [{one: "one", two: "two", three: "three"}, {four: "four", five: "five", six: "six"}]
```

before:
```ruby
Array(array_input).flatten
=> [{:one=>"one", :two=>"two", :three=>"three"}, {:four=>"four", :five=>"five", :six=>"six"}] # good!

Array(hash_input).flatten
=> [:one, "one", :two, "two", :three, "three"] # bad!
```

after:
```ruby
[array_input].flatten
=> [{:one=>"one", :two=>"two", :three=>"three"}, {:four=>"four", :five=>"five", :six=>"six"}] # good!

[hash_input].flatten
=> [{:one=>"one", :two=>"two", :three=>"three"}] # good!
```

This bug was discovered via [this Sentry alert](https://sentry.prod.appeals.va.gov/department-of-veterans-affairs/efolder/issues/11021/).
