### PR TITLE
vbms return to reader directly on s3 miss enabled

### DIFF
--- a/app/controllers/api/v2/records_controller.rb
+++ b/app/controllers/api/v2/records_controller.rb
@@ -2,9 +2,16 @@ class Api::V2::RecordsController < Api::V2::ApplicationController
   before_action :validate_access
 
   def show
-    #Check before fetch if the file is saved in S3
+    result = if FeatureToggle.enabled?(:vbms_to_reader_on_s3_miss, user: current_user)
+               # return s3 cache miss directly from VBMS
+               # instead of saving to s3 first
+               record.api_fetch!
+             else
+               record.fetch!
+             end
+
     document_source_to_headers
-    result = record.fetch!
+
     return document_failed if record.failed?
 
     # Only cache if we're not returning an error
@@ -47,7 +54,6 @@ class Api::V2::RecordsController < Api::V2::ApplicationController
   end
 
   def document_source_to_headers
-    from_s3 ||= S3Service.exists? record.s3_filename
-    headers["X-Document-Source"] = !!from_s3 ? "S3" : "VBMS"
+    headers["X-Document-Source"] = @record.sourced || ""
   end
 end

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -5,6 +5,8 @@ class Record < ApplicationRecord
 
   belongs_to :manifest_source
 
+  attr_accessor :sourced
+
   validates :manifest_source, :version_id, :series_id, presence: true
 
   enum status: {
@@ -36,6 +38,10 @@ class Record < ApplicationRecord
 
   def fetch!
     fetcher.process
+  end
+
+  def api_fetch!
+    api_fetcher.process
   end
 
   # TODO: remove this method when implmenentation of VVA/VBMS service is changed towards v2 API
@@ -88,6 +94,10 @@ class Record < ApplicationRecord
 
   def fetcher
     @fetcher ||= RecordFetcher.new(record: self)
+  end
+
+  def api_fetcher
+    @api_fetcher ||= RecordApiFetcher.new(record: self)
   end
 
   # Since Windows has the maximum length for a path, we crop type_name if the filename is longer than set maximum (issue #371)

--- a/app/services/record_api_fetcher.rb
+++ b/app/services/record_api_fetcher.rb
@@ -1,24 +1,13 @@
-class RecordFetcher < RecordFetcherBase
+class RecordApiFetcher < RecordFetcherBase
 
   EXCEPTIONS = [VBMS::ClientError, VVA::ClientError].freeze
   SECONDS_TO_AUTO_UNLOCK = 90
 
   def process
-    s = Redis::Semaphore.new("record_#{record.id}".to_s,
-                             url: Rails.application.secrets.redis_url_cache,
-                             stale_client_timeout: 5,
-                             expiration: SECONDS_TO_AUTO_UNLOCK)
-    MetricsService.record("RecordFetcher Semaphore lock from VA manifest source name: #{record.manifest_source.name} for file_number #{record.file_number}",
-                          service: record.manifest_source.name.downcase.to_sym,
-                          name: "recordfetcher_semaphore_lock") do
-      s.lock(SECONDS_TO_AUTO_UNLOCK)
-    end
     content_from_s3 || content_from_va_service
   rescue *EXCEPTIONS => error
     Rails.logger.error("Caught #{error}")
     nil
-  ensure
-    s&.unlock
   end
 
   private
@@ -30,8 +19,9 @@ class RecordFetcher < RecordFetcherBase
                                     name: "v2_fetch_document_file") do
       record.service.v2_fetch_document_file(record)
     end
+
     content = image_converter(content)
-    content_store_to_s3(content)
+
     content
   end
 

--- a/app/services/record_fetcher_base.rb
+++ b/app/services/record_fetcher_base.rb
@@ -1,0 +1,40 @@
+class RecordFetcherBase
+  include ActiveModel::Model
+
+  attr_accessor :record
+
+  protected
+
+  def content_from_s3
+    record.update(sourced: "S3")
+    return false if BaseController.dependencies_faked_for_CEAPI?
+
+    @content_from_s3 ||= MetricsService.record("RecordFetcher fetch content from S3 filename: #{record.s3_filename} for file_number #{record.file_number}",
+                                               service: :s3,
+                                               name: "content_from_s3") do
+      S3Service.fetch_content(record.s3_filename)
+    end
+  end
+
+  def image_converter(content)
+    MetricsService.record("ImageConverterService for #{record.s3_filename}",
+                          service: :image_converter,
+                          name: "image_converter_service") do
+      ImageConverterService.new(image: content, record: record).process
+    end
+  end
+
+  def content_store_to_s3(content)
+    if BaseController.dependencies_faked_for_CEAPI?
+      save_path = Rails.root.join('tmp', 'temp_pdf.pdf')
+      IO.binwrite(save_path, content)
+    else
+      MetricsService.record("RecordFetcher S3 store content for #{record.s3_filename}",
+                            service: :s3,
+                            name: "content_from_va_service") do
+        S3Service.store_file(record.s3_filename, content)
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Resolves APPEALS-46702

### Description
When Reader make an API call to eFolder to retrieve a document and document not found in the s3 cache, the eFolder will return the document directly from VBMS instead of first trying to store to s3. There is already another process that will store the document to s3

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to ...

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)

### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 ---|---

### Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.

### Database Changes
*Only for Schema Changes*

* [ ] Timestamps (created_at, updated_at) for new tables
* [ ] Column comments updated
* [ ] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [ ] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [ ] Appropriate indexes added (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)
* [ ] Add your indexes safely (see [Caseflow::Migrations](https://github.com/department-of-veterans-affairs/caseflow/blob/master/lib/caseflow/migration.rb)
* [ ] DB schema docs updated with `make docs` (after running `make migrate`)
* [ ] #appeals-schema notified with summary and link to this PR
* [ ] Any non-obvious semantics or logic useful for interpreting database data is documented at [Caseflow Data Model and Dictionary](https://github.com/department-of-veterans-affairs/caseflow/wiki/Caseflow-Data-Model-and-Dictionary)

### Integrations: Adding endpoints for external APIs
* [ ] Check that Caseflow's external API code for the endpoint matches the code in the relevant integration repo
  * [ ] Request: Service name, method name, input field names
  * [ ] Response: Check expected data structure
* [ ] Update Fakes
* [ ] Integrations impacting functionality are tested in Caseflow UAT
