### PR TITLE
Add current_user to SaveFilesInS3 Job

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ModuleLength
 module ApplicationHelper
   def ui_user?
     return false unless RequestStore[:current_user]
+
     (RequestStore[:current_user].roles || []).include?("Download eFolder")
   end
 
@@ -13,6 +13,7 @@ module ApplicationHelper
     begin
       route = Rails.application.routes.recognize_path(full_path)
       return full_path unless route
+
       ["", route[:controller], route[:action]].join("/")
 
     # no match in recognize_path
@@ -21,4 +22,3 @@ module ApplicationHelper
     end
   end
 end
-# rubocop:enable Metrics/ModuleLength

--- a/app/jobs/v2/download_manifest_job.rb
+++ b/app/jobs/v2/download_manifest_job.rb
@@ -4,18 +4,18 @@ class V2::DownloadManifestJob < ApplicationJob
   def perform(manifest_source, user = nil)
     manifest_source.update(status: :pending)
 
-    RequestStore.store[:current_user] = user if user
+    RequestStore.store[:current_user] = user if user.present?
     Raven.extra_context(manifest_source: manifest_source.id)
 
     documents = ManifestFetcher.new(manifest_source: manifest_source).process
 
     log_info(manifest_source.manifest.file_number, documents, manifest_source.manifest.zipfile_size)
 
-    V2::SaveFilesInS3Job.perform_later(manifest_source) if documents.present? && !ApplicationController.helpers.ui_user?
-  rescue StandardError => error
+    V2::SaveFilesInS3Job.perform_later(manifest_source, current_user&.id) if documents.present? && !ApplicationController.helpers.ui_user?
+  rescue StandardError => e
     manifest_source.update!(status: :failed)
-    Rails.logger.error "DownloadManifestJob encountered error #{error.class.name} when fetching manifest for appeal #{manifest_source.manifest.file_number}"
-    raise error
+    Rails.logger.error "DownloadManifestJob encountered error #{e.class.name} when fetching manifest for appeal #{manifest_source.manifest.file_number}"
+    raise e
   end
 
   def max_attempts

--- a/app/jobs/v2/save_files_in_s3_job.rb
+++ b/app/jobs/v2/save_files_in_s3_job.rb
@@ -1,8 +1,14 @@
 class V2::SaveFilesInS3Job < ApplicationJob
   queue_as :low_priority
 
-  def perform(manifest_source)
-    Raven.extra_context(manifest_source: manifest_source.id)
+  def perform(manifest_source, user_id)
+    Raven.extra_context(manifest_source: manifest_source.id, user_id: user_id)
+
+    # Set user for permission check if the user is blank
+    if FeatureToggle.enabled?(:check_user_sensitivity) && RequestStore[:current_user].blank?
+      user = User.find(user_id)
+      RequestStore.store[:current_user] = user
+    end
 
     manifest_source.records.each(&:fetch!)
   end

--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -77,7 +77,6 @@ class ExternalApi::VBMSService
 
     if FeatureToggle.enabled?(:use_ce_api)
       # Not using #send_and_log_request because logging to MetricService implemeneted in CE API gem
-      # Method call returns the response body, so no need to return response.content/body
       VeteranFileFetcher.get_document_content(doc_series_id: document.series_id)
     else
       request = VBMS::Requests::GetDocumentContent.new(document.document_id)


### PR DESCRIPTION
Resolves [NoMethodError: undefined method `css_id' for nil:NilClass](https://jira.devops.va.gov/browse/APPEALS-58178).

### Description
- Since the SaveFilesInS3 job is spawned by another job, it does not have access to RequestStore[:current_user] which is needed for verifying veteran/user sensitivity compatibility.

- This PR also fixes several Rubocop violations in various files.

### Acceptance Criteria
- [ ] All specs passing.

### Testing Plan
1. Go to eFolder UAT.
2. Search for a veteran.
3. Verify eFolder can be fetched and download.
4. Verify there are no errors in Sentry.