### PR TITLE
Kev ma/appeals 58827 v2

### DIFF
--- a/app/services/json_api_response_adapter.rb
+++ b/app/services/json_api_response_adapter.rb
@@ -3,6 +3,8 @@
 # Translates JSON API responses into a format that's compatible with the legacy SOAP responses expected
 # by most of caseflow-efolder
 class JsonApiResponseAdapter
+  include Caseflow::DocumentTypes
+
   def adapt_v2_fetch_documents_for(json_response)
     json_response = normalize_json_response(json_response)
 
@@ -45,7 +47,9 @@ class JsonApiResponseAdapter
       document_id: "{#{file_json['currentVersionUuid'].upcase}}",
       series_id: "{#{file_json['uuid'].upcase}}",
       version: "1",
-      type_description: provider_data["subject"],
+      # CE Api doesn't provide document category type desciption.
+      # Use Caseflow document type mapping instead, and if not found then "Unknown"
+      type_description: TYPES[provider_data["documentTypeId"]] || TYPES[10],
       type_id: provider_data["documentTypeId"],
       doc_type: provider_data["documentTypeId"],
       subject: provider_data["subject"],

--- a/spec/services/json_api_response_adapter_spec.rb
+++ b/spec/services/json_api_response_adapter_spec.rb
@@ -36,12 +36,24 @@ describe JsonApiResponseAdapter do
       expect(parsed.length).to eq 2
 
       expect(parsed[0].document_id).to eq "{03223945-468B-4E8A-B79B-82FA73C2D2D9}"
+      expect(parsed[0].type_description).to eq "Rating Decision - Codesheet"
       expect(parsed[0].received_at).to eq "2018/03/08"
       expect(parsed[0].mime_type).to eq "application/pdf"
 
       expect(parsed[1].document_id).to eq "{7D6AFD8C-3BF7-4224-93AE-E1F07AC43C71}"
+      expect(parsed[1].type_description).to eq "Rating Decision - Narrative"
       expect(parsed[1].received_at).to eq "2018/12/08"
       expect(parsed[1].mime_type).to eq "application/pdf"
+    end
+
+    it "returns type description 'Unknown' if mapping is not found in Caseflow" do
+      file = File.open(Rails.root.join("spec/support/api_responses/ce_api_folders_files_search_unknown.json"))
+      data_hash = JSON.parse(File.read(file))
+      file.close
+
+      parsed = described.adapt_v2_fetch_documents_for(data_hash)
+
+      expect(parsed[0].type_description).to eq "UNKNOWN"
     end
   end
 end

--- a/spec/support/api_responses/ce_api_folders_files_search_unknown.json
+++ b/spec/support/api_responses/ce_api_folders_files_search_unknown.json
@@ -1,0 +1,47 @@
+{
+  "page": {
+    "totalPages": 1,
+    "requestedResultsPerPage": 20,
+    "currentPage": 1,
+    "totalResults": 1
+  },
+  "files": [
+    {
+      "owner": {
+        "type": "VETERAN",
+        "id": "123456789"
+      },
+      "uuid": "23e7ae3b-5489-4fa9-b6e3-b1f953287138",
+      "currentVersionUuid": "03223945-468b-4e8a-b79b-82fa73c2d2d9",
+      "currentVersion": {
+        "systemData": {
+          "uploadedDateTime": "2018-03-08T14:21:40",
+          "contentName": "20180308091849 - codesheet.pdf",
+          "mimeType": "application/pdf",
+          "uploadSource": "RATING"
+        },
+        "providerData": {
+          "subject": "Rating Decision - Codesheet",
+          "documentTypeId": 999111,
+          "ocrStatus": "Failure to Process",
+          "newMail": false,
+          "bookmarks": {
+            "VBA": {
+              "isDefaultRealm": true
+            }
+          },
+          "systemSource": "RATING",
+          "isAnnotated": false,
+          "modifiedDateTime": "2018-03-08T14:21:40",
+          "numberOfContentions": 0,
+          "readByCurrentUser": false,
+          "dateVaReceivedDocument": "2018-03-08",
+          "hasContentionAnnotations": false,
+          "contentSource": "VBMS-R",
+          "actionable": false,
+          "lastOpenedDocument": false
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Resolves [https://jira.devops.va.gov/browse/APPEALS-58827](https://jira.devops.va.gov/browse/APPEALS-58827)

### Description
Updated JsonApiResponseAdapter.rb file to properly use VBMS document type description from Caseflow::DocumentTypes::TYPES mapping instead of "Subject"
Updated rspecs to cover changes to this Record field

### Acceptance Criteria
- [x] Code compiles correctly

### Testing Plan
1. See [https://jira.devops.va.gov/browse/APPEALS-58827](https://jira.devops.va.gov/browse/APPEALS-58827)
2. Login to Efolder with a user of sensitivity level 9 and search up 314159004
3. Document names shown in the first column should correlate to "Category - Type" in VBMS.
4. For files not mapped in Caseflow, we should see UNKNOWN

### Code Documentation Updates
- [x] Add or update code comments at the top of the class, module, and/or component.

