### PR TITLE
Add null constraint to temp id

### DIFF
--- a/db/migrate/20201201220847_change_temp_id_to_not_null.rb
+++ b/db/migrate/20201201220847_change_temp_id_to_not_null.rb
@@ -1,0 +1,9 @@
+class ChangeTempIdToNotNull < ActiveRecord::Migration[5.2]
+  def up
+    change_column :records, :temp_id, :bigint, null: false
+  end
+
+  def down
+    change_column :records, :temp_id, :bigint, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_01_181531) do
+ActiveRecord::Schema.define(version: 2020_12_01_220847) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,7 +66,7 @@ ActiveRecord::Schema.define(version: 2020_12_01_181531) do
     t.string "series_id"
     t.integer "version"
     t.datetime "upload_date"
-    t.bigint "temp_id"
+    t.bigint "temp_id", null: false
     t.index ["manifest_source_id", "series_id"], name: "index_records_on_manifest_source_id_and_series_id"
     t.index ["temp_id"], name: "index_records_on_temp_id", unique: true
     t.index ["version_id", "manifest_source_id"], name: "index_records_on_version_id_and_manifest_source_id", unique: true


### PR DESCRIPTION
## Desc.
Postgres enforces a not null constraint on columns that would be a primary key. Sets us up to make temp id our primary

## Testing
`make migrate` succeeds
`bin/rails db:rollback` succeeds