### PR TITLE
Ensure Errors From RSpec Test Failures Register in GHA Workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
 
     # Artifact Uploads
     - uses: actions/upload-artifact@v3
-      if: sucess() || failure()
+      if: success() || failure()
       with:
         path: "./test-results"
 
@@ -113,7 +113,7 @@ jobs:
         path: "./tmp/capybara"
 
     - uses: actions/upload-artifact@v3
-      if: sucess() || failure()
+      if: success() || failure()
       with:
         path: "./log/test.log"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,21 +95,25 @@ jobs:
         mkdir -p ./test-results/rspec
         mkdir .webdrivers
         chmod -R 777 ${GITHUB_WORKSPACE}
+        set -o pipefail
         runuser -u circleci -- make -f Makefile.example test | tee ./test-results/rspec/rspec.out # circleci refers to user
       env:
         POSTGRES_HOST: postgres
+      shell: bash
 
     # Artifact Uploads
     - uses: actions/upload-artifact@v3
+      if: sucess() || failure()
       with:
         path: "./test-results"
+
     - uses: actions/upload-artifact@v3
-      with:
-        path: "./test-results"
-    - uses: actions/upload-artifact@v3
+      if: failure()
       with:
         path: "./tmp/capybara"
+
     - uses: actions/upload-artifact@v3
+      if: sucess() || failure()
       with:
         path: "./log/test.log"
 

--- a/spec/features/help_spec.rb
+++ b/spec/features/help_spec.rb
@@ -11,6 +11,6 @@ RSpec.feature "Help" do
       click_on "Help"
     end
     # rubocop:enable Lint/HandleExceptions
-    expect(page).to have_content("Frequently Asked Questions")
+    expect(page).to have_content("Frequently Asked Answers")
   end
 end

--- a/spec/features/help_spec.rb
+++ b/spec/features/help_spec.rb
@@ -11,6 +11,6 @@ RSpec.feature "Help" do
       click_on "Help"
     end
     # rubocop:enable Lint/HandleExceptions
-    expect(page).to have_content("Frequently Asked Answers")
+    expect(page).to have_content("Frequently Asked Questions")
   end
 end


### PR DESCRIPTION
Resolves [APPEALS-37215](https://jira.devops.va.gov/browse/APPEALS-37215)

### Description
Alters the build GHA workflow to execute the RSpec command within a bash shell with pipefail enabled so that error codes thrown by test failures aren't eaten by our output redirection.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Test failures cause the rake check to fail during a GHA run

### Testing Plan
1. Verify that the RSpec step in [this CI execution](https://github.com/department-of-veterans-affairs/caseflow-efolder/actions/runs/7283418631/job/19847258013) failed appropriately due to an intentional test failure.
2. Ensure that the artifact upload steps **did** execute, uploading test logs and Capybara snapshots.
3. A download link for an artifact.zip file should be on the [summary page](https://github.com/department-of-veterans-affairs/caseflow-efolder/actions/runs/7283418631) that contains the aforementioned artifacts.
4. Make sure I didn't leave that test failure in the code. 😄 

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)
