### PR TITLE
Remove editing PR from list of trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: efolder_rake
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize]
 
 env:
   FORCE_COLOR: "1" #Forces color within GHA - Note RSPEC still won't use color see line 199 --tty for rspec color


### PR DESCRIPTION
Editing a PR should not trigger the workflow, especially not until new workflows cancel previous ones that are not longer needed.