### PR TITLE
Correctly Handle Blank JSON Responses

### DIFF
--- a/app/services/json_api_response_adapter.rb
+++ b/app/services/json_api_response_adapter.rb
@@ -5,6 +5,9 @@
 class JsonApiResponseAdapter
   def adapt_v2_fetch_documents_for(json_response)
     documents = []
+
+    return documents unless valid_json_response?(json_response)
+
     json_response.body["files"].each do |file_resp|
       documents.push(v2_fetch_documents_file_response(file_resp))
     end
@@ -13,6 +16,14 @@ class JsonApiResponseAdapter
   end
 
   private
+
+  def valid_json_response?(json_response)
+    return false if json_response.blank?
+
+    return false if json_response.body.blank?
+
+    json_response.body.key?("files")
+  end
 
   def v2_fetch_documents_file_response(file_json)
     system_data = file_json["currentVersion"]["systemData"]

--- a/app/services/json_api_response_adapter.rb
+++ b/app/services/json_api_response_adapter.rb
@@ -18,9 +18,7 @@ class JsonApiResponseAdapter
   private
 
   def valid_json_response?(json_response)
-    return false if json_response.blank?
-
-    return false if json_response.body.blank?
+    return false if json_response&.body.blank?
 
     json_response.body.key?("files")
   end

--- a/spec/services/json_api_response_adapter_spec.rb
+++ b/spec/services/json_api_response_adapter_spec.rb
@@ -8,9 +8,35 @@ describe JsonApiResponseAdapter do
   let(:api_response) { instance_double(ExternalApi::Response) }
 
   describe "#adapt_v2_fetch_documents_for" do
+    context "with invalid responses" do
+      it "handles blank responses" do
+        parsed = described.adapt_v2_fetch_documents_for(nil)
+
+        expect(parsed.length).to eq 0
+      end
+
+      it "handles blank response bodies" do
+        response = instance_double(ExternalApi::Response, body: nil)
+        parsed = described.adapt_v2_fetch_documents_for(response)
+
+        expect(parsed.length).to eq 0
+      end
+
+      it "handles response bodies with no files" do
+        response = instance_double(ExternalApi::Response, body: {})
+        parsed = described.adapt_v2_fetch_documents_for(response)
+
+        expect(parsed.length).to eq 0
+      end
+    end
+
     it "correctly parses an API response" do
-      expect(api_response).to receive(:body)
-        .and_return(JSON.load(Rails.root.join("spec/support/api_responses/ce_api_folders_files_search.json")))
+      file = File.open(Rails.root.join("spec/support/api_responses/ce_api_folders_files_search.json"))
+      data_hash = JSON.parse(File.read(file))
+      file.close
+
+      expect(api_response).to receive(:body).exactly(3).times
+        .and_return(data_hash)
 
       parsed = described.adapt_v2_fetch_documents_for(api_response)
 

--- a/spec/services/json_api_response_adapter_spec.rb
+++ b/spec/services/json_api_response_adapter_spec.rb
@@ -35,8 +35,8 @@ describe JsonApiResponseAdapter do
       data_hash = JSON.parse(File.read(file))
       file.close
 
-      expect(api_response).to receive(:body).exactly(3).times
-        .and_return(data_hash)
+      expect(api_response).to receive(:body)
+        .exactly(3).times.and_return(data_hash)
 
       parsed = described.adapt_v2_fetch_documents_for(api_response)
 


### PR DESCRIPTION
### Description
Improves handling of blank API responses in the `JsonApiResponseAdapter`.

### Acceptance Criteria
- [ ] All specs passing

### Testing Plan
1. Run specs: `bundle exec rspec spec/services/json_api_response_adapter_spec.rb`