### PR TITLE
Update Logic for Setting Veteran ID in Request

### DIFF
--- a/app/controllers/api/v2/manifests_controller.rb
+++ b/app/controllers/api/v2/manifests_controller.rb
@@ -42,6 +42,19 @@ class Api::V2::ManifestsController < Api::V2::ApplicationController
     @veteran_file_number ||= verify_veteran_file_number
   end
 
+  def verify_veteran_file_number
+    # The frontend may not have set this value (needed by parent's verify_veteran_file_number)
+    # but we are still able to determine it here in the child using the manifest
+    if request.headers["HTTP_FILE_NUMBER"].blank?
+      if params[:id].present?
+        manifest = Manifest.find(params[:id])
+        request.headers["HTTP_FILE_NUMBER"] = manifest.file_number
+      end
+    end
+
+    super
+  end
+
   def json_manifests(manifest)
     ActiveModelSerializers::SerializableResource.new(
       manifest,

--- a/client/src/apiActions.jsx
+++ b/client/src/apiActions.jsx
@@ -157,8 +157,8 @@ export const startDocumentDownload = (manifestId, csrfToken) => (dispatch) => {
     );
 };
 
-export const restartManifestFetch = (manifestId, veteranId, csrfToken) => (dispatch) => {
-  postRequest(`/api/v2/manifests/${manifestId}`, csrfToken, { 'FILE-NUMBER': veteranId }).
+export const restartManifestFetch = (manifestId, csrfToken) => (dispatch) => {
+  postRequest(`/api/v2/manifests/${manifestId}`, csrfToken).
     then(
       (resp) => setStateFromResponse(dispatch, resp),
       (err) => dispatch(setErrorMessage(buildErrorMessageFromResponse(err.response)))

--- a/client/src/containers/DownloadContainer.jsx
+++ b/client/src/containers/DownloadContainer.jsx
@@ -39,7 +39,7 @@ class DownloadContainer extends React.PureComponent {
       !manifestFetchComplete(this.props.documentSources) ||
       this.props.documentsFetchStatus === MANIFEST_DOWNLOAD_STATE.IN_PROGRESS
     ) {
-      this.props.restartManifestFetch(manifestId, this.props.veteranId, this.props.csrfToken);
+      this.props.restartManifestFetch(manifestId, this.props.csrfToken);
       this.props.pollManifestFetchEndpoint(0, manifestId, this.props.csrfToken);
     }
   }

--- a/spec/requests/api/v2/manifests_spec.rb
+++ b/spec/requests/api/v2/manifests_spec.rb
@@ -50,7 +50,7 @@ describe "Manifests API v2", type: :request do
 
     context "when the check succeeds" do
       it "allows access to the start action" do
-        expect(mock_sensitivity_checker).to receive(:sensitivity_levels_compatible?).twice
+        expect(mock_sensitivity_checker).to receive(:sensitivity_levels_compatible?).exactly(3).times
           .with(user: user, veteran_file_number: "DEMO987").and_return(true)
 
         post "/api/v2/manifests", params: nil, headers: headers
@@ -59,7 +59,7 @@ describe "Manifests API v2", type: :request do
       end
 
       it "allows access to the refresh action" do
-        expect(mock_sensitivity_checker).to receive(:sensitivity_levels_compatible?).twice
+        expect(mock_sensitivity_checker).to receive(:sensitivity_levels_compatible?).exactly(3).times
           .with(user: user, veteran_file_number: "DEMO987").and_return(true)
 
         post "/api/v2/manifests/#{manifest.id}", params: nil, headers: headers


### PR DESCRIPTION
Resolves [eFolder>>View Result link on Recent Downloads throwing error page](https://jira.devops.va.gov/browse/APPEALS-57091).

### Description
- Remove recently-added frontend logic for setting veteran ID in refresh request as it is unreliable in the way it sets the veteran ID.

- Update manifests_controller to set the veteran ID using the manifest as this is much more reliable.

### Acceptance Criteria
- [ ] All specs passing

### Testing Plan
See Jira ticket.
