### PR TITLE
DO_NOT_MERGE APPEALS-38441 Revisit Deprecation Warnings before Rails 6.0

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,7 +39,7 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
 
   # Print deprecation notices to the stderr.
-  config.active_support.deprecation = :stderr
+  config.active_support.deprecation = :raise
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true


### PR DESCRIPTION
Check to see if any new deprecation warnings popped up that need to be addressed before updating to Rails 6.0