### PR TITLE
MattT/APPEALS-35629: Upgrade Docker Image Versions in docker-compose and GHA Workflow Files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-8-cores-latest
     services:
       postgres:
-        image: postgres:14.10
+        image: postgres:14.8
         env:
           POSTGRES_USER: root
           POSTGRES_PASSWORD: password

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,14 +7,14 @@ on:
 
 env:
   FORCE_COLOR: "1" #Forces color within GHA - Note RSPEC still won't use color see line 199 --tty for rspec color
-      
+
 
 jobs:
   rake:
     runs-on: ubuntu-8-cores-latest
     services:
       postgres:
-        image: postgres:11.7
+        image: postgres:14.10
         env:
           POSTGRES_USER: root
           POSTGRES_PASSWORD: password
@@ -62,7 +62,7 @@ jobs:
         && rm /tmp/chrome.deb
         echo "Chrome exe name: $(ls /usr/bin | chrome)"
         echo "Chrome version: $(google-chrome --version)"
-       
+
     - name: Ruby version
       run: ruby -v
 
@@ -89,7 +89,7 @@ jobs:
 
     - name: Assets Precompile
       run: |
-          ./ci-bin/capture-log "bundle exec rake assets:precompile"    
+          ./ci-bin/capture-log "bundle exec rake assets:precompile"
 
     - name: RSpec
       run: |-
@@ -99,8 +99,8 @@ jobs:
         runuser -u circleci -- make -f Makefile.example test | tee ./test-results/rspec/rspec.out # circleci refers to user
       env:
         POSTGRES_HOST: postgres
-        
-    # Artifact Uploads    
+
+    # Artifact Uploads
     - uses: actions/upload-artifact@v3
       with:
         path: "./test-results"
@@ -119,7 +119,7 @@ jobs:
       run: |-
         npm install -g eslint
         ./ci-bin/capture-log "make -f Makefile.example lint"
-      if: ${{ always() }}  
+      if: ${{ always() }}
 
     - name: Security
       run:  ./ci-bin/capture-log "make -f Makefile.example security"

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -6,7 +6,7 @@ services:
       - "16379:6379"
 
   appeals-postgres:
-    image: postgres:14.10
+    image: postgres:14.8
     ports:
       - "5432:5432"
     volumes:

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -6,7 +6,7 @@ services:
       - "16379:6379"
 
   appeals-postgres:
-    image: postgres:11.7
+    image: postgres:14.10
     ports:
       - "5432:5432"
     volumes:

--- a/docker-compose-m1.yml
+++ b/docker-compose-m1.yml
@@ -6,7 +6,7 @@ services:
       - "16379:6379"
 
   appeals-postgres:
-    image: postgres:11.7
+    image: postgres:14.10
     ports:
       - "15432:5432"
     volumes:

--- a/docker-compose-m1.yml
+++ b/docker-compose-m1.yml
@@ -6,7 +6,7 @@ services:
       - "16379:6379"
 
   appeals-postgres:
-    image: postgres:14.10
+    image: postgres:14.8
     ports:
       - "15432:5432"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "16379:6379"
 
   appeals-postgres:
-    image: postgres:11.7
+    image: postgres:14.10
     ports:
       - "15432:5432"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "16379:6379"
 
   appeals-postgres:
-    image: postgres:14.10
+    image: postgres:14.8
     ports:
       - "15432:5432"
     volumes:


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-35629](https://jira.devops.va.gov/browse/APPEALS-35629)

# Description
Upgrade the `postgres` image versions from 11.7 to 14.8.

## Acceptance Criteria
- [ ] The `postgres` image versions are set to **14.8** in the following files:
   - [ ] eFolder Express
      - [ ] [docker-compose.yml](https://github.com/department-of-veterans-affairs/caseflow-efolder/blob/f426b4fc714041f114ee1c3629965bff33c9a965/docker-compose.yml#L9)
      - [ ] [docker-compose-local.yml](https://github.com/department-of-veterans-affairs/caseflow-efolder/blob/f426b4fc714041f114ee1c3629965bff33c9a965/docker-compose-local.yml#L9)
      - [ ] [docker-compose-m1.yml](https://github.com/department-of-veterans-affairs/caseflow-efolder/blob/f426b4fc714041f114ee1c3629965bff33c9a965/docker-compose-m1.yml#L9)
      - [ ] [.github/workflows/build.yml](https://github.com/department-of-veterans-affairs/caseflow-efolder/blob/f426b4fc714041f114ee1c3629965bff33c9a965/.github/workflows/build.yml#L17)

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Go to [APPEALS-35629](https://jira.devops.va.gov/browse/APPEALS-35629) and note the attached tests.