### PR TITLE
[DO NOT MERGE] Rails 5.2.Z - Raise on deprecation warnings in test env

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,7 +35,7 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
 
   # Print deprecation notices to the stderr.
-  config.active_support.deprecation = :stderr
+  config.active_support.deprecation = :raise
 
   config.s3_enabled = false
 


### PR DESCRIPTION
This is just an exploratory branch to see what deprecation warnings will emerge from the test suite.