### PR TITLE
Bigint for record ids

### DIFF
--- a/db/migrate/20201201160251_change_record_id_to_bigint.rb
+++ b/db/migrate/20201201160251_change_record_id_to_bigint.rb
@@ -1,0 +1,9 @@
+class ChangeRecordIdToBigint < ActiveRecord::Migration[5.2]
+  def up
+    change_column :records, :id, :bigint
+  end
+
+  def down
+    change_column :records, :id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_26_162945) do
+ActiveRecord::Schema.define(version: 2020_12_01_160251) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
## Description
We are currently at over the int limit for Record ids. This bumps us to bigints (2147483647 limit to 9223372036854775807)

## Test:

`make migrate` succeeds
`bin/rails db:rollback` succeeds

after migrating:
```ruby
 pp Record.columns.first
#<ActiveRecord::ConnectionAdapters::PostgreSQLColumn:0x00007fcbb27b39c0
 @collation=nil,
 @comment=nil,
 @default=nil,
 @default_function="nextval('records_id_seq'::regclass)",
 @max_identifier_length=63,
 @name="id",
 @null=false,
 @sql_type_metadata=
  #<ActiveRecord::ConnectionAdapters::SqlTypeMetadata:0x00007fcbb27b3ad8
   @limit=8,
   @precision=nil,
   @scale=nil,
   @sql_type="bigint",
   @type=:integer>,
 @table_name="records">

manifest = Manifest.create(file_number: "1234")
source = ManifestSource.create(name: %w[VBMS VVA].sample, manifest: manifest)
Record.create(id: 2147483283, version_id: "1234",  series_id: "5678", manifest_source: source)
Record.find(2147483283)
=> #<Record id: 2147483283, ... >
```

## Out of scope
Discussing if we need all these records
https://dsva.slack.com/archives/C2ZAMLK88/p1606839279040500