### PR TITLE
Updates Gemfile.lock to mimemagic 0.3.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,7 +253,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.1104)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)


### PR DESCRIPTION
Resolves https://jenkins.uat.appeals.va.gov/job/bakes/job/prod/job/efolder/169/console failed build

### Description
Updates Gemfile.lock to mimemagic 0.3.6

See https://github.com/minad/mimemagic/issues/98

0.3.5 was yanked from the Internet due to a licensing issue, and an 0.4.0 version was released. But ActiveStorage depends on marcel which depends on 0.3.x, so an 0.3.6 version was released.

```
    marcel (0.3.3)
      mimemagic (~> 0.3.2)
```

This version GPL2 licensed. This appears to be a non-issue for our case but IANAL.