### PR TITLE
Fix Bug Preventing File Fetching

### DIFF
--- a/app/jobs/v2/download_manifest_job.rb
+++ b/app/jobs/v2/download_manifest_job.rb
@@ -11,7 +11,7 @@ class V2::DownloadManifestJob < ApplicationJob
 
     log_info(manifest_source.manifest.file_number, documents, manifest_source.manifest.zipfile_size)
 
-    #V2::SaveFilesInS3Job.perform_later(manifest_source) if documents.present? && !ApplicationController.helpers.ui_user?
+    V2::SaveFilesInS3Job.perform_later(manifest_source) if documents.present? && !ApplicationController.helpers.ui_user?
   rescue StandardError => error
     manifest_source.update!(status: :failed)
     Rails.logger.error "DownloadManifestJob encountered error #{error.class.name} when fetching manifest for appeal #{manifest_source.manifest.file_number}"

--- a/app/jobs/v2/download_manifest_job.rb
+++ b/app/jobs/v2/download_manifest_job.rb
@@ -11,7 +11,7 @@ class V2::DownloadManifestJob < ApplicationJob
 
     log_info(manifest_source.manifest.file_number, documents, manifest_source.manifest.zipfile_size)
 
-    V2::SaveFilesInS3Job.perform_later(manifest_source) if documents.present? && !ApplicationController.helpers.ui_user?
+    #V2::SaveFilesInS3Job.perform_later(manifest_source) if documents.present? && !ApplicationController.helpers.ui_user?
   rescue StandardError => error
     manifest_source.update!(status: :failed)
     Rails.logger.error "DownloadManifestJob encountered error #{error.class.name} when fetching manifest for appeal #{manifest_source.manifest.file_number}"


### PR DESCRIPTION
Resolves bug found in eFolder testing.

### Description
- Update `app/services/external_api/vbms_service.rb` to init a VBMS client automatically vs. requiring consumers to init the client themselves.

### Acceptance Criteria
- [ ] All specs passing

### Testing Plan
1. Run specs for changed files:
    - `bundle exec rspec spec/services/external_api/vbms_service_spec.rb`
