### PR TITLE
Update PG, rubocop gems, remove therubyracer (#1668)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
-  TargetRubyVersion: 2.3
-  TargetRailsVersion: 4.2
+  TargetRubyVersion: 2.5
+  TargetRailsVersion: 5.1
   Include:
     - '**/config.ru'
     - '**/Rakefile'
@@ -11,28 +11,6 @@ AllCops:
     - 'config/**/*'
     - 'script/**/*'
     - 'vendor/**/*'
-
-Rails/Output:
-  Exclude:
-    - 'lib/**/*.rb'
-
-Rails/SkipsModelValidations:
-  Enabled: false
-
-Rails/FilePath:
-  Enabled: false
-
-Rails/HasManyOrHasOneDependent:
-  Enabled: false
-
-Rails/UnknownEnv:
-  Enabled: false
-
-Rails/OutputSafety:
-  Enabled: false
-
-Rails/InverseOf:
-  Enabled: false
 
 Style/GuardClause:
   Enabled: false
@@ -52,7 +30,7 @@ Style/Documentation:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 200
 
 Metrics/BlockLength:
@@ -70,9 +48,6 @@ Metrics/AbcSize:
 Style/DoubleNegation:
   Enabled: false
 
-Rails:
-  Enabled: true
-
 Style/NegatedIf:
   Enabled: false
 
@@ -80,9 +55,6 @@ Naming/FileName:
   Enabled: false
 
 Naming/HeredocDelimiterNaming:
-  Enabled: false
-
-Rails/DynamicFindBy:
   Enabled: false
 
 Style/TrailingCommaInArrayLiteral:

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem "newrelic_rpm"
 gem "nokogiri", ">=1.10.5"
 gem "omniauth-saml-va", git: "https://github.com/department-of-veterans-affairs/omniauth-saml-va", branch: "pek-iam-ssoi"
 #gem "omniauth-saml-va", git: "https://github.com/department-of-veterans-affairs/omniauth-saml-va", ref: "fbe2b878c250b14ee996ef6699c42df2c42e41a1"
-gem "pg", "~> 0.18", platforms: :ruby
+gem "pg", "~> 1.5.7", platforms: :ruby
 gem "puma", "5.6.4"
 gem "rack-cors", ">= 1.0.4"
 gem "rails", "6.0.6.1"
@@ -42,7 +42,6 @@ gem "ruby_claim_evidence_api", git: "https://github.com/department-of-veterans-a
 gem "sass-rails", "~> 5.0"
 gem "sentry-raven"
 gem "shoryuken", "3.1.11"
-gem "therubyracer", platforms: :ruby
 gem "turbolinks"
 gem "uglifier", ">= 1.3.0"
 gem "uswds-rails", git: "https://github.com/18F/uswds-rails-gem.git"
@@ -60,7 +59,7 @@ group :development, :test do
   gem "dotenv-rails"
   gem "pry"
   gem "pry-byebug"
-  gem "rubocop", "~> 0.67.2", require: false
+  gem "rubocop", "= 0.83", require: false
   gem "scss_lint", require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
     akami (1.3.1)
       gyoku (>= 0.4.0)
       nokogiri
-    ast (2.4.1)
+    ast (2.4.2)
     aws-eventstream (1.1.0)
     aws-partitions (1.942.0)
     aws-sdk-core (3.131.0)
@@ -271,7 +271,6 @@ GEM
       socksify
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
-    jaro_winkler (1.5.4)
     jbuilder (2.10.1)
       activesupport (>= 5.0.0)
     jmespath (1.4.0)
@@ -282,7 +281,6 @@ GEM
     jsonapi-renderer (0.2.2)
     launchy (2.5.0)
       addressable (~> 2.7)
-    libv8 (3.16.14.19)
     listen (3.4.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -343,10 +341,11 @@ GEM
     omniauth-saml (1.10.3)
       omniauth (~> 1.3, >= 1.3.2)
       ruby-saml (~> 1.9)
-    parallel (1.20.1)
-    parser (3.0.0.0)
+    parallel (1.26.2)
+    parser (3.3.4.2)
       ast (~> 2.4.1)
-    pg (0.21.0)
+      racc
+    pg (1.5.7)
     pkcs11 (0.3.3)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -354,7 +353,6 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
-    psych (3.3.0)
     public_suffix (5.1.1)
     puma (5.6.4)
       nio4r (~> 2.0)
@@ -422,7 +420,6 @@ GEM
       redis
     redis-store (1.9.0)
       redis (>= 4, < 5)
-    ref (2.0.0)
     regexp_parser (2.8.3)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -453,15 +450,14 @@ GEM
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
     rspec-support (3.10.1)
-    rubocop (0.67.2)
-      jaro_winkler (~> 1.5.1)
+    rubocop (0.83.0)
       parallel (~> 1.10)
-      parser (>= 2.5, != 2.5.1.1)
-      psych (>= 3.1.0)
+      parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
+      rexml
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.6)
-    ruby-progressbar (1.11.0)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    ruby-progressbar (1.13.0)
     ruby-saml (1.12.2)
       nokogiri (>= 1.10.5)
       rexml
@@ -521,9 +517,6 @@ GEM
     statsd-instrument (3.7.0)
     strscan (3.1.0)
     systemu (2.6.5)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.11)
@@ -538,7 +531,7 @@ GEM
       tzinfo (>= 1.0.0)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.5.0)
+    unicode-display_width (1.8.0)
     uuid (2.3.9)
       macaddr (~> 1.0)
     wannabe_bool (0.7.1)
@@ -611,7 +604,7 @@ DEPENDENCIES
   newrelic_rpm
   nokogiri (>= 1.10.5)
   omniauth-saml-va!
-  pg (~> 0.18)
+  pg (~> 1.5.7)
   pry
   pry-byebug
   puma (= 5.6.4)
@@ -627,7 +620,7 @@ DEPENDENCIES
   rspec-github
   rspec-rails
   rspec-retry
-  rubocop (~> 0.67.2)
+  rubocop (= 0.83)
   ruby_claim_evidence_api!
   rubyzip (>= 1.3.0)
   saml_idp!
@@ -640,7 +633,6 @@ DEPENDENCIES
   single_cov
   sniffybara!
   statsd-instrument
-  therubyracer
   timecop
   turbolinks
   tzinfo-data
@@ -653,4 +645,4 @@ DEPENDENCIES
   zero_downtime_migrations
 
 BUNDLED WITH
-   2.4.19
+   2.4.22

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,6 @@
 require File.expand_path("config/application", __dir__)
 
 # Load rake support files
-Dir[Rails.root.join("lib/tasks/support/**/*.rb")].each { |f| require f }
+Dir[Rails.root.join("lib/tasks/support/**/*.rb")].sort.each { |f| require f }
 
 Rails.application.load_tasks


### PR DESCRIPTION
Resolves [APPEALS-54874](https://jira.devops.va.gov/browse/APPEALS-54874), [APPEALS-54878](https://jira.devops.va.gov/browse/APPEALS-54878)

### Description
- Update PG gem to minimum version 1.5.7
- Update rubocop to version 0.83 to resolve a dependency issue
- Remove therubyracer gem

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Verify that automated test suite is passing