### PR TITLE
Caseflow-commons updated to 1.0.0 - bourbon/neat removal

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -137,7 +137,6 @@ linters:
     properties: []
   VendorPrefixes:
     enabled: true
-    identifier_list: bourbon
     include: []
     exclude: []
   ZeroUnit:

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "activejob_dj_overrides"
 gem "aws-sdk", "~> 2"
 gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: "98547485d863f2f0d3bb9a1b9ec92a8fe21ba306"
 gem "bootsnap", require: false
-gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "fb6fa9658825c143eb8d202b87128f34ca7e210b"
+gem "caseflow", "~> 1.0.0", git: "https://github.com/department-of-veterans-affairs/caseflow-commons"
 gem "coffee-rails", "> 4.1.0"
 gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", branch: "master"
 gem "connect_vva", git: "https://github.com/department-of-veterans-affairs/connect_vva.git", ref: "dfd1aeb2605c1f237f520bcdc41b059202e8944d"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,16 +20,14 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/caseflow-commons
-  revision: fb6fa9658825c143eb8d202b87128f34ca7e210b
-  ref: fb6fa9658825c143eb8d202b87128f34ca7e210b
+  revision: edd91cc2d3bcbdb84f7637bdfe5bcfa20c583759
+  branch: AlecK/APPEALS-27013
   specs:
-    caseflow (0.4.6)
+    caseflow (1.0.0)
       aws-sdk (~> 2.10)
-      bourbon (= 4.2.7)
       d3-rails
       jquery-rails
       momentjs-rails
-      neat
       rails (>= 4.2.7.1)
       redis-namespace
       redis-rails
@@ -166,9 +164,6 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
-    bourbon (4.2.7)
-      sass (~> 3.4)
-      thor (~> 0.19)
     brakeman (4.10.1)
     builder (3.2.4)
     bundler-audit (0.7.0.1)
@@ -201,7 +196,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    d3-rails (5.9.2)
+    d3-rails (7.8.5)
       railties (>= 3.1)
     database_cleaner (1.8.5)
     date (3.3.4)
@@ -288,8 +283,6 @@ GEM
     multipart-post (2.3.0)
     mustermann (1.1.2)
       ruby2_keywords (~> 0.0.1)
-    neat (4.0.0)
-      thor (~> 0.19)
     net-imap (0.4.10)
       date
       net-protocol
@@ -615,4 +608,4 @@ DEPENDENCIES
   zero_downtime_migrations
 
 BUNDLED WITH
-   1.17.3
+   2.4.17

--- a/app/assets/stylesheets/_commons.scss
+++ b/app/assets/stylesheets/_commons.scss
@@ -1,5 +1,3 @@
-@import 'bourbon';
-@import 'neat';
 @import 'uswds_rails_overrides/core/defaults';
 @import 'uswds/all';
 @import 'uswds_rails_overrides/all';
@@ -571,14 +569,6 @@ div {
     overflow: hidden;
   }
 }
-
-
-//-----------------------------------*
-// CSS based on Web Design Guidelines.
-// - Uses Neat.bourbon.io as a grid
-// - Uses patterns and components
-//   from refills.bourbon.io/unstyled/
-//-----------------------------------*/
 
 
 //===========================


### PR DESCRIPTION
🔴 Warning: Merge & deploy only after [caseflow-commons 1.0.0](https://github.com/department-of-veterans-affairs/caseflow-commons/pull/225) has been merged to master. 🔴

### Description
This is a breakout PR for a portion of the Rails 6.1 update to eFolder to test the removal of the Bourbon and Neat gems from caseflow-commons. 

🔴 Warning: Merge & deploy only after [caseflow-commons 1.0.0](https://github.com/department-of-veterans-affairs/caseflow-commons/pull/225) has been merged to master. 🔴