### PR TITLE
APPEALS-53151: Update ECR workflow to utilize OIDC flow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       options: --privileged # Necessary for Rspec to run with our configuration within GHA. Needed for rspec step to prevent chromedriver issue
       credentials:
           username: AWS
-          password: ${{ secrets.ECR_PASSWORD }}
+          password: ${{ secrets.VAEC_ECR_PASSWORD }}
       env:
         DBUS_SESSION_BUS_ADDRESS: /dev/null
         RAILS_ENV: test

--- a/.github/workflows/ecr-login.yml
+++ b/.github/workflows/ecr-login.yml
@@ -1,32 +1,50 @@
-name: ECR Token Cron Job
+name: ECR Login Token Refresh
 on:
+  workflow_dispatch:
+  # Every 6 hours, the password validity is 12 hours
   schedule:
     - cron:  '0 */6 * * *'
+
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   login:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Configure AWS Credentials
+        id: acquire-credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-gov-west-1
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          output-credentials: true
+
       - name: retrieve ecr password and store as secret
+        if: steps.acquire-credentials.outcome == 'success'
         run: |
           pip3 install -r .github/workflows/requirements.txt
           python3 .github/workflows/ecr_password_updater.py
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ steps.acquire-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.acquire-credentials.outputs.aws-secret-access-key }}
           AWS_DEFAULT_REGION: us-gov-west-1
           GH_API_ACCESS_TOKEN: ${{ secrets.GH_API_ACCESS_TOKEN }}
-  # This 'test' job is usefull for fast debugging
+
+  # This 'test' job is useful for fast debugging
   test:
     needs: login
-    timeout-minutes: 1
     runs-on: ubuntu-latest
+    timeout-minutes: 1
     container:
-      image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/cimg-ruby:2.7.3-browsers
+      image: 065403089830.dkr.ecr.us-gov-west-1.amazonaws.com/gaimg-ruby:2.7.3-ga-browsers
       credentials:
         username: AWS
         # Here is the password retrieved as a secret that is set by the `login` job
-        password: ${{ secrets.ECR_PASSWORD }}
+        password: ${{ secrets.VAEC_ECR_PASSWORD }}
     steps:
       - run: echo "Inside a container pulled from ECR!!"

--- a/.github/workflows/ecr_password_updater.py
+++ b/.github/workflows/ecr_password_updater.py
@@ -15,7 +15,7 @@ def encrypt(raw_public_key: str, secret_value: str) -> str:
     return b64encode(encrypted).decode("utf-8")
 
 
-def get_ecr_password() -> str:
+def get_VAEC_ECR_PASSWORD() -> str:
     """Retrieve ECR password, it comes b64 encoded, in the format user:password
        From https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecr.html#ECR.Client.get_authorization_token
     """
@@ -39,9 +39,9 @@ if __name__ == '__main__':
     public_key_value = get_public_key_response['key']
     public_key_id = get_public_key_response['key_id']
 
-    password = get_ecr_password()
+    password = get_VAEC_ECR_PASSWORD()
     encrypted_password = encrypt(public_key_value, password)
-    update_password = requests.put('https://api.github.com/repos/department-of-veterans-affairs/caseflow-efolder/actions/secrets/ECR_PASSWORD',
+    update_password = requests.put('https://api.github.com/repos/department-of-veterans-affairs/caseflow-efolder/actions/secrets/VAEC_ECR_PASSWORD',
                                    headers={'Accept': 'application/vnd.github.v3+json',
                                             'Authorization': 'token ' + os.environ['GH_API_ACCESS_TOKEN']},
                                    data=json.dumps({'encrypted_value': encrypted_password, 'key_id': public_key_id,


### PR DESCRIPTION
Resolves [APPEALS-53151](https://jira.devops.va.gov/browse/APPEALS-53151)

### Description
- Alters ECR Token Refresh workflow to instead utilize the OIDC flow in order to obtain temporary AWS credentials.
- Shifts all references to ECR images to instead utilize our VAEC account number.

Please see https://github.com/department-of-veterans-affairs/caseflow/pull/22348 to see these changes in action in that repository. Unfortunately, the version of the workflow in this repo didn't have the `workflow_dispatch` trigger and so it cannot be tested here until it is merged.