### PR TITLE
Fix Missing Manifest User Causing Sensitivity Check Failures

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -13,6 +13,15 @@ class Api::V1::ApplicationController < BaseController
     }, status: 500
   end
 
+  rescue_from BGS::SensitivityLevelCheckFailure do |e|
+    render json: {
+      status: e.message,
+      featureToggles: {
+        checkUserSensitivity: FeatureToggle.enabled?(:check_user_sensitivity)
+      }
+    }, status: :forbidden
+  end
+
   rescue_from BGS::PublicError do |error|
     forbidden(error.public_message)
   end

--- a/app/controllers/api/v2/manifests_controller.rb
+++ b/app/controllers/api/v2/manifests_controller.rb
@@ -2,18 +2,18 @@
 
 class Api::V2::ManifestsController < Api::V2::ApplicationController
   # Need this as a before action since it gates access to these controller methods
-  before_action :file_number, only: [:start, :refresh]
+  before_action :veteran_file_number, only: [:start, :refresh]
 
   def start
     return if performed?
 
-    manifest = Manifest.includes(:sources, :records).find_or_create_by_user(user: current_user, file_number: file_number)
+    manifest = Manifest.includes(:sources, :records).find_or_create_by_user(user: current_user, file_number: veteran_file_number)
     manifest.start!
     render json: json_manifests(manifest)
   end
 
   def refresh
-    manifest = Manifest.includes(:sources, :records).find_or_create_by_user(user: current_user, file_number: file_number)
+    manifest = Manifest.includes(:sources, :records).find_or_create_by_user(user: current_user, file_number: veteran_file_number)
 
     return record_not_found if manifest.blank?
     return sensitive_record unless manifest.files_downloads.find_by(user: current_user)
@@ -38,8 +38,8 @@ class Api::V2::ManifestsController < Api::V2::ApplicationController
 
   private
 
-  def file_number
-    @file_number ||= verify_veteran_file_number
+  def veteran_file_number
+    @veteran_file_number ||= verify_veteran_file_number
   end
 
   def json_manifests(manifest)

--- a/app/controllers/api/v2/manifests_controller.rb
+++ b/app/controllers/api/v2/manifests_controller.rb
@@ -1,24 +1,25 @@
+# frozen_string_literal: true
+
 class Api::V2::ManifestsController < Api::V2::ApplicationController
+  # Need this as a before action since it gates access to these controller methods
+  before_action :file_number, only: [:start, :refresh]
+
   def start
-    file_number = verify_veteran_file_number
     return if performed?
 
     manifest = Manifest.includes(:sources, :records).find_or_create_by_user(user: current_user, file_number: file_number)
     manifest.start!
     render json: json_manifests(manifest)
-  rescue BGS::SensitivityLevelCheckFailure
-    forbidden("This user does not have permission to access this information")
   end
 
   def refresh
-    manifest = Manifest.find(params[:id])
-    return record_not_found unless manifest
+    manifest = Manifest.includes(:sources, :records).find_or_create_by_user(user: current_user, file_number: file_number)
+
+    return record_not_found if manifest.blank?
     return sensitive_record unless manifest.files_downloads.find_by(user: current_user)
 
     manifest.start!
     render json: json_manifests(manifest)
-  rescue BGS::SensitivityLevelCheckFailure
-    forbidden("This user does not have permission to access this information")
   end
 
   def progress
@@ -36,6 +37,10 @@ class Api::V2::ManifestsController < Api::V2::ApplicationController
   end
 
   private
+
+  def file_number
+    @file_number ||= verify_veteran_file_number
+  end
 
   def json_manifests(manifest)
     ActiveModelSerializers::SerializableResource.new(

--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -1,6 +1,20 @@
+# frozen_string_literal: true
+
+require "bgs"
+require "bgs_errors"
+
 class BaseController < ActionController::Base
   before_action :strict_transport_security
   before_action :current_user
+
+  rescue_from BGS::SensitivityLevelCheckFailure do |e|
+    render json: {
+      status: e.message,
+      featureToggles: {
+        checkUserSensitivity: FeatureToggle.enabled?(:check_user_sensitivity)
+      }
+    }, status: :forbidden
+  end
 
   private
 

--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -7,15 +7,6 @@ class BaseController < ActionController::Base
   before_action :strict_transport_security
   before_action :current_user
 
-  rescue_from BGS::SensitivityLevelCheckFailure do |e|
-    render json: {
-      status: e.message,
-      featureToggles: {
-        checkUserSensitivity: FeatureToggle.enabled?(:check_user_sensitivity)
-      }
-    }, status: :forbidden
-  end
-
   private
 
   def strict_transport_security

--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -38,7 +38,7 @@ class Manifest < ApplicationRecord
       )
         vbms_source.start!
       else
-        raise BGS::SensitivityLevelCheckFailure.new, "Unauthorized"
+        raise BGS::SensitivityLevelCheckFailure.new, "You are not authorized to access this manifest"
       end
     else
       vbms_source.start!

--- a/app/services/sensitivity_checker.rb
+++ b/app/services/sensitivity_checker.rb
@@ -4,8 +4,8 @@ class SensitivityChecker
   def sensitivity_levels_compatible?(user:, veteran_file_number:)
     bgs_service.sensitivity_level_for_user(user) >=
       bgs_service.sensitivity_level_for_veteran(veteran_file_number)
-  rescue StandardError => error
-    ExceptionLogger.capture(error)
+  rescue StandardError => e
+    ExceptionLogger.capture(e)
 
     false
   end

--- a/spec/requests/api/v2/manifests_spec.rb
+++ b/spec/requests/api/v2/manifests_spec.rb
@@ -33,6 +33,64 @@ describe "Manifests API v2", type: :request do
     Timecop.freeze(Time.utc(2015, 1, 1, 17, 0, 0))
   end
 
+  context "With sensitivity check failures" do
+    let(:mock_sensitivity_checker) { instance_double(SensitivityChecker) }
+
+    before do
+      allow(SensitivityChecker).to receive(:new).and_return(mock_sensitivity_checker)
+
+      FeatureToggle.enable!(:check_user_sensitivity)
+      FeatureToggle.enable!(:skip_vva)
+    end
+
+    after do
+      FeatureToggle.disable!(:check_user_sensitivity)
+      FeatureToggle.disable!(:skip_vva)
+    end
+
+    context "when the check succeeds" do
+      it "allows access to the start action" do
+        expect(mock_sensitivity_checker).to receive(:sensitivity_levels_compatible?)
+          .with(user: user, veteran_file_number: "DEMO987").and_return(true)
+
+        post "/api/v2/manifests", params: nil, headers: headers
+
+        expect(response.code).to eq("200")
+      end
+
+      it "allows access to the refresh action" do
+        expect(mock_sensitivity_checker).to receive(:sensitivity_levels_compatible?)
+          .with(user: user, veteran_file_number: "DEMO987").and_return(true)
+
+        post "/api/v2/manifests/#{manifest.id}", params: nil, headers: headers
+
+        expect(response.code).to eq("200")
+      end
+    end
+
+    context "when the check fails" do
+      it "gates access to the start action" do
+        expect(mock_sensitivity_checker).to receive(:sensitivity_levels_compatible?)
+          .with(user: user, veteran_file_number: "DEMO987").and_return(false)
+
+        post "/api/v2/manifests", params: nil, headers: headers
+
+        expect(response.code).to eq("403")
+        expect(JSON.parse(response.body)["status"]).to eq("You are not authorized to access this manifest")
+      end
+
+      it "gates access to the refresh action" do
+        expect(mock_sensitivity_checker).to receive(:sensitivity_levels_compatible?)
+          .with(user: user, veteran_file_number: "DEMO987").and_return(false)
+
+        post "/api/v2/manifests/#{manifest.id}", params: nil, headers: headers
+
+        expect(response.code).to eq("403")
+        expect(JSON.parse(response.body)["status"]).to eq("You are not authorized to access this manifest")
+      end
+    end
+  end
+
   context "View download history" do
     let(:manifest1) { Manifest.find_or_create_by!(file_number: "123C") }
     let(:manifest2) { Manifest.find_or_create_by!(file_number: "567C") }


### PR DESCRIPTION
Resolves [eFolder>>View Result link on Recent Downloads throwing error page](https://jira.devops.va.gov/browse/APPEALS-57091).

### Description
For the `refresh` action in `app/controllers/api/v2/manifests_controller.rb`, the app was using `Manifest.find` to load the manifest. However, this would result in the `manifest` not having a `user` set and this was causing the new user sensitivity checks to fail.

This PR updates the `refresh` action in `app/controllers/api/v2/manifests_controller.rb` to use the `Manifest.find_or_create_by_user` method which will set `manifest.user` as part of its logic.

### Acceptance Criteria
- [ ] All specs passing

### Testing Plan
NOTE: UAT only

Follow repro steps in ticket and verify the issue is fixed.