### PR TITLE
Update JSON Parsing Logic to Handle CE API Gem Changes

### DIFF
--- a/app/services/json_api_response_adapter.rb
+++ b/app/services/json_api_response_adapter.rb
@@ -4,11 +4,12 @@
 # by most of caseflow-efolder
 class JsonApiResponseAdapter
   def adapt_v2_fetch_documents_for(json_response)
+    json_response = normalize_json_response(json_response)
+
+    return nil unless valid_file_response?(json_response)
+
     documents = []
-
-    return documents unless valid_json_response?(json_response)
-
-    json_response.body["files"].each do |file_resp|
+    json_response["files"].each do |file_resp|
       documents.push(v2_fetch_documents_file_response(file_resp))
     end
 
@@ -17,10 +18,18 @@ class JsonApiResponseAdapter
 
   private
 
-  def valid_json_response?(json_response)
-    return false if json_response&.body.blank?
+  def normalize_json_response(json_response)
+    if json_response.blank?
+      {}
+    elsif json_response.instance_of?(Hash)
+      json_response.with_indifferent_access
+    elsif json_response.instance_of?(String)
+      JSON.parse(json_response)
+    end
+  end
 
-    json_response.body.key?("files")
+  def valid_file_response?(json_response)
+    json_response.key?("files")
   end
 
   def v2_fetch_documents_file_response(file_json)

--- a/spec/services/json_api_response_adapter_spec.rb
+++ b/spec/services/json_api_response_adapter_spec.rb
@@ -5,28 +5,24 @@ require "json"
 describe JsonApiResponseAdapter do
   subject(:described) { described_class.new }
 
-  let(:api_response) { instance_double(ExternalApi::Response) }
-
   describe "#adapt_v2_fetch_documents_for" do
     context "with invalid responses" do
       it "handles blank responses" do
         parsed = described.adapt_v2_fetch_documents_for(nil)
 
-        expect(parsed.length).to eq 0
+        expect(parsed).to be_nil
+      end
+
+      it "handles empty response bodies" do
+        parsed = described.adapt_v2_fetch_documents_for({})
+
+        expect(parsed).to be_nil
       end
 
       it "handles blank response bodies" do
-        response = instance_double(ExternalApi::Response, body: nil)
-        parsed = described.adapt_v2_fetch_documents_for(response)
+        parsed = described.adapt_v2_fetch_documents_for("")
 
-        expect(parsed.length).to eq 0
-      end
-
-      it "handles response bodies with no files" do
-        response = instance_double(ExternalApi::Response, body: {})
-        parsed = described.adapt_v2_fetch_documents_for(response)
-
-        expect(parsed.length).to eq 0
+        expect(parsed).to be_nil
       end
     end
 
@@ -35,10 +31,7 @@ describe JsonApiResponseAdapter do
       data_hash = JSON.parse(File.read(file))
       file.close
 
-      expect(api_response).to receive(:body)
-        .exactly(3).times.and_return(data_hash)
-
-      parsed = described.adapt_v2_fetch_documents_for(api_response)
+      parsed = described.adapt_v2_fetch_documents_for(data_hash)
 
       expect(parsed.length).to eq 2
 


### PR DESCRIPTION
Resolves [NoMethodError - undefined method `body' for Hash:0x00007f62dbafe908](https://jira.devops.va.gov/browse/APPEALS-57787)

### Description
- Gem now returns the JSON body of a HTTP response, so our response parsing code needed to be updated to handle the new format.

- Update the VBMS service to alert us of any API responses that can't be parsed so we can troubleshoot them.

### Acceptance Criteria
- [ ] All specs passing

### Testing Plan
1. Follow steps in ticket in UAT.
