### PR TITLE
Update received_at Date Parsing Logic

### DIFF
--- a/app/services/json_api_response_adapter.rb
+++ b/app/services/json_api_response_adapter.rb
@@ -19,14 +19,16 @@ class JsonApiResponseAdapter
     provider_data = file_json["currentVersion"]["providerData"]
 
     OpenStruct.new(
-      document_id: "{#{file_json["currentVersionUuid"].upcase}}",
-      series_id: "{#{file_json["uuid"].upcase}}",
+      document_id: "{#{file_json['currentVersionUuid'].upcase}}",
+      series_id: "{#{file_json['uuid'].upcase}}",
       version: "1",
       type_description: provider_data["subject"],
       type_id: provider_data["documentTypeId"],
       doc_type: provider_data["documentTypeId"],
       subject: provider_data["subject"],
-      received_at: provider_data["dateVaReceivedDocument"],
+      # gsub here so that JS will correctly handle this date
+      # (with dashes the date is 1 day off due to UTC issues)
+      received_at: provider_data["dateVaReceivedDocument"]&.gsub("-", "/"),
       source: provider_data["contentSource"],
       mime_type: system_data["mimeType"],
       alt_doc_types: nil,

--- a/spec/services/json_api_response_adapter_spec.rb
+++ b/spec/services/json_api_response_adapter_spec.rb
@@ -17,11 +17,11 @@ describe JsonApiResponseAdapter do
       expect(parsed.length).to eq 2
 
       expect(parsed[0].document_id).to eq "{03223945-468B-4E8A-B79B-82FA73C2D2D9}"
-      expect(parsed[0].received_at).to eq "2018-03-08"
+      expect(parsed[0].received_at).to eq "2018/03/08"
       expect(parsed[0].mime_type).to eq "application/pdf"
 
       expect(parsed[1].document_id).to eq "{7D6AFD8C-3BF7-4224-93AE-E1F07AC43C71}"
-      expect(parsed[1].received_at).to eq "2018-12-08"
+      expect(parsed[1].received_at).to eq "2018/12/08"
       expect(parsed[1].mime_type).to eq "application/pdf"
     end
   end


### PR DESCRIPTION
Resolves [Difference between Rest API and Soap API Date forma](https://jira.devops.va.gov/browse/APPEALS-46996)

### Description
- Use slashes instead of hyphens to help JS correctly parse the date.

### Acceptance Criteria
- [ ] All specs passing

### Testing Plan
1. Run specs for changed files:
    - `bundle exec rspec spec/services/json_api_response_adapter_spec.rb`