### PR TITLE
Add null constraint to temp id

### DIFF
--- a/db/migrate/20201201220847_change_temp_id_to_not_null.rb
+++ b/db/migrate/20201201220847_change_temp_id_to_not_null.rb
@@ -1,0 +1,9 @@
+class ChangeTempIdToNotNull < ActiveRecord::Migration[5.2]
+  def up
+    change_column :records, :temp_id, :bigint, null: false
+  end
+
+  def down
+    change_column :records, :temp_id, :bigint, null: true
+  end
+end

--- a/db/migrate/20201201221434_change_temp_id_to_primary_key.rb
+++ b/db/migrate/20201201221434_change_temp_id_to_primary_key.rb
@@ -1,0 +1,25 @@
+class ChangeTempIdToPrimaryKey < ActiveRecord::Migration[5.2]
+  def up
+    ActiveRecord::Base.transaction do
+      # Remove our primary key on id
+      execute "ALTER TABLE records DROP CONSTRAINT records_pkey;"
+      # Add temp_id as the primary key, using index from a previous migration for performace gains if it exists
+      execute "ALTER TABLE records ADD CONSTRAINT records_pkey PRIMARY KEY USING INDEX index_records_on_temp_id;"
+      # Ensure we auto increment our primary key
+      execute "CREATE SEQUENCE records_temp_id_seq;"
+      execute "ALTER TABLE records ALTER temp_id SET DEFAULT NEXTVAL('records_temp_id_seq');"
+      execute "SELECT SETVAL('records_temp_id_seq', (SELECT MAX(temp_id) FROM records));"
+    end
+  end
+
+  def down
+    ActiveRecord::Base.transaction do
+      # Remove our primary key on temp_id
+      execute "ALTER TABLE records DROP CONSTRAINT records_pkey;"
+      # Add temp_id as the primary key, Don't have an index here to rely on
+      execute "ALTER TABLE records ADD PRIMARY KEY (id);"
+      # Add back the index that gets removed when adding a primary key on an index
+      add_index :records, :temp_id, unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_01_181531) do
+ActiveRecord::Schema.define(version: 2020_12_01_220847) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,7 +66,7 @@ ActiveRecord::Schema.define(version: 2020_12_01_181531) do
     t.string "series_id"
     t.integer "version"
     t.datetime "upload_date"
-    t.bigint "temp_id"
+    t.bigint "temp_id", null: false
     t.index ["manifest_source_id", "series_id"], name: "index_records_on_manifest_source_id_and_series_id"
     t.index ["temp_id"], name: "index_records_on_temp_id", unique: true
     t.index ["version_id", "manifest_source_id"], name: "index_records_on_version_id_and_manifest_source_id", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_01_220847) do
+ActiveRecord::Schema.define(version: 2020_12_01_221434) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,7 +49,8 @@ ActiveRecord::Schema.define(version: 2020_12_01_220847) do
     t.index ["file_number"], name: "index_manifests_on_file_number", unique: true
   end
 
-  create_table "records", id: :serial, force: :cascade do |t|
+  create_table "records", primary_key: "temp_id", force: :cascade do |t|
+    t.serial "id", null: false
     t.integer "manifest_source_id"
     t.integer "status", default: 0
     t.string "version_id"
@@ -66,9 +67,7 @@ ActiveRecord::Schema.define(version: 2020_12_01_220847) do
     t.string "series_id"
     t.integer "version"
     t.datetime "upload_date"
-    t.bigint "temp_id", null: false
     t.index ["manifest_source_id", "series_id"], name: "index_records_on_manifest_source_id_and_series_id"
-    t.index ["temp_id"], name: "index_records_on_temp_id", unique: true
     t.index ["version_id", "manifest_source_id"], name: "index_records_on_version_id_and_manifest_source_id", unique: true
   end
 


### PR DESCRIPTION
Blocked by #1269

## Desc.
Switches the primary key of record to temp id

## Testing
`make migrate` succeeds
`bin/rails db:rollback` succeeds

after migrating:
```ruby
 pp Record.columns.first
#<ActiveRecord::ConnectionAdapters::PostgreSQLColumn:0x00007fea27414ba0
...
 @default_function=nil,
 @name="id",
 @null=true,
...

 pp Record.columns.last
#<ActiveRecord::ConnectionAdapters::PostgreSQLColumn:0x00007fea2dc02b18
...
 @default_function="nextval('records_temp_id_seq'::regclass)",
 @name="temp_id",
 @null=false,
...

# Ensure id is not being set
manifest = Manifest.create(file_number: "134")
source = ManifestSource.create(name: %w[VBMS VVA].sample, manifest: manifest)
# Don't be concerned if ID still shows in the active record as not null, it is null in the db.
# id here is the primary key of record (now temp id) NOT id column in the db (confusing, sorry)
Record.create(version_id: "1234",  series_id: "5678", manifest_source: source)
Record.pluck(:id).last
=> nil
```