### PR TITLE
Remove Unneeded Sensitivity Checks

### DIFF
--- a/app/controllers/api/v2/manifests_controller.rb
+++ b/app/controllers/api/v2/manifests_controller.rb
@@ -6,8 +6,6 @@ class Api::V2::ManifestsController < Api::V2::ApplicationController
     manifest = Manifest.includes(:sources, :records).find_or_create_by_user(user: current_user, file_number: file_number)
     manifest.start!
     render json: json_manifests(manifest)
-  rescue BGS::SensitivityLevelCheckFailure => e
-    sensitivity_check_failure_response
   end
 
   def refresh
@@ -17,8 +15,6 @@ class Api::V2::ManifestsController < Api::V2::ApplicationController
 
     manifest.start!
     render json: json_manifests(manifest)
-  rescue BGS::SensitivityLevelCheckFailure => e
-    sensitivity_check_failure_response
   end
 
   def progress
@@ -27,6 +23,7 @@ class Api::V2::ManifestsController < Api::V2::ApplicationController
       files_download ||= FilesDownload.find_with_manifest(manifest_id: params[:id], user_id: current_user.id)
     end
     return record_not_found unless files_download
+
     render json: json_manifests(files_download.manifest)
   end
 
@@ -35,10 +32,6 @@ class Api::V2::ManifestsController < Api::V2::ApplicationController
   end
 
   private
-
-  def sensitivity_check_failure_response
-    render json: { statusText: "This user does not have permission to access this information" }, status: :forbidden
-  end
 
   def json_manifests(manifest)
     ActiveModelSerializers::SerializableResource.new(

--- a/app/exceptions/bgs_errors.rb
+++ b/app/exceptions/bgs_errors.rb
@@ -5,5 +5,4 @@ module BGS
   class NoActiveStations < StandardError; end
   class NoCaseflowAccess < StandardError; end
   class StationAssertionRequired < StandardError; end
-  class SensitivityLevelCheckFailure < StandardError; end
 end

--- a/app/models/manifest_source.rb
+++ b/app/models/manifest_source.rb
@@ -19,6 +19,7 @@ class ManifestSource < ApplicationRecord
 
   def start!
     return if current? || processing?
+
     V2::DownloadManifestJob.perform_later(self, RequestStore[:current_user])
   rescue StandardError
     update(status: :initialized)

--- a/client/src/components/AlertBanner.jsx
+++ b/client/src/components/AlertBanner.jsx
@@ -25,7 +25,7 @@ export default class AlertBanner extends React.PureComponent {
       break;
     }
 
-    return <div className={`usa-alert ${alertTypeClass}`} role="alert" {...css(this.props.style)}>
+    return <div className={`usa-alert ${alertTypeClass}`} role="alert" style={this.props.inlineStyles}>
       <div className="usa-alert-body">
         <h2 className="usa-alert-heading">{this.props.title}</h2>
         <div className="usa-alert-text" {...reduceDoubleTopMargin}>{this.props.children}</div>

--- a/client/src/containers/WelcomeContainer.jsx
+++ b/client/src/containers/WelcomeContainer.jsx
@@ -24,7 +24,7 @@ const searchBarNoteTextStyling = css({
   textAlign: 'center'
 });
 
-const unauthorizedMessageStyling = {
+const alertBannerStyling = {
   marginTop: '0px',
   marginBottom: '30px'
 };
@@ -54,7 +54,7 @@ class WelcomeContainer extends React.PureComponent {
         <AlertBanner
           title="We could not complete the search for this Veteran ID"
           alertType="error"
-          style={{ marginTop: '0px !important', marginBottom: '30px' }}
+          inlineStyles={alertBannerStyling}
         >
           <p>{this.props.errorMessage.message}</p>
         </AlertBanner>
@@ -64,7 +64,7 @@ class WelcomeContainer extends React.PureComponent {
         <AlertBanner
           title="Additional access needed to search for this veteran ID"
           alertType="warning"
-          inlineStyles={unauthorizedMessageStyling}
+          inlineStyles={alertBannerStyling}
         >
           <p>
             Please try searching for another veteran or&nbsp;

--- a/client/src/containers/WelcomeContainer.jsx
+++ b/client/src/containers/WelcomeContainer.jsx
@@ -24,6 +24,11 @@ const searchBarNoteTextStyling = css({
   textAlign: 'center'
 });
 
+const unauthorizedMessageStyling = {
+  marginTop: '0px',
+  marginBottom: '30px'
+};
+
 class WelcomeContainer extends React.PureComponent {
   componentDidMount() {
     this.props.setShowUnauthorizedVeteranMessage(false);
@@ -59,7 +64,7 @@ class WelcomeContainer extends React.PureComponent {
         <AlertBanner
           title="Additional access needed to search for this veteran ID"
           alertType="warning"
-          style={{ marginTop: '0px !important', marginBottom: '30px' }}
+          inlineStyles={unauthorizedMessageStyling}
         >
           <p>
             Please try searching for another veteran or&nbsp;

--- a/spec/models/manifest_spec.rb
+++ b/spec/models/manifest_spec.rb
@@ -1,83 +1,38 @@
 describe Manifest do
-  describe "#start!" do
-    let(:user) { User.create(css_id: "Foo", station_id: "112") }
-    let(:manifest) { Manifest.create(file_number: "1234", user: user) }
+  context "#start!" do
+    before do
+      Timecop.freeze(Time.utc(2015, 12, 2, 17, 0, 0))
+      allow(V2::DownloadManifestJob).to receive(:perform_later)
+    end
+
+    let(:manifest) { Manifest.create(file_number: "1234") }
 
     subject { manifest.start! }
 
-    context "without sensitivity level check" do
-      before do
-        Timecop.freeze(Time.utc(2015, 12, 2, 17, 0, 0))
-        allow(V2::DownloadManifestJob).to receive(:perform_later)
-        expect(FeatureToggle).to receive(:enabled?).with(:check_user_sensitivity).and_return(false)
-        expect(FeatureToggle).to receive(:enabled?).with(:skip_vva).and_return(false)
-      end
-
-      context "when never fetched" do
-        it "starts all jobs" do
-          expect(manifest.sources.size).to eq 0
-          subject
-          expect(manifest.sources.size).to eq 2
-          expect(V2::DownloadManifestJob).to have_received(:perform_later).twice
-        end
-      end
-
-      context "when all manifests are current" do
-        it "does not start any jobs" do
-          manifest.sources.create(name: "VVA", status: :success, fetched_at: 2.hours.ago)
-          manifest.sources.create(name: "VBMS", status: :success, fetched_at: 2.hours.ago)
-          subject
-          expect(V2::DownloadManifestJob).to_not have_received(:perform_later)
-        end
-      end
-
-      context "when one manifest is expired" do
-        it "starts one job" do
-          manifest.sources.create(name: "VVA", status: :success, fetched_at: 2.hours.ago)
-          manifest.sources.create(name: "VBMS", status: :success, fetched_at: 5.hours.ago)
-          subject
-          expect(V2::DownloadManifestJob).to have_received(:perform_later).once
-        end
+    context "when never fetched" do
+      it "starts all jobs" do
+        expect(manifest.sources.size).to eq 0
+        subject
+        expect(manifest.sources.size).to eq 2
+        expect(V2::DownloadManifestJob).to have_received(:perform_later).twice
       end
     end
 
-    context "with sensitivity level check" do
-      let(:mock_sensitivity_checker) { instance_double(SensitivityChecker) }
-
-      before do
-        allow(SensitivityChecker).to receive(:new).and_return(mock_sensitivity_checker)
+    context "when all manifests are current" do
+      it "does not start any jobs" do
+        manifest.sources.create(name: "VVA", status: :success, fetched_at: 2.hours.ago)
+        manifest.sources.create(name: "VBMS", status: :success, fetched_at: 2.hours.ago)
+        subject
+        expect(V2::DownloadManifestJob).to_not have_received(:perform_later)
       end
+    end
 
-      context "when check_user_sensitivity feature toggle is enabled" do
-        before { FeatureToggle.enable!(:check_user_sensitivity) }
-        after { FeatureToggle.disable!(:check_user_sensitivity) }
-
-        it "enqueues a job if the sensitivity check passes" do
-          expect(mock_sensitivity_checker).to receive(:sensitivity_levels_compatible?)
-            .with(user: user, veteran_file_number: "1234").and_return(true)
-          expect(V2::DownloadManifestJob).to receive(:perform_later).twice
-
-          subject
-        end
-
-        it "raises an exception if the sensitivity check fails" do
-          expect(mock_sensitivity_checker).to receive(:sensitivity_levels_compatible?)
-            .with(user: user, veteran_file_number: "1234").and_return(false)
-          expect(V2::DownloadManifestJob).to_not receive(:perform_later)
-
-          expect { subject }.to raise_error(BGS::SensitivityLevelCheckFailure)
-        end
-      end
-
-      context "when check_user_sensitivity feature toggle is disabled" do
-        before { FeatureToggle.disable!(:check_user_sensitivity) }
-
-        it "enqueues a job to fetch the manifest" do
-          expect(mock_sensitivity_checker).to_not receive(:sensitivity_levels_compatible?)
-          expect(V2::DownloadManifestJob).to receive(:perform_later).twice
-
-          subject
-        end
+    context "when one manifest is expired" do
+      it "starts one job" do
+        manifest.sources.create(name: "VVA", status: :success, fetched_at: 2.hours.ago)
+        manifest.sources.create(name: "VBMS", status: :success, fetched_at: 5.hours.ago)
+        subject
+        expect(V2::DownloadManifestJob).to have_received(:perform_later).once
       end
     end
   end


### PR DESCRIPTION
Resolves [APPEALS-47113](https://jira.devops.va.gov/browse/APPEALS-47113)

### Description
Remove checks as they are already handled by the sensitive_record method.

### Acceptance Criteria
- [ ] All specs passing

### Testing Plan
1. Enable feature toggle in the Rails console: `FeatureToggle.enable!(:check_user_sensitivity)`
2. In the Efolder UI, type a veteran file number and click "Search".
3. You should receive a banner stating that you need additional permissions to view this information.