### PR TITLE
Fix Incorrect Keyword in Script

### DIFF
--- a/lib/scripts/find_valid_veteran_file_numbers.rb
+++ b/lib/scripts/find_valid_veteran_file_numbers.rb
@@ -27,7 +27,7 @@ class FindValidVeteranFileNumbers
         valid_file_numbers[key].push(file_number)
       rescue RuntimeError => e
         invalid_file_numbers.push(manifest.file_number)
-        continue
+        next
       end
     end
 


### PR DESCRIPTION
Resolves [Veteran IDs for UAT test scenarios](https://jira.devops.va.gov/browse/APPEALS-58216)

### Description
Fixes incorrect Ruby keyword in script.

### Acceptance Criteria
- [ ] All specs passing

### Testing Plan
1. Run the script via the Rails console:

```
s = FindValidVeteranFileNumbers.new
s.run
```