### PR TITLE
Deepak/appeals 65021

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -31,7 +31,7 @@ class Api::V1::ApplicationController < BaseController
     render json: {
       status: e.message,
       featureToggles: {
-        use_ce_api: FeatureToggle.enabled?(:use_ce_api)
+        use_ce_api: FeatureToggle.enabled?(:use_ce_api, user: RequestStore[:current_user])
       }
     }, status: :forbidden
   end

--- a/app/controllers/api/v2/application_controller.rb
+++ b/app/controllers/api/v2/application_controller.rb
@@ -23,7 +23,7 @@ class Api::V2::ApplicationController < Api::V1::ApplicationController
 
     return invalid_file_number unless bgs_service.valid_file_number?(file_number)
 
-    if FeatureToggle.enabled?(:use_ce_api)
+    if FeatureToggle.enabled?(:use_ce_api, user: RequestStore[:current_user])
       if sensitivity_checker.sensitivity_levels_compatible?(
         user: current_user,
         veteran_file_number: file_number

--- a/app/controllers/api/v2/manifests_controller.rb
+++ b/app/controllers/api/v2/manifests_controller.rb
@@ -5,7 +5,7 @@ class Api::V2::ManifestsController < Api::V2::ApplicationController
   before_action :veteran_file_number, only: [:start, :refresh]
 
   def start
-    if FeatureToggle.enabled?(:use_ce_api)
+    if use_ce_api?
       return if performed?
 
       manifest = Manifest.includes(:sources, :records).find_or_create_by_user(user: current_user, file_number: veteran_file_number)
@@ -21,7 +21,7 @@ class Api::V2::ManifestsController < Api::V2::ApplicationController
   end
 
   def refresh
-    manifest = if FeatureToggle.enabled?(:use_ce_api) 
+    manifest = if use_ce_api? 
                  Manifest.includes(:sources, :records).find_or_create_by_user(user: current_user, file_number: veteran_file_number)
                else
                  Manifest.find(params[:id])
@@ -50,6 +50,10 @@ class Api::V2::ManifestsController < Api::V2::ApplicationController
   end
 
   private
+
+  def use_ce_api?
+    FeatureToggle.enabled?(:use_ce_api, user: RequestStore[:current_user])
+  end
 
   def veteran_file_number
     @veteran_file_number ||= verify_veteran_file_number

--- a/app/jobs/v2/save_files_in_s3_job.rb
+++ b/app/jobs/v2/save_files_in_s3_job.rb
@@ -5,7 +5,7 @@ class V2::SaveFilesInS3Job < ApplicationJob
     Raven.extra_context(manifest_source: manifest_source.id, user_id: user_id)
 
     # Set user for permission check if the user is blank
-    if FeatureToggle.enabled?(:use_ce_api) && RequestStore[:current_user].blank?
+    if FeatureToggle.enabled?(:use_ce_api, user: RequestStore[:current_user]) && RequestStore[:current_user].blank?
       user = User.find(user_id)
       RequestStore.store[:current_user] = user
     end

--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -31,7 +31,7 @@ class Manifest < ApplicationRecord
     # Reset stale manifests.
     update!(fetched_files_status: :initialized) if ready_for_refresh?
 
-    if FeatureToggle.enabled?(:use_ce_api)
+    if FeatureToggle.enabled?(:use_ce_api, user: RequestStore[:current_user])
       if sensitivity_checker.sensitivity_levels_compatible?(
         user: user,
         veteran_file_number: file_number

--- a/app/services/error_handlers/claim_evidence_api_error_handler.rb
+++ b/app/services/error_handlers/claim_evidence_api_error_handler.rb
@@ -26,6 +26,6 @@ class ErrorHandlers::ClaimEvidenceApiErrorHandler
   end
 
   def use_ce_api?
-    FeatureToggle.enabled?(:use_ce_api)
+    FeatureToggle.enabled?(:use_ce_api, user: RequestStore[:current_user])
   end
 end

--- a/spec/models/manifest_spec.rb
+++ b/spec/models/manifest_spec.rb
@@ -1,6 +1,9 @@
 describe Manifest do
   describe "#start!" do
-    let(:user) { User.create(css_id: "Foo", station_id: "112") }
+    let(:user) do
+      user = User.create(css_id: "VSO", station_id: "283")
+      RequestStore.store[:current_user] = user
+    end
     let(:manifest) { Manifest.create(file_number: "1234", user: user) }
 
     subject { manifest.start! }
@@ -9,7 +12,7 @@ describe Manifest do
       before do
         Timecop.freeze(Time.utc(2015, 12, 2, 17, 0, 0))
         allow(V2::DownloadManifestJob).to receive(:perform_later)
-        expect(FeatureToggle).to receive(:enabled?).with(:use_ce_api).and_return(false)
+        expect(FeatureToggle).to receive(:enabled?).with(:use_ce_api, user: user).and_return(false)
         expect(FeatureToggle).to receive(:enabled?).with(:skip_vva).and_return(false)
       end
 
@@ -47,7 +50,7 @@ describe Manifest do
       before do
         allow(SensitivityChecker).to receive(:new).and_return(mock_sensitivity_checker)
         allow(FeatureToggle).to receive(:enabled?).with(:skip_vva).and_return(false)
-        expect(FeatureToggle).to receive(:enabled?).with(:use_ce_api).and_return(true)
+        expect(FeatureToggle).to receive(:enabled?).with(:use_ce_api, user: user).and_return(true)
       end
 
       it "enqueues a job if the sensitivity check passes" do

--- a/spec/services/external_api/vbms_service_spec.rb
+++ b/spec/services/external_api/vbms_service_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-
+ 
 describe ExternalApi::VBMSService do
   subject(:described) { described_class }
 
@@ -66,7 +66,7 @@ describe ExternalApi::VBMSService do
       it "calls the PagedDocuments SOAP API endpoint" do
         veteran_id = "123456789"
 
-        expect(FeatureToggle).to receive(:enabled?).with(:use_ce_api).and_return(false)
+        expect(FeatureToggle).to receive(:enabled?).with(:use_ce_api, user: user).and_return(false)
         expect(FeatureToggle).to receive(:enabled?).with(:vbms_pagination, user: user).and_return(true)
         expect(described_class).to receive(:vbms_client)
         expect(VBMS::Service::PagedDocuments).to receive(:new).and_return(:test_service)
@@ -78,6 +78,7 @@ describe ExternalApi::VBMSService do
     end
 
     context "with no feature toggles enabled" do
+      
       let!(:user) do
         user = User.create(css_id: "VSO", station_id: "283", participant_id: "1234")
         RequestStore.store[:current_user] = user
@@ -85,8 +86,7 @@ describe ExternalApi::VBMSService do
 
       it "calls the FindDocumentVersionReference SOAP API endpoint" do
         veteran_id = "123456789"
-
-        expect(FeatureToggle).to receive(:enabled?).with(:use_ce_api).and_return(false)
+        expect(FeatureToggle).to receive(:enabled?).with(:use_ce_api, user: user).and_return(false)
         expect(FeatureToggle).to receive(:enabled?).with(:vbms_pagination, user: user).and_return(false)
         expect(VBMS::Requests::FindDocumentVersionReference).to receive(:new)
           .with(veteran_id).and_return(:test_service)


### PR DESCRIPTION
Resolves - https://jira.devops.va.gov/browse/APPEALS-65021

### Description
Update the use_ce_api feature flag for the user-specific

You'll need to specify the scope at which you're checking the feature state: if you check enabled? without specifying a user, the result will be false if the feature is only enabled for specific user.
FeatureToggle.enabled?(:bar, user: current_user)

- State checking methods receive User objects, not Arrays

- Example of config_file - [features-config.yml] for higher Envs
 ```
 [
    {
      feature: "use_ce_api",
      enable_all: true
    },
    {
      feature: "use_ce_api",
      users: ["VHAISADJURIN", "VHAISAPROKOA", "VHAISWSTEWAA"]
    }
  ]
```

### Acceptance Criteria
- [X] Code compiles correctly

### Testing Plan
1. For backend console
FeatureToggle.enable!(:use_ce_api, users: ["CSS_ID_1", "CSS_ID_2"])
FeatureToggle.disable!(:use_ce_api, users: ["CSS_ID_1", "CSS_ID_2"])

