### PR TITLE
Store id in temp binint column

### DIFF
--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -5,6 +5,8 @@ class Record < ApplicationRecord
 
   validates :manifest_source, :version_id, :series_id, presence: true
 
+  before_save :save_to_temp_columns
+
   enum status: {
     initialized: 0,
     success: 1,
@@ -109,5 +111,9 @@ class Record < ApplicationRecord
 
   def adjust_mime_type
     self.mime_type = "application/pdf" if mime_type == "application/octet-stream"
+  end
+
+  def save_to_temp_columns
+    self.temp_id = id
   end
 end

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -5,8 +5,6 @@ class Record < ApplicationRecord
 
   validates :manifest_source, :version_id, :series_id, presence: true
 
-  before_save :save_to_temp_columns
-
   enum status: {
     initialized: 0,
     success: 1,
@@ -26,6 +24,8 @@ class Record < ApplicationRecord
   # Convert mime type to "application/pdf" if it is a binary file
   # then PDFkit will check if PDF is valid
   before_create :adjust_mime_type
+
+  after_save :save_to_temp_columns
 
   delegate :manifest, :service, to: :manifest_source
   delegate :file_number, to: :manifest

--- a/db/migrate/20201201174552_add_temp_id_to_records.rb
+++ b/db/migrate/20201201174552_add_temp_id_to_records.rb
@@ -1,0 +1,9 @@
+class AddTempIdToRecords < ActiveRecord::Migration[5.2]
+  def up
+    add_column :records, :temp_id, :bigint
+  end
+
+  def down
+    remove_column :records, :temp_id
+  end
+end

--- a/db/migrate/20201201181531_add_index_to_temp_id.rb
+++ b/db/migrate/20201201181531_add_index_to_temp_id.rb
@@ -1,0 +1,11 @@
+class AddIndexToTempId < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def up
+    add_index :records, :temp_id, unique: true, algorithm: :concurrently
+  end
+
+  def down
+    remove_index :records, :temp_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_01_174552) do
+ActiveRecord::Schema.define(version: 2020_12_01_181531) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -68,6 +68,7 @@ ActiveRecord::Schema.define(version: 2020_12_01_174552) do
     t.datetime "upload_date"
     t.bigint "temp_id"
     t.index ["manifest_source_id", "series_id"], name: "index_records_on_manifest_source_id_and_series_id"
+    t.index ["temp_id"], name: "index_records_on_temp_id", unique: true
     t.index ["version_id", "manifest_source_id"], name: "index_records_on_version_id_and_manifest_source_id", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_26_162945) do
+ActiveRecord::Schema.define(version: 2020_12_01_174552) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,7 +49,7 @@ ActiveRecord::Schema.define(version: 2020_05_26_162945) do
     t.index ["file_number"], name: "index_manifests_on_file_number", unique: true
   end
 
-  create_table "records", force: :cascade do |t|
+  create_table "records", id: :serial, force: :cascade do |t|
     t.integer "manifest_source_id"
     t.integer "status", default: 0
     t.string "version_id"
@@ -66,6 +66,7 @@ ActiveRecord::Schema.define(version: 2020_05_26_162945) do
     t.string "series_id"
     t.integer "version"
     t.datetime "upload_date"
+    t.bigint "temp_id"
     t.index ["manifest_source_id", "series_id"], name: "index_records_on_manifest_source_id_and_series_id"
     t.index ["version_id", "manifest_source_id"], name: "index_records_on_version_id_and_manifest_source_id", unique: true
   end

--- a/spec/models/record_spec.rb
+++ b/spec/models/record_spec.rb
@@ -89,21 +89,21 @@ describe Record do
   end
 
   context ".create" do
+    let(:mime_type) { "application/octet-stream" }
+    let(:record) { Record.create(mime_type: mime_type, version_id: "1234", series_id: "5678", manifest_source: source) }
+
     context "mime_type" do
-      subject do
-        Record.create(
-          mime_type: mime_type,
-          version_id: "1234",
-          series_id: "5678",
-          manifest_source: source
-        ).mime_type
-      end
+      subject { record.mime_type }
 
       context "if application/octet-stream" do
-        let(:mime_type) { "application/octet-stream" }
-
         it { is_expected.to eq("application/pdf") }
       end
+    end
+
+    context "temp_id" do
+      subject { record.temp_id }
+
+      it { is_expected.to eq(record.id) }
     end
   end
 


### PR DESCRIPTION
## Description
Added a column to store id in big int as part one in: https://jilt.com/blog/migrations-zero-downtime-rails/

## Testing
all the below succeed
```bash
$ make migrate

...
[2020-12-01 13:18:42 -0500] Migrating to AddTempIdToRecords (20201201174552)
[2020-12-01 13:18:42 -0500]    (2.7ms)  BEGIN
== 20201201174552 AddTempIdToRecords: migrating ===============================
-- add_column(:records, :temp_id, :bigint)
[2020-12-01 13:18:42 -0500]    (2.7ms)  ALTER TABLE "records" ADD "temp_id" bigint
   -> 0.0032s
== 20201201174552 AddTempIdToRecords: migrated (0.0034s) ======================

[2020-12-01 13:18:42 -0500]   ActiveRecord::SchemaMigration Create (3.2ms)  INSERT INTO "schema_migrations" ("version") VALUES ($1) RETURNING "version"  [["version", "20201201174552"]]
[2020-12-01 13:18:42 -0500]    (3.9ms)  COMMIT
[2020-12-01 13:18:42 -0500] Migrating to AddIndexToTempId (20201201181531)
== 20201201181531 AddIndexToTempId: migrating =================================
-- add_index(:records, :temp_id, {:unique=>true, :algorithm=>:concurrently})
[2020-12-01 13:18:42 -0500]    (10.7ms)  CREATE UNIQUE INDEX CONCURRENTLY "index_records_on_temp_id" ON "records"  ("temp_id")
   -> 0.0197s
== 20201201181531 AddIndexToTempId: migrated (0.0198s) ========================
...

$ bin/rails db:rollback

...
[2020-12-01 13:18:04 -0500] Migrating to AddIndexToTempId (20201201181531)
== 20201201181531 AddIndexToTempId: reverting =================================
-- remove_index(:records, :temp_id)
[2020-12-01 13:18:04 -0500]    (4.6ms)  DROP INDEX  "index_records_on_temp_id"
   -> 0.0231s
== 20201201181531 AddIndexToTempId: reverted (0.0232s) ========================
...

$ bin/rails db:rollback

...
[2020-12-01 13:18:16 -0500] Migrating to AddTempIdToRecords (20201201174552)
[2020-12-01 13:18:16 -0500]    (2.6ms)  BEGIN
== 20201201174552 AddTempIdToRecords: reverting ===============================
-- remove_column(:records, :temp_id)
[2020-12-01 13:18:16 -0500]    (4.6ms)  ALTER TABLE "records" DROP COLUMN "temp_id"
   -> 0.0049s
== 20201201174552 AddTempIdToRecords: reverted (0.0051s) ======================
...
```
Make sure both rollbacks remove each migration.

after migrating:
```ruby
pp Record.columns.last
#<ActiveRecord::ConnectionAdapters::PostgreSQLColumn:0x00007fa3d8493940
 @collation=nil,
 @comment=nil,
 @default=nil,
 @default_function=nil,
 @max_identifier_length=63,
 @name="temp_id",
 @null=true,
 @sql_type_metadata=
  #<ActiveRecord::ConnectionAdapters::SqlTypeMetadata:0x00007fa3d8493a58
   @limit=8,
   @precision=nil,
   @scale=nil,
   @sql_type="bigint",
   @type=:integer>,
 @table_name="records">

manifest = Manifest.create(file_number: "123456")
source = ManifestSource.create(name: %w[VBMS VVA].sample, manifest: manifest)
record = Record.create(version_id: "1234",  series_id: "5678", manifest_source: source)
=> #<Record id: 1, ..., temp_id: 1>
```

