### PR TITLE
AlecK/APPEALS-26886 eFolder Post Rails 6.0 Config Update

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -92,15 +92,6 @@ module CaseflowEfolder
     # This can be changed to the defualt and removed if we no longer support IE5-8 (old browsers)
     Rails.application.config.action_view.default_enforce_utf8 = true
 
-    # Embed purpose and expiry metadata inside signed and encrypted
-    # cookies for increased security.
-    #
-    # This option is not backwards compatible with earlier Rails versions.
-    # It's best enabled when your entire app is migrated and stable on 6.0.
-    # Default change to true as of 6.0
-    # Remove after stable 6.0
-    Rails.application.config.action_dispatch.use_cookies_with_metadata = false
-
     # Enable the same cache key to be reused when the object being cached of type
     # `ActiveRecord::Relation` changes by moving the volatile information (max updated at and count)
     # of the relation's cache key into the cache version to support recycling cache key.

--- a/config/application.rb
+++ b/config/application.rb
@@ -52,16 +52,6 @@ module CaseflowEfolder
     # Rails 5.2 default overrides
     #---------------------------------------------------------------------------------------
 
-    # Use AES-256-GCM authenticated encryption for encrypted cookies.
-    # Also, embed cookie expiry in signed or encrypted cookies for increased security.
-    #
-    # This option is not backwards compatible with earlier Rails versions.
-    # It's best enabled when your entire app is migrated and stable on 5.2.
-    #
-    # Existing cookies will be converted on read then written with the new scheme.
-    # Default as of 5.2: true
-    Rails.application.config.action_dispatch.use_authenticated_cookie_encryption = false
-
     # Use AES-256-GCM authenticated encryption as default cipher for encrypting messages
     # instead of AES-256-CBC, when use_authenticated_message_encryption is set to true.
     # Default as of 5.2: true


### PR DESCRIPTION
Resolves [APPEALS-26886](https://jira.devops.va.gov/browse/APPEALS-26886)

# Required
This story needs to be tested and merged at the same time as [APPEALS-34124](https://jira.devops.va.gov/browse/APPEALS-34124), since caseflow and eFolder share the same session cookie.

When we release to Production, end users should not notice any changes, however there is a low risk that they could experience some authentication wonkiness, forcing them to log in again.

### Description
As part of update to Rails `6.0.Z`, we set `config.action_dispatch.use_cookies_with_metadata = false` to enable seamless rollback to Rails `5.2.Z` if necessary. Now that Rails 6.0 is stable in production, we can safely migrate to the default for this setting.

Rails 5.2 introduced setting `config.action_dispatch.use_cookies_with_metadata`.  We are currently overriding the default in order to preserve the pre-existing behavior, however, since we are now changing cookie configuration for Rails 6.0, this is an opportune time to migrate to the default for this setting as well.

### Acceptance Criteria
After Rails 6.0 is stable in production, in the `config/application.rb` file:
- remove the override for `config.action_dispatch.use_authenticated_cookie_encryption`
- remove the override for `config.action_dispatch.use_cookies_with_metadata`

