### PR TITLE
AlecK/APPEALS-26715 Setup monitoring for deprecation warnings (again)

### DIFF
--- a/app/services/slack_service.rb
+++ b/app/services/slack_service.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# [DUPE] This class is a port of the same-named service from Caseflow:
+#   https://github.com/department-of-veterans-affairs/caseflow/blob/c868523c45660d84d72122b35569a50337609c69/app/services/slack_service.rb
+class SlackService
+  DEFAULT_CHANNEL = Rails.deploy_env?(:prod) ? "#appeals-job-alerts" : "#appeals-uat-alerts"
+  COLORS = {
+    error: "#ff0000",
+    info: "#cccccc",
+    warn: "#ffff00"
+  }.freeze
+
+  def initialize(url:)
+    @url = url
+  end
+
+  attr_reader :url
+
+  def send_notification(msg, title = "", channel = DEFAULT_CHANNEL)
+    return unless url && (aws_env == "uat" || aws_env == "prod")
+
+    slack_msg = format_slack_msg(msg, title, channel)
+
+    params = { body: slack_msg.to_json, headers: { "Content-Type" => "application/json" } }
+    http_service.post(url, params)
+  end
+
+  private
+
+  def http_service
+    @http_service ||= begin
+      # we do not want the self-signed cert normally part of the HTTPClient CA chain.
+      client = HTTPClient.new
+      client.ssl_config.clear_cert_store
+      client.ssl_config.add_trust_ca(ENV["SSL_CERT_FILE"])
+      client
+    end
+  end
+
+  def pick_color(title, msg)
+    if /error/i.match?(title)
+      COLORS[:error]
+    elsif /warn/i.match?(title)
+      COLORS[:warn]
+    elsif /error/i.match?(msg)
+      COLORS[:error]
+    elsif /warn/i.match?(msg)
+      COLORS[:warn]
+    else
+      COLORS[:info]
+    end
+  end
+
+  def format_slack_msg(msg, title, channel)
+    channel.prepend("#") unless channel.match?(/^#/)
+
+    {
+      username: "eFolder (#{aws_env})",
+      channel: channel,
+      attachments: [
+        {
+          title: title,
+          color: pick_color(title, msg),
+          text: msg
+        }
+      ]
+    }
+  end
+
+  def aws_env
+    ENV.fetch("DEPLOY_ENV", "development")
+  end
+end

--- a/config/initializers/deprecation_warning_subscriber.rb
+++ b/config/initializers/deprecation_warning_subscriber.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# @note For use in conjuction with setting `Rails.application.config.active_support.deprecation = :notify`.
+#   Whenever a “deprecation.rails” notification is published, it will dispatch the event
+#   (ActiveSupport::Notifications::Event) to method #deprecation.
+class DeprecationWarningSubscriber < ActiveSupport::Subscriber
+  APP_NAME = "efolder"
+  SLACK_ALERT_CHANNEL = "#appeals-deprecation-alerts"
+
+  attach_to :rails
+
+  def deprecation(event)
+    emit_warning_to_application_logs(event)
+    emit_warning_to_sentry(event)
+    ## Skip until we have ENV["SSL_CERT_FILE"] set in eFolder environments, as needed by SlackService
+    # emit_warning_to_slack_alerts_channel(event)
+  rescue StandardError => error
+    Raven.capture_exception(error)
+  end
+
+  private
+
+  def emit_warning_to_application_logs(event)
+    Rails.logger.warn(event.payload[:message])
+  end
+
+  def emit_warning_to_sentry(event)
+    # Need to convert callstack elements from `Thread::Backtrace::Location` objects to `Strings`
+    #   to avoid a `TypeError` on `options.deep_dup` in `Raven.capture_message`:
+    #   https://github.com/getsentry/sentry-ruby/blob/2e07e0295ba83df4c76c7bf3315d199c7050a7f9/lib/raven/instance.rb#L114
+    callstack_strings = event.payload[:callstack].map(&:to_s)
+
+    Raven.capture_message(
+      event.payload[:message],
+      level: "warning",
+      extra: {
+        message: event.payload[:message],
+        gem_name: event.payload[:gem_name],
+        deprecation_horizon: event.payload[:deprecation_horizon],
+        callstack: callstack_strings,
+        environment: Rails.env
+      }
+    )
+  end
+
+  def emit_warning_to_slack_alerts_channel(event)
+    slack_alert_title = "Deprecation Warning - #{APP_NAME} (#{ENV['DEPLOY_ENV']})"
+    
+    SlackService
+     .new(url: ENV["SLACK_DISPATCH_ALERT_URL"])
+     .send_notification(event.payload[:message], slack_alert_title, SLACK_ALERT_CHANNEL)
+  end
+end

--- a/spec/initializers/deprecation_warning_subscriber_spec.rb
+++ b/spec/initializers/deprecation_warning_subscriber_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+describe "DeprecationWarningSubscriber" do
+  let(:rails_logger) { Rails.logger }
+  let(:slack_service) { SlackService.new(url: "dummy-url") }
+
+  before do
+    allow(Rails).to receive(:logger).and_return(rails_logger)
+    allow(rails_logger).to receive(:warn)
+
+    allow(Raven).to receive(:capture_message)
+    allow(Raven).to receive(:capture_exception)
+
+    allow(SlackService).to receive(:new).with(url: anything).and_return(slack_service)
+    allow(slack_service).to receive(:send_notification)
+  end
+
+  context "when a 'deprecation.rails' event is instrumented" do
+    let(:payload) do
+      {
+        message: "test message",
+        gem_name: "Rails",
+        deprecation_horizon: "6.0",
+        callstack: [location_1, location_2]
+      }
+    end
+    let(:location_1) { instance_double("Thread::Backtrace::Location", to_s: "location 1") }
+    let(:location_2) { instance_double("Thread::Backtrace::Location", to_s: "location 2") }
+
+    def instrument_deprecation_warning
+      ActiveSupport::Notifications.instrument("deprecation.rails", payload)
+    end
+
+    it "emits a warning to the application logs" do
+      instrument_deprecation_warning
+
+      expect(rails_logger).to have_received(:warn).with(payload[:message])
+    end
+
+    it "emits a warning to Sentry" do
+      instrument_deprecation_warning
+
+      expect(Raven).to have_received(:capture_message).with(
+        payload[:message],
+        level: "warning",
+        extra: {
+          message: payload[:message],
+          gem_name: "Rails",
+          deprecation_horizon: "6.0",
+          callstack: ["location 1", "location 2"],
+          environment: Rails.env
+        }
+      )
+    end
+
+    xit "emits a warning to Slack channel" do
+      instrument_deprecation_warning
+
+      expect(slack_service).to have_received(:send_notification).with(
+       payload[:message],
+       "Deprecation Warning - efolder (#{ENV['DEPLOY_ENV']})",
+       "#appeals-deprecation-alerts"
+      )
+    end
+
+    xcontext "when an exception occurs" do
+      before { allow(slack_service).to receive(:send_notification).and_raise(StandardError) }
+
+      it "logs error to Sentry" do
+        instrument_deprecation_warning
+
+        expect(Raven).to have_received(:capture_exception).with(StandardError)
+      end
+
+      it "does not raise error" do
+        expect { instrument_deprecation_warning }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/services/slack_service_spec.rb
+++ b/spec/services/slack_service_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+describe SlackService do
+  let(:slack_service) { SlackService.new(url: "http://www.example.com") }
+  let(:http_agent) { double("http") }
+  let(:ssl_config) { double("ssl") }
+
+  before do
+    stub_const("ENV", "DEPLOY_ENV" => "uat")
+
+    @http_params = nil
+    allow(HTTPClient).to receive(:new) { http_agent }
+    allow(http_agent).to receive(:ssl_config) { ssl_config }
+    allow(ssl_config).to receive(:clear_cert_store) { true }
+    allow(ssl_config).to receive(:add_trust_ca) { true }
+    allow(http_agent).to receive(:post) do |_url, params|
+      @http_params = params
+      "response"
+    end
+  end
+
+  it "posts to http" do
+    response = slack_service.send_notification("hello")
+    expect(response).to eq("response")
+  end
+
+  context "when it is not run in the uat or prod environment" do
+    it "does not make post request" do
+      stub_const("ENV", "DEPLOY_ENV" => "dev")
+      slack_service.send_notification("filler message contents")
+      expect(@http_params).to be_nil
+    end
+  end
+
+  context "color selection" do
+    context "title contains ERROR" do
+      it "picks red color" do
+        slack_service.send_notification("filler message contents", "[ERROR] ouch!")
+        expect(@http_params[:body]).to match(/"#ff0000"/)
+      end
+    end
+
+    context "message contains error but title contains warning" do
+      it "picks yellow color" do
+        slack_service.send_notification("there was an error", "Really just a warning")
+        expect(@http_params[:body]).to match(/"#ffff00"/)
+      end
+    end
+
+    context "message contains error" do
+      it "picks red color" do
+        slack_service.send_notification("there was an error")
+        expect(@http_params[:body]).to match(/"#ff0000"/)
+      end
+    end
+
+    context "message contains warning" do
+      it "picks yellow color" do
+        slack_service.send_notification("a warning of something")
+        expect(@http_params[:body]).to match(/"#ffff00"/)
+      end
+    end
+
+    context "no magic string" do
+      it "defaults to gray" do
+        slack_service.send_notification("hello world")
+        expect(@http_params[:body]).to match(/"#cccccc"/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
(Re-)Resolves: https://jira.devops.va.gov/browse/APPEALS-26715

This reverts commit 86b473747f65efaf785d0c18dc8f76f066aad5ae, which accidentally wiped out the changes from original PR https://github.com/department-of-veterans-affairs/caseflow-efolder/pull/1402 when it was merged into `master`.

See https://github.com/department-of-veterans-affairs/caseflow-efolder/pull/1402 for more details.