### PR TITLE
Gate VBMS Methods with Sensitivity Checks

### DIFF
--- a/spec/services/external_api/vbms_service_spec.rb
+++ b/spec/services/external_api/vbms_service_spec.rb
@@ -52,7 +52,6 @@ describe ExternalApi::VBMSService do
     before do
       allow(JsonApiResponseAdapter).to receive(:new).and_return(mock_json_adapter)
       FeatureToggle.enable!(:check_user_sensitivity)
-      allow(mock_sensitivity_checker).to receive(:sensitivity_levels_compatible?).and_return(true)
     end
 
     after { FeatureToggle.disable!(:check_user_sensitivity) }
@@ -120,7 +119,6 @@ describe ExternalApi::VBMSService do
     before do
       allow(JsonApiResponseAdapter).to receive(:new).and_return(mock_json_adapter)
       FeatureToggle.enable!(:check_user_sensitivity)
-      allow(mock_sensitivity_checker).to receive(:sensitivity_levels_compatible?).and_return(true)
     end
 
     after { FeatureToggle.disable!(:check_user_sensitivity) }

--- a/spec/services/external_api/vbms_service_spec.rb
+++ b/spec/services/external_api/vbms_service_spec.rb
@@ -3,12 +3,59 @@
 describe ExternalApi::VBMSService do
   subject(:described) { described_class }
 
+  let(:mock_sensitivity_checker) { instance_double(SensitivityChecker, sensitivity_levels_compatible?: true) }
+
+  before do
+    allow(SensitivityChecker).to receive(:new).and_return(mock_sensitivity_checker)
+  end
+
+  describe ".verify_user_veteran_access" do
+    context "with check_user_sensitivity feature flag enabled" do
+      before { FeatureToggle.enable!(:check_user_sensitivity) }
+      after { FeatureToggle.disable!(:check_user_sensitivity) }
+
+      let!(:user) do
+        user = User.create(css_id: "VSO", station_id: "283", participant_id: "1234")
+        RequestStore.store[:current_user] = user
+      end
+
+      it "checks the user's sensitivity" do
+        expect(mock_sensitivity_checker).to receive(:sensitivity_levels_compatible?)
+          .with(user: user, veteran_file_number: "123456789").and_return(true)
+
+        described.verify_user_veteran_access("123456789")
+      end
+
+      it "raises an exception when the sensitivity level is not compatible" do
+        expect(mock_sensitivity_checker).to receive(:sensitivity_levels_compatible?)
+          .with(user: user, veteran_file_number: "123456789").and_return(false)
+
+        expect { described.verify_user_veteran_access("123456789") }
+          .to raise_error(RuntimeError, "User does not have permission to access this information")
+      end
+    end
+
+    context "with check_user_sensitivity feature flag disabled" do
+      before { FeatureToggle.disable!(:check_user_sensitivity) }
+
+      it "does not check the user's sensitivity" do
+        expect(mock_sensitivity_checker).not_to receive(:sensitivity_levels_compatible?)
+
+        described.verify_user_veteran_access("123456789")
+      end
+    end
+  end
+
   describe ".v2_fetch_documents_for" do
     let(:mock_json_adapter) { instance_double(JsonApiResponseAdapter) }
 
     before do
       allow(JsonApiResponseAdapter).to receive(:new).and_return(mock_json_adapter)
+      FeatureToggle.enable!(:check_user_sensitivity)
+      allow(mock_sensitivity_checker).to receive(:sensitivity_levels_compatible?).and_return(true)
     end
+
+    after { FeatureToggle.disable!(:check_user_sensitivity) }
 
     context "with use_ce_api feature toggle enabled" do
       before { FeatureToggle.enable!(:use_ce_api) }
@@ -33,6 +80,7 @@ describe ExternalApi::VBMSService do
       it "calls the PagedDocuments SOAP API endpoint" do
         veteran_id = "123456789"
 
+        expect(FeatureToggle).to receive(:enabled?).with(:check_user_sensitivity).and_return(false)
         expect(FeatureToggle).to receive(:enabled?).with(:use_ce_api).and_return(false)
         expect(FeatureToggle).to receive(:enabled?).with(:vbms_pagination, user: user).and_return(true)
         expect(described_class).to receive(:vbms_client)
@@ -53,6 +101,7 @@ describe ExternalApi::VBMSService do
       it "calls the FindDocumentVersionReference SOAP API endpoint" do
         veteran_id = "123456789"
 
+        expect(FeatureToggle).to receive(:enabled?).with(:check_user_sensitivity).and_return(false)
         expect(FeatureToggle).to receive(:enabled?).with(:use_ce_api).and_return(false)
         expect(FeatureToggle).to receive(:enabled?).with(:vbms_pagination, user: user).and_return(false)
         expect(VBMS::Requests::FindDocumentVersionReference).to receive(:new)
@@ -70,7 +119,11 @@ describe ExternalApi::VBMSService do
 
     before do
       allow(JsonApiResponseAdapter).to receive(:new).and_return(mock_json_adapter)
+      FeatureToggle.enable!(:check_user_sensitivity)
+      allow(mock_sensitivity_checker).to receive(:sensitivity_levels_compatible?).and_return(true)
     end
+
+    after { FeatureToggle.disable!(:check_user_sensitivity) }
 
     context "with use_ce_api feature toggle enabled" do
       before { FeatureToggle.enable!(:use_ce_api) }
@@ -94,8 +147,17 @@ describe ExternalApi::VBMSService do
 
   describe ".v2_fetch_document_file" do
     context "with use_ce_api feature toggle enabled" do
-      before { FeatureToggle.enable!(:use_ce_api) }
-      after { FeatureToggle.disable!(:use_ce_api) }
+      before do
+        FeatureToggle.enable!(:use_ce_api)
+        FeatureToggle.disable!(:check_user_sensitivity)
+      end
+
+      after do
+        FeatureToggle.disable!(:use_ce_api)
+      end
+
+      let(:manifest) { Manifest.create(file_number: "1234") }
+      let(:source) { ManifestSource.create(name: %w[VBMS VVA].sample, manifest: manifest) }
 
       let(:fake_record) do
         Record.create(
@@ -103,7 +165,8 @@ describe ExternalApi::VBMSService do
           series_id: "{4444-4444}",
           received_at: Time.utc(2015, 9, 6, 1, 0, 0),
           type_id: "825",
-          mime_type: "application/pdf"
+          mime_type: "application/pdf",
+          manifest_source: source
         )
       end
 


### PR DESCRIPTION
Resolves [APPEALS-47113](https://jira.devops.va.gov/browse/APPEALS-47113)

### Description
Validate user access to veteran before allowing fetch of veteran data.

Covers the following methods:
- FindDocumentVersionReferenceByDateRange
- FindDocumentVersionReference
- PagedDocuments
- GetDocumentContent

### Acceptance Criteria
- [ ] All specs passing

### Testing Plan
1. Enable feature toggle in the Rails console: `FeatureToggle.enable!(:check_user_sensitivity)`
2. In the Efolder UI, type a veteran file number and click "Search".
3. You should receive a banner stating that you need additional permissions to view this information.