### PR TITLE
add document source to records api v2 response headers

### DIFF
--- a/app/controllers/api/v2/records_controller.rb
+++ b/app/controllers/api/v2/records_controller.rb
@@ -2,6 +2,8 @@ class Api::V2::RecordsController < Api::V2::ApplicationController
   before_action :validate_access
 
   def show
+    #Check before fetch if the file is saved in S3
+    document_source_to_headers
     result = record.fetch!
     return document_failed if record.failed?
 
@@ -42,5 +44,10 @@ class Api::V2::RecordsController < Api::V2::ApplicationController
   def validate_access
     return record_not_found unless record
     sensitive_record unless record.accessible_by?(current_user)
+  end
+
+  def document_source_to_headers
+    from_s3 ||= S3Service.exists? record.s3_filename
+    headers["X-Document-Source"] = !!from_s3 ? "S3" : "VBMS"
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -105,7 +105,7 @@ module CaseflowEfolder
             methods:     :get,
             # when making a cross-origin request, only Cache-Control, Content-Language, 
             # Content-Type, Expires, Last-Modified, Pragma are exposed. PDF.js requires some additional headers to be sent as well
-            expose:      ['content-range, content-length, accept-ranges'], # Headers to send in response
+            expose:      ['content-range, content-length, accept-ranges, x-document-source'], # Headers to send in response
             credentials: true
         end
     end


### PR DESCRIPTION
Resolves Backend for APPEALS-39777

### Description
Documents V2 API #show, add new header key X-Document-Source that will show "VBMS" or "S3".
The Caseflow-Reader app uses this API to show documents and will track if the document was sourced from AWS S3 or VBMS to see if there is a correlation with the response time. 

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to ...

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)

### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 ---|---

### Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.

### Database Changes
*Only for Schema Changes*

* [ ] Timestamps (created_at, updated_at) for new tables
* [ ] Column comments updated
* [ ] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [ ] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [ ] Appropriate indexes added (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)
* [ ] Add your indexes safely (see [Caseflow::Migrations](https://github.com/department-of-veterans-affairs/caseflow/blob/master/lib/caseflow/migration.rb)
* [ ] DB schema docs updated with `make docs` (after running `make migrate`)
* [ ] #appeals-schema notified with summary and link to this PR
* [ ] Any non-obvious semantics or logic useful for interpreting database data is documented at [Caseflow Data Model and Dictionary](https://github.com/department-of-veterans-affairs/caseflow/wiki/Caseflow-Data-Model-and-Dictionary)

### Integrations: Adding endpoints for external APIs
* [ ] Check that Caseflow's external API code for the endpoint matches the code in the relevant integration repo
  * [ ] Request: Service name, method name, input field names
  * [ ] Response: Check expected data structure
* [ ] Update Fakes
* [ ] Integrations impacting functionality are tested in Caseflow UAT
